### PR TITLE
build: add generateGenesysCloudMessengerTransportPodspec task 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,6 +96,11 @@ pipeline{
                 sh './gradlew :transport:assembleMessengerTransportReleaseXCFramework'
             }
         }
+        stage("CI Build - CocoaPods podspec creation for publication"){
+            steps{
+                sh './gradlew :transport:generateGenesysCloudMessengerTransportPodspec'
+            }
+        }
     }
     post{
         success{

--- a/transport/GenesysCloudMessengerTransport.podspec_template
+++ b/transport/GenesysCloudMessengerTransport.podspec_template
@@ -8,7 +8,30 @@ The Genesys Cloud Messenger Transport SDK is a framework that provides methods f
                              DESC
 
   s.homepage               = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
-  s.license                = 'MIT'
+  s.license                = { :type => 'MIT', :text => <<-LICENSE
+MIT License
+
+Copyright (c) 2021 Genesys Cloud Services, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+                               LICENSE
+                             }
   s.author                 = 'Genesys Cloud Services, Inc.'
   s.source                 = { :http => '<SOURCE_HTTP_URL>' }
 

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -148,6 +148,16 @@ tasks {
         archiveClassifier.set("javadoc")
         from("./deployment")
     }
+
+    register("generateGenesysCloudMessengerTransportPodspec") {
+        doLast {
+            val podspecFileName = "GenesysCloudMessengerTransport.podspec"
+            var content = file("${podspecFileName}_template").readText()
+                .replace(oldValue = "<VERSION>", newValue = version.toString())
+                .replace(oldValue = "<SOURCE_HTTP_URL>", newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v${version}/MessengerTransport.xcframework.zip")
+            file(podspecFileName, PathValidation.NONE).writeText(content)
+        }
+    }
 }
 
 publishing {

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -150,8 +150,10 @@ tasks {
     }
 
     register("generateGenesysCloudMessengerTransportPodspec") {
+        val podspecFileName = "GenesysCloudMessengerTransport.podspec"
+        group = "publishing"
+        description = "Generates the $podspecFileName file for publication to CocoaPods."
         doLast {
-            val podspecFileName = "GenesysCloudMessengerTransport.podspec"
             var content = file("${podspecFileName}_template").readText()
                 .replace(oldValue = "<VERSION>", newValue = version.toString())
                 .replace(oldValue = "<SOURCE_HTTP_URL>", newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v${version}/MessengerTransport.xcframework.zip")


### PR DESCRIPTION
Since the transport library version is now in build.gradle.kts, seemed like a decent idea to create a gradle task that can also generate the Cocoapods podspec file to be used for publication. This PR adds a new gradle task`:transport:generateGenesysCloudMessengerTransportPodspec` for that purpose. I also added the MIT License text to the podspec which removes the warning when linting/publishing the Pod.