### PR TITLE
Gmdx 162 - MessagingClinet.kt async api should throw more general Exception.

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
@@ -130,7 +130,7 @@ interface MessagingClient {
      *
      * @throws CancellationException
      */
-    @Throws(CancellationException::class, ResponseException::class, IllegalArgumentException::class)
+    @Throws(Exception::class)
     suspend fun fetchNextPage()
 
     /**
@@ -144,6 +144,6 @@ interface MessagingClient {
     /**
      *  Fetch deployment configuration based on deployment id.
      */
-    @Throws(CancellationException::class, ResponseException::class, IllegalArgumentException::class)
+    @Throws(Exception::class)
     suspend fun fetchDeploymentConfig(): DeploymentConfig
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
@@ -2,8 +2,6 @@ package com.genesys.cloud.messenger.transport
 
 import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.util.ErrorCode
-import io.ktor.client.features.ResponseException
-import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * WebMessagingClient provides bi-directional communication between a guest and Genesys Cloud via
@@ -128,7 +126,7 @@ interface MessagingClient {
     /**
      * Get message history for a conversation.
      *
-     * @throws CancellationException
+     * @throws Exception
      */
     @Throws(Exception::class)
     suspend fun fetchNextPage()
@@ -143,6 +141,8 @@ interface MessagingClient {
 
     /**
      *  Fetch deployment configuration based on deployment id.
+     *
+     *  @throws Exception
      */
     @Throws(Exception::class)
     suspend fun fetchDeploymentConfig(): DeploymentConfig


### PR DESCRIPTION
- Use MessagingClient.fetchHistory() and MessagingClient.deploymentConfig() will throw Exception::class instead of long list of specific Exceptions.