### PR TITLE
GMDX-209 Use new syntax to send attachments to Shyrka.

### DIFF
--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - jetfire (0.1.5)
-  - transport (1.1.0):
+  - transport (1.1.14):
     - jetfire (~> 0.1.5)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   jetfire: 60c16cd6ae0282928e24203eb93f03b89c1929ce
-  transport: 8a7905f949c322b4bafaec1aa907506b22b19d02
+  transport: ff3eab621fa10f62fa93a4732dcbeeb55007987e
 
 PODFILE CHECKSUM: 5eac24c446a9287e8ab64ba98923743c10ec8982
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -1,5 +1,7 @@
 package com.genesys.cloud.messenger.transport.core
 
+import assertk.assertThat
+import assertk.assertions.containsOnly
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
@@ -100,9 +102,16 @@ internal class MessageExtensionTest {
                     )
                 )
             )
-        val expectedAttachmentIds = arrayOf("first test attachment id")
+        val expectedContent = Message.Content(
+            contentType = Message.Content.Type.Attachment,
+            attachment = Attachment(
+                id = "first test attachment id",
+                fileName = "test.png",
+                state = Attachment.State.Uploaded("http://test.com")
+            )
+        )
 
-        assertTrue { expectedAttachmentIds.contentEquals(givenMessage.getUploadedAttachments()) }
+        assertThat(givenMessage.getUploadedAttachments()).containsOnly(expectedContent)
     }
 
     @Test

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.core
 
 import assertk.assertThat
+import assertk.assertions.containsOnly
 import com.genesys.cloud.messenger.transport.shyrka.send.OnMessageRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.TextMessage
 import io.mockk.Called
@@ -41,8 +42,6 @@ internal class MessageStoreTest {
             assertEquals(expectedOnMessageRequest.token, token)
             assertEquals(expectedOnMessageRequest.message, message)
             assertNull(time)
-            assertNotNull(attachmentIds)
-            assertTrue { attachmentIds.isEmpty() }
         }
 
         assertEquals(expectedMessage, subject.getConversation()[0])
@@ -72,8 +71,12 @@ internal class MessageStoreTest {
         )
 
         subject.prepareMessage("test message").run {
-            assertNotNull(attachmentIds)
-            assertTrue { attachmentIds.contains("given id") }
+            assertThat(this.message.content).containsOnly(
+                Message.Content(
+                    contentType = Message.Content.Type.Attachment,
+                    attachment(state = Attachment.State.Uploaded("http://someurl.com"))
+                )
+            )
         }
         assertTrue { subject.pendingMessage.attachments.isEmpty() }
     }
@@ -85,8 +88,8 @@ internal class MessageStoreTest {
         )
 
         subject.prepareMessage("test message").run {
-            assertNotNull(attachmentIds)
-            assertTrue { attachmentIds.isEmpty() }
+            assertNotNull(this.message.content)
+            assertTrue { this.message.content.isEmpty() }
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.core
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 /**
  * Container for attachment related information.
@@ -8,8 +9,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Attachment(
     val id: String,
-    val fileName: String,
-    val state: State,
+    @Transient val fileName: String = "",
+    @Transient val state: State = State.Presigning,
 ) {
     /**
      * Represent Attachment states.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -56,4 +56,21 @@ data class Message(
          */
         data class Error(val code: ErrorCode, val message: String?) : State()
     }
+
+    /**
+     * Content of the Message.
+     *
+     * @property contentType is a type of the Content attached to the Message.
+     * @property attachment attachment itself.
+     */
+    @Serializable
+    data class Content(
+        val contentType: Type,
+        val attachment: Attachment,
+    ) {
+        @Serializable
+        enum class Type {
+            Attachment
+        }
+    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -31,8 +31,7 @@ internal class MessageStore(
         }
         return OnMessageRequest(
             token = token,
-            message = TextMessage(text, metadata = mapOf("customMessageId" to messageToSend.id)),
-            attachmentIds = messageToSend.getUploadedAttachments()
+            message = TextMessage(text, metadata = mapOf("customMessageId" to messageToSend.id), content = messageToSend.getUploadedAttachments()),
         )
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
@@ -8,7 +8,6 @@ internal class OnMessageRequest(
     override val token: String,
     val message: TextMessage,
     val time: String? = null,
-    val attachmentIds: Array<String>? = null
 ) : WebMessagingRequest {
     @Required override val action: String = RequestAction.ON_MESSAGE.value
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
@@ -1,12 +1,14 @@
 package com.genesys.cloud.messenger.transport.shyrka.send
 
+import com.genesys.cloud.messenger.transport.core.Message
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class TextMessage(
     val text: String,
-    val metadata: Map<String, String>? = null
+    val metadata: Map<String, String>? = null,
+    val content: List<Message.Content> = emptyList()
 ) {
     @Required val type = "Text"
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -24,17 +24,17 @@ internal fun StructuredMessage.toMessage(): Message {
     )
 }
 
-internal fun Message.getUploadedAttachments(): Array<String> {
-    if (this.attachments.isEmpty()) return emptyArray()
+internal fun Message.getUploadedAttachments(): List<Message.Content> {
+    if (this.attachments.isEmpty()) return emptyList()
     return this.attachments.filter {
         it.value.state is Attachment.State.Uploaded
     }.map {
-        it.key
-    }.toTypedArray()
+        Message.Content(contentType = Message.Content.Type.Attachment, attachment = it.value)
+    }.toList()
 }
 
 private fun List<StructuredMessage.Content>.toAttachments(): Map<String, Attachment> {
-    return this.map {
+    return this.associate {
         it.attachment.run {
             this.id to Attachment(
                 id = this.id,
@@ -42,5 +42,5 @@ private fun List<StructuredMessage.Content>.toAttachments(): Map<String, Attachm
                 state = Attachment.State.Sent(this.url),
             )
         }
-    }.toMap()
+    }
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -4,6 +4,8 @@ import assertk.assertThat
 import assertk.assertions.hasClass
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
+import com.genesys.cloud.messenger.transport.core.Attachment
+import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.receive.GenerateUrlError
 import com.genesys.cloud.messenger.transport.shyrka.receive.JwtResponse
@@ -70,14 +72,21 @@ class SerializationTest {
 
         val messageWithAttachmentRequest = OnMessageRequest(
             token = "<token>",
-            message = TextMessage(text = "Hello world", metadata = mapOf("id" to "aaa-bbb-ccc")),
-            attachmentIds = arrayOf("abcd-1234")
+            message = TextMessage(
+                text = "Hello world", metadata = mapOf("id" to "aaa-bbb-ccc"),
+                content = listOf(
+                    Message.Content(
+                        contentType = Message.Content.Type.Attachment,
+                        attachment = Attachment("abcd-1234")
+                    )
+                )
+            ),
         )
 
         encodedString = WebMessagingJson.json.encodeToString(messageWithAttachmentRequest)
 
         assertThat(encodedString, "encoded OnMessageRequest with attachment")
-            .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"type":"Text"},"attachmentIds":["abcd-1234"],"action":"onMessage"}""")
+            .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"content":[{"contentType":"Attachment","attachment":{"id":"abcd-1234"}}],"type":"Text"},"action":"onMessage"}""")
     }
 
     @Test

--- a/transport/transport.podspec
+++ b/transport/transport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'transport'
-    spec.version                  = '1.1.0'
+    spec.version                  = '1.1.14'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :git => "Not Published", :tag => "Cocoapods/#{spec.name}/#{spec.version}" }
     spec.authors                  = 'Genesys Cloud Services, Inc.'


### PR DESCRIPTION
- Use List<Content> to send attachments via Shyrka.
- Exclude Attachment.filename and Attachment.state fields from serialization.
- Update unit tests.
- Update Podfile.lock and transport.podspec versions.