### PR TITLE
Enabling bitcode for release builds

### DIFF
--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -40,11 +40,8 @@ android {
 }
 
 val kermitVersion = "0.1.9"
-val configuration: String? by project
-val sdk: String? by project
-val bitcode: String = if ("release".equals(configuration, true)) "bitcode" else "marker"
-version = project.rootProject.version
 val iosFrameworkName = "MessengerTransport"
+version = project.rootProject.version
 
 kotlin {
     android {
@@ -85,7 +82,6 @@ kotlin {
             // To specify a custom Objective-C prefix/name for the Kotlin framework, use the `-module-name` compiler option or matching Gradle DSL statement.
             freeCompilerArgs += listOf("-module-name", "GCM")
             export("co.touchlab:kermit:$kermitVersion")
-            embedBitcode(bitcode)
         }
         pod("jetfire", "~> 0.1.5")
     }


### PR DESCRIPTION
We're no longer using the old `packForXcode` task which we had passed a configuration to that determined if bitcode was embedded or just marked. As of Kotlin 1.3.20, embedding bitcode is done by default for iOS framework targets. The  tasks from the XCFramework plugin appears to be building them correctly. To verify, I ran `:transport:assembleMessengerTransportReleaseXCFramework`. Then, using the recommendation from this SO (https://stackoverflow.com/questions/30722606/what-does-enable-bitcode-do-in-xcode-7/66845532#66845532), I used `otool -v -s __LLVM __bundle "transport/build/XCFrameworks/release/MessengerTransport.xcframework/ios-arm64/MessengerTransport.framework/MessengerTransport" ` to verity that the release ios-arm64 framework embedded bitcode.