### PR TITLE
GMDX-175 Internalize Log related files.

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -5,9 +5,9 @@ object Deps {
     private const val kermitVersion = "0.1.9"
     private const val kotlinxSerializationJsonVersion = "1.1.0"
     private const val ktorVersion = "1.6.0"
-    private const val logbackVersion = "1.2.8"
+    private const val logbackVersion = "1.2.10"
     private const val mockWebServerVersion = "4.9.0"
-    private const val mockkVersion = "1.11.0"
+    private const val mockkVersion = "1.12.2"
     private const val okhttpVersion = "4.9.1"
 
     object Libs {

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -82,7 +82,6 @@ kotlin {
             baseName = iosFrameworkName
             // To specify a custom Objective-C prefix/name for the Kotlin framework, use the `-module-name` compiler option or matching Gradle DSL statement.
             freeCompilerArgs += listOf("-module-name", "GCM")
-            export(Deps.Libs.kermit)
         }
         pod("jetfire", "~> 0.1.5")
     }

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 /**
  * Android platform-specific implementations of common utility functions.
  */
-actual class Platform {
+internal actual class Platform {
     /**
      * The name of the Android SDK version currently running on this device.
      */

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocketListener.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocketListener.kt
@@ -1,6 +1,6 @@
 package com.genesys.cloud.messenger.transport.network
 
-interface PlatformSocketListener {
+internal interface PlatformSocketListener {
     fun onOpen()
     fun onFailure(t: Throwable)
     fun onMessage(text: String)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
@@ -3,7 +3,7 @@ package com.genesys.cloud.messenger.transport.util
 /**
  * Expect declaration of common utility functions.
  */
-expect class Platform() {
+internal expect class Platform() {
     /**
      * The name of the OS version currently running on this device.
      */

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/ConfigurableKermitLogger.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/ConfigurableKermitLogger.kt
@@ -3,7 +3,7 @@ package com.genesys.cloud.messenger.transport.util.logs
 import co.touchlab.kermit.Logger
 import co.touchlab.kermit.Severity
 
-class ConfigurableKermitLogger(
+internal class ConfigurableKermitLogger(
     private val enabled: Boolean,
     private val delegate: Logger,
 ) : Logger() {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/KermitKtorLogger.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/KermitKtorLogger.kt
@@ -3,7 +3,7 @@ package com.genesys.cloud.messenger.transport.util.logs
 import co.touchlab.kermit.Kermit
 import io.ktor.client.features.logging.Logger
 
-class KermitKtorLogger(
+internal class KermitKtorLogger(
     private val kermit: Kermit
 ) : Logger {
     override fun log(message: String) {

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/Platform.kt
@@ -11,7 +11,7 @@ import platform.posix.timeval
 /**
  * iOS platform-specific implementations of common utility functions.
  */
-actual class Platform {
+internal actual class Platform {
     /**
      * The device name and system version currently running on this device.
      */


### PR DESCRIPTION
- Make log related files internal
- Platform.kt should be internal as it intent is for local usage.
- Remove Kermit dependency when building a .framework
- Upgrade logback to 1.2.10 see: https://cve.report/CVE-2021-42550
- Upgrade mockk to 1.12.2 see: https://github.com/mockk/mockk/releases/tag/1.12.2