### PR TITLE
GMDX-167 Decouple fetchDeploymentConfig from MessagingClient API

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -112,7 +112,13 @@ class TestBedViewModel : ViewModel(), CoroutineScope, MessageListener {
 
     private suspend fun doDeployment() {
         try {
-            onSocketMessageReceived(client.fetchDeploymentConfig().toString())
+            onSocketMessageReceived(
+                MobileMessenger.fetchDeploymentConfig(
+                    BuildConfig.DEPLOYMENT_DOMAIN,
+                    BuildConfig.DEPLOYMENT_ID,
+                    true,
+                ).toString()
+            )
         } catch (t: Throwable) {
             handleException(t, "fetch deployment config")
         }

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -12,12 +12,14 @@ import MessengerTransport
 class ContentViewController: UIViewController {
 
     private let client: MessagingClient
+    private let deployment: Deployment
     let config: Configuration
     private var attachImageName = ""
     private let attachmentName = "image"
     private var byteArray: [UInt8]? = nil
 
     init(deployment: Deployment) {
+        self.deployment = deployment
         self.config = Configuration(deployment: deployment, tokenStoreKey: "com.genesys.cloud.messenger", logging: true)!
         let messageListener = Listener()
         self.client = MobileMessenger().createMessagingClient(configuration: self.config, listener: messageListener)
@@ -284,7 +286,8 @@ extension ContentViewController : UITextFieldDelegate {
         case ("detach", let attachId?):
             client.detach(attachmentId: attachId)
         case ("deployment", _):
-            client.fetchDeploymentConfig(completionHandler: { deploymentConfig, error in
+            MobileMessenger().fetchDeploymentConfig(domain: deployment.domain!, deploymentId: deployment.deploymentId!, logging: true,
+                completionHandler: { deploymentConfig, error in
                 if let error = error {
                     self.info.text = "<\(error.localizedDescription)>"
                     return

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/MobileMessenger.kt
@@ -3,11 +3,13 @@ package com.genesys.cloud.messenger.transport.util
 import android.content.Context
 import com.genesys.cloud.messenger.transport.AttachmentHandler
 import com.genesys.cloud.messenger.transport.Configuration
+import com.genesys.cloud.messenger.transport.DeploymentConfigUseCase
 import com.genesys.cloud.messenger.transport.JwtHandler
 import com.genesys.cloud.messenger.transport.MessageStore
 import com.genesys.cloud.messenger.transport.MessagingClient
 import com.genesys.cloud.messenger.transport.MessagingClientImpl
 import com.genesys.cloud.messenger.transport.WebMessagingApi
+import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
 
@@ -21,7 +23,7 @@ object MobileMessenger {
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
         val token =
             TokenStoreImpl(context = context, configuration.tokenStoreKey).token
-        val api = WebMessagingApi(log.withTag(LogTag.API), configuration)
+        val api = WebMessagingApi(configuration)
         val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
         val messageStore = MessageStore(
             MessageDispatcher(listener = listener),
@@ -44,5 +46,23 @@ object MobileMessenger {
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
         )
+    }
+
+    /**
+     *  Fetch deployment configuration based on deployment id and domain.
+     *
+     * @param deploymentId the ID of the deployment containing configuration and routing information.
+     * @param domain the regional base domain address for a Genesys Cloud Web Messaging service. For example, "mypurecloud.com".
+     * @param logging indicates if logging should be enabled. False by default.
+     *
+     * @throws Exception
+     */
+    @Throws(Exception::class)
+    suspend fun fetchDeploymentConfig(
+        domain: String,
+        deploymentId: String,
+        logging: Boolean = false
+    ): DeploymentConfig {
+        return DeploymentConfigUseCase(logging).fetch(domain, deploymentId)
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/MessagingClientImplTest.kt
@@ -13,15 +13,12 @@ import com.genesys.cloud.messenger.transport.util.logs.Log
 import io.mockk.MockKVerificationScope
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifySequence
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.runBlocking
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -74,8 +71,6 @@ class MessagingClientImplTest {
                 any()
             )
         } returns TestWebMessagingApiResponses.testMessageEntityList
-
-        coEvery { fetchDeploymentConfig() } returns TestWebMessagingApiResponses.testDeploymentConfig
     }
 
     private val subject = MessagingClientImpl(
@@ -303,24 +298,6 @@ class MessagingClientImplTest {
         verifySequence {
             connectSequence()
             mockStateListener(MessagingClient.State.Configured(connected = true, newSession = true))
-        }
-    }
-
-    @Test
-    fun whenFetchDeploymentConfig() {
-        runBlocking { subject.fetchDeploymentConfig() }
-
-        coVerify { mockWebMessagingApi.fetchDeploymentConfig() }
-    }
-
-    @Test
-    fun whenFetchDeploymentConfigThrowsCancellationException() {
-        coEvery {
-            mockWebMessagingApi.fetchDeploymentConfig()
-        } throws CancellationException()
-
-        runBlocking {
-            assertFailsWith<CancellationException> { subject.fetchDeploymentConfig() }
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/DeploymentConfigUseCase.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/DeploymentConfigUseCase.kt
@@ -1,0 +1,22 @@
+package com.genesys.cloud.messenger.transport
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
+import com.genesys.cloud.messenger.transport.util.defaultHttpClient
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.http.URLBuilder
+
+internal class DeploymentConfigUseCase(
+    logging: Boolean,
+    private val client: HttpClient = defaultHttpClient(logging),
+) {
+    suspend fun fetch(
+        domain: String,
+        deploymentId: String,
+    ): DeploymentConfig {
+        val url = URLBuilder("https://api-cdn.$domain").apply {
+            path("webdeployments/v1/deployments/$deploymentId/config.json")
+        }.build()
+        return client.get("$url")
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClient.kt
@@ -1,6 +1,5 @@
 package com.genesys.cloud.messenger.transport
 
-import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.util.ErrorCode
 
 /**
@@ -171,12 +170,4 @@ interface MessagingClient {
      */
     @Throws(IllegalStateException::class)
     fun disconnect()
-
-    /**
-     *  Fetch deployment configuration based on deployment id.
-     *
-     *  @throws Exception
-     */
-    @Throws(Exception::class)
-    suspend fun fetchDeploymentConfig(): DeploymentConfig
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/MessagingClientImpl.kt
@@ -3,7 +3,6 @@ package com.genesys.cloud.messenger.transport
 import com.genesys.cloud.messenger.transport.MessagingClient.State
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.receive.AttachmentDeletedResponse
-import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.GenerateUrlError
 import com.genesys.cloud.messenger.transport.shyrka.receive.JwtResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
@@ -81,7 +80,10 @@ internal class MessagingClientImpl(
         val request = ConfigureSessionRequest(
             token = token,
             deploymentId = configuration.deploymentId,
-            journeyContext = JourneyContext(JourneyCustomer(token, "cookie"), JourneyCustomerSession("", "web"))
+            journeyContext = JourneyContext(
+                JourneyCustomer(token, "cookie"),
+                JourneyCustomerSession("", "web")
+            )
         )
         val encodedJson = WebMessagingJson.json.encodeToString(request)
         webSocket.sendMessage(encodedJson)
@@ -166,10 +168,6 @@ internal class MessagingClientImpl(
                     it.total,
                 )
             }
-    }
-
-    override suspend fun fetchDeploymentConfig(): DeploymentConfig {
-        return api.fetchDeploymentConfig()
     }
 
     private fun handleError(code: ErrorCode, message: String? = null) {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/WebMessagingApi.kt
@@ -1,16 +1,10 @@
 package com.genesys.cloud.messenger.transport
 
-import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
-import com.genesys.cloud.messenger.transport.util.logs.Log
+import com.genesys.cloud.messenger.transport.util.defaultHttpClient
 import io.ktor.client.HttpClient
-import io.ktor.client.features.HttpCallValidator
 import io.ktor.client.features.ResponseException
-import io.ktor.client.features.json.JsonFeature
-import io.ktor.client.features.json.serializer.KotlinxSerializer
-import io.ktor.client.features.logging.LogLevel
-import io.ktor.client.features.logging.Logging
 import io.ktor.client.features.onUpload
 import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.get
@@ -18,13 +12,11 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.put
 import io.ktor.http.HttpHeaders
-import kotlinx.serialization.json.Json
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class WebMessagingApi(
-    log: Log,
     private val configuration: Configuration,
-    private val client: HttpClient = defaultHttpClient(log, configuration),
+    private val client: HttpClient = defaultHttpClient(configuration.logging),
 ) {
 
     /**
@@ -58,32 +50,7 @@ internal class WebMessagingApi(
             body = byteArray
         }
     }
-
-    /**
-     * @throws ResponseException if unsuccessful response from the service
-     */
-    suspend fun fetchDeploymentConfig(): DeploymentConfig {
-        return client.get("${configuration.deploymentConfigUrl}")
-    }
 }
 
 private fun HttpRequestBuilder.headerAuthorizationBearer(jwt: String) =
     header(HttpHeaders.Authorization, "bearer $jwt")
-
-private fun defaultHttpClient(log: Log, configuration: Configuration): HttpClient = HttpClient {
-    if (configuration.logging) {
-        install(Logging) {
-            this.logger = log.ktorLogger
-            level = LogLevel.ALL
-        }
-    }
-    install(JsonFeature) {
-        serializer = KotlinxSerializer(
-            Json {
-                ignoreUnknownKeys = true
-                useAlternativeNames = false
-            }
-        )
-    }
-    install(HttpCallValidator)
-}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -14,6 +14,7 @@ data class DeploymentConfig(
     val journeyEvents: JourneyEvents,
     val status: Status,
 ) {
+    @Serializable
     enum class Status {
         @SerialName("Active")
         Active,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/HttpClientProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/HttpClientProvider.kt
@@ -1,0 +1,28 @@
+package com.genesys.cloud.messenger.transport.util
+
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import com.genesys.cloud.messenger.transport.util.logs.LogTag
+import io.ktor.client.HttpClient
+import io.ktor.client.features.HttpCallValidator
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.client.features.logging.LogLevel
+import io.ktor.client.features.logging.Logging
+
+internal fun defaultHttpClient(logging: Boolean = false): HttpClient = HttpClient {
+    if (logging) {
+        install(Logging) {
+            this.logger = Log(logging, LogTag.HTTP_CLIENT).ktorLogger
+            level = LogLevel.ALL
+        }
+    }
+    install(JsonFeature) {
+        serializer = KotlinxSerializer(
+            kotlinx.serialization.json.Json {
+                ignoreUnknownKeys = true
+                useAlternativeNames = false
+            }
+        )
+    }
+    install(HttpCallValidator)
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -8,4 +8,5 @@ internal object LogTag {
     const val ATTACHMENT_HANDLER = "MMSDKAttachmentHandler"
     const val MESSAGE_STORE = "MMSDKMessageStore"
     const val TOKEN_STORE = "MMSDKTokenStore"
+    const val HTTP_CLIENT = "MMSDKHttpClient"
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/DeploymentConfigUseCaseTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/DeploymentConfigUseCaseTest.kt
@@ -1,0 +1,54 @@
+package com.genesys.cloud.messenger.transport
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.features.json.serializer.KotlinxSerializer
+import io.ktor.http.ContentType
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val BASIC_DEPLOYMENT_CONFIG_RESPONSE_PATH =
+    "/webdeployments/v1/deployments/deploymentId/config.json"
+
+class DeploymentConfigUseCaseTest {
+    private val subject = DeploymentConfigUseCase(false, mockHttpClient())
+
+    @Test
+    fun whenFetchDeploymentConfig() {
+        val expectedTestDeploymentConfig = TestWebMessagingApiResponses.testDeploymentConfig
+
+        val result = runBlocking {
+            withTimeout(DEFAULT_TIMEOUT) {
+                subject.fetch("inindca.com", "deploymentId")
+            }
+        }
+        assertEquals(expectedTestDeploymentConfig, result)
+    }
+
+    private fun mockHttpClient(): HttpClient = HttpClient(MockEngine) {
+        install(JsonFeature) {
+            serializer = KotlinxSerializer()
+        }
+        engine {
+            val responseHeaders =
+                headersOf("Content-Type" to listOf(ContentType.Application.Json.toString()))
+            addHandler { request ->
+                when (request.url.fullPath) {
+                    BASIC_DEPLOYMENT_CONFIG_RESPONSE_PATH -> {
+                        respond(
+                            TestWebMessagingApiResponses.deploymentConfigResponse,
+                            headers = responseHeaders
+                        )
+                    }
+                    else -> error("Unhandled ${request.url.fullPath}")
+                }
+            }
+        }
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/TestUtils.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/TestUtils.kt
@@ -1,0 +1,3 @@
+package com.genesys.cloud.messenger.transport
+
+internal const val DEFAULT_TIMEOUT = 10000L

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/WebMessagingApiTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/WebMessagingApiTest.kt
@@ -1,6 +1,5 @@
 package com.genesys.cloud.messenger.transport
 
-import com.genesys.cloud.messenger.transport.util.logs.Log
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -18,16 +17,12 @@ private const val EMPTY_MESSAGE_ENTITY_RESPONSE_PATH =
     "/api/v2/webmessaging/messages?pageNumber=0&pageSize=0"
 private const val BASIC_MESSAGE_ENTITY_RESPONSE_PATH =
     "/api/v2/webmessaging/messages?pageNumber=1&pageSize=25"
-private const val BASIC_DEPLOYMENT_CONFIG_RESPONSE_PATH =
-    "/webdeployments/v1/deployments/deploymentId/config.json"
-private const val DEFAULT_TIMEOUT = 10000L
 
 class WebMessagingApiTest {
     private val subject: WebMessagingApi
         get() {
             val configuration = configuration()
             return WebMessagingApi(
-                log = Log(configuration.logging, "Log"),
                 configuration = configuration,
                 client = mockHttpClient()
             )
@@ -44,19 +39,6 @@ class WebMessagingApiTest {
         }
 
         assertEquals(expectedEntityList, result)
-    }
-
-    @Test
-    fun whenFetchDeploymentConfig() {
-        val expectedTestDeploymentConfig = TestWebMessagingApiResponses.testDeploymentConfig
-
-        val result = runBlocking {
-            withTimeout(DEFAULT_TIMEOUT) {
-                subject.fetchDeploymentConfig()
-            }
-        }
-
-        assertEquals(expectedTestDeploymentConfig, result)
     }
 
     @Test
@@ -97,12 +79,6 @@ class WebMessagingApiTest {
                     EMPTY_MESSAGE_ENTITY_RESPONSE_PATH -> {
                         respond(
                             TestWebMessagingApiResponses.messageEntityListResponseWithoutMessages,
-                            headers = responseHeaders
-                        )
-                    }
-                    BASIC_DEPLOYMENT_CONFIG_RESPONSE_PATH -> {
-                        respond(
-                            TestWebMessagingApiResponses.deploymentConfigResponse,
                             headers = responseHeaders
                         )
                     }


### PR DESCRIPTION
- Remove fetchDeploymentConfig() from MessagingClient to DeploymentConfigUseCase
- Extract HttpClient initialization from WebMessagingApi to standalone class.
- Update Tests
- Update Test Applications