### PR TITLE
Update logback version to 1.2.8

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -5,7 +5,7 @@ object Deps {
     private const val kermitVersion = "0.1.9"
     private const val kotlinxSerializationJsonVersion = "1.1.0"
     private const val ktorVersion = "1.6.0"
-    private const val logbackVersion = "1.2.3"
+    private const val logbackVersion = "1.2.8"
     private const val mockWebServerVersion = "4.9.0"
     private const val mockkVersion = "1.11.0"
     private const val okhttpVersion = "4.9.1"


### PR DESCRIPTION
Snyk reported a medium vulnerability in the logback dependency at version 1.2.3 which looks like it can be remediated by upgrading to at least version 1.2.7.