### PR TITLE
Removes unused `generateDownloadUrl` client method

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ allprojects {
     }
 }
 
-
 plugins {
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
 }

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -3,7 +3,7 @@ object Deps {
     private const val coroutinesVersion = "1.4.3-native-mt"
     private const val junitVersion = "4.13.2"
     private const val kermitVersion = "0.1.9"
-    private const val kotlinxSerializationJsonVersion = "1.1.0"
+    private const val kotlinxSerializationJsonVersion = "1.3.1"
     private const val ktorVersion = "1.6.0"
     private const val logbackVersion = "1.2.10"
     private const val mockWebServerVersion = "4.9.0"

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -173,7 +173,7 @@ class ContentViewController: UIViewController {
                 print("Socket <error>. code: <\(error.code.description)> , message: <\(error.message ?? "No message")>")
                 self?.info.text = "Socket <error>. code: <\(error.code.description)> , message: <\(error.message ?? "No message")>"
             default:
-                break
+                print("Unexpected stateListener state: \(state)")
             }
         }
     }
@@ -190,7 +190,7 @@ class ContentViewController: UIViewController {
             case let history as MessageEvent.HistoryFetched:
                 self?.info.text = "start of conversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)> "
             default:
-                break
+                print("Unexpected messageListener event: \(event)")
             }
         }        
     }

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -40,7 +40,6 @@ android {
     }
 }
 
-val kermitVersion = "0.1.9"
 val iosFrameworkName = "MessengerTransport"
 version = project.rootProject.version
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -139,16 +139,6 @@ interface MessagingClient {
     fun detach(attachmentId: String)
 
     /**
-     * Request a new and valid URL to download an attachment that was previously uploaded. Download
-     * URLs expire.
-     *
-     * @param attachmentId the ID of the attachment
-     * @throws IllegalStateException
-     */
-    @Throws(IllegalStateException::class)
-    fun generateDownloadUrl(attachmentId: String)
-
-    /**
      * Attachments typically expire 72 hours after being uploaded. This method can be used to
      * immediately delete the file prior to that expiration.
      *

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -141,15 +141,6 @@ internal class MessagingClientImpl(
     }
 
     @Throws(IllegalStateException::class)
-    override fun generateDownloadUrl(attachmentId: String) {
-        log.i { "generateDownloadUrl(attachmentId = $attachmentId)" }
-        val request = GetAttachmentRequest(
-            token = token,
-            attachmentId = attachmentId
-        )
-    }
-
-    @Throws(IllegalStateException::class)
     override fun deleteAttachment(attachmentId: String) {
         log.i { "deleteAttachment(attachmentId = $attachmentId)" }
         val request = DeleteAttachmentRequest(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -18,7 +18,6 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.send.ConfigureSessionRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.EchoRequest
-import com.genesys.cloud.messenger.transport.shyrka.send.GetAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyContext
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomer
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomerSession


### PR DESCRIPTION
This commit removes the `generateDownloadUrl` method from the client API since it currently does not perform any work. Further investigate with the backend team can be done to determine if this endpoint is of utility to mobile apps.