### PR TITLE
Add the commonMain api dependencies to the pom.

### DIFF
--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -181,7 +181,7 @@ publishing {
 
                 withXml {
                     asNode().appendNode("dependencies").let { dependenciesNode ->
-                        listOf("androidMainImplementation", "commonMainImplementation").forEach {
+                        listOf("androidMainImplementation", "commonMainImplementation" , "commonMainApi").forEach {
                             for (dependency in configurations[it].dependencies) {
                                 if (dependency.name != "unspecified") {
                                     dependenciesNode.appendNode("dependency").let { node ->

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -181,7 +181,7 @@ publishing {
 
                 withXml {
                     asNode().appendNode("dependencies").let { dependenciesNode ->
-                        listOf("androidMainImplementation", "commonMainImplementation" , "commonMainApi").forEach {
+                        listOf("androidMainImplementation", "androidMainApi", "commonMainImplementation" , "commonMainApi").forEach {
                             for (dependency in configurations[it].dependencies) {
                                 if (dependency.name != "unspecified") {
                                     dependenciesNode.appendNode("dependency").let { node ->


### PR DESCRIPTION
Left the API dependency out of the pom, which makes the resultant artifact crash when initializing Kermit.