### PR TITLE
Feature/gmdx 227

### DIFF
--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -277,7 +277,9 @@ extension ContentViewController : UITextFieldDelegate {
                 let image = UIImage(named: self.attachmentName)
                 guard let data = image?.pngData() as NSData? else { return }
                 self.byteArray = data.toByteArray()
-                self.info.text = "<loaded \(String(describing: self.byteArray?.count)) bytes>"
+                DispatchQueue.main.async {
+                    self.info.text = "<loaded \(String(describing: self.byteArray?.count)) bytes>"
+                }
             }
         case ("attach", _):
             if(byteArray != nil) {

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -29,7 +29,7 @@ object MobileMessenger {
         val api = WebMessagingApi(configuration)
         val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
-        val attachmentHandler = AttachmentHandler(
+        val attachmentHandler = AttachmentHandlerImpl(
             api,
             token,
             log.withTag(LogTag.ATTACHMENT_HANDLER),

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerTest.kt
@@ -39,6 +39,7 @@ internal class AttachmentHandlerTest {
     }
     private val attachmentSlot = slot<Attachment>()
     private val mockAttachmentListener: (Attachment) -> Unit = spyk()
+    private val processedAttachments = mutableMapOf<String, ProcessedAttachment>()
 
     private val givenToken = "00000000-0000-0000-0000-000000000000"
     private val givenAttachmentId = "99999999-9999-9999-9999-999999999999"
@@ -52,6 +53,7 @@ internal class AttachmentHandlerTest {
         givenToken,
         mockk(relaxed = true),
         mockAttachmentListener,
+        processedAttachments,
     )
 
     @ExperimentalCoroutinesApi

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -37,7 +37,7 @@ class MessagingClientImplTest {
             TextMessage("Hello world")
         )
     }
-    private val mockAttachmentHandler: IAttachmentHandler = mockk(relaxed = true) {
+    private val mockAttachmentHandler: AttachmentHandler = mockk(relaxed = true) {
         every {
             prepare(
                 any(),

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -7,6 +7,7 @@ import com.genesys.cloud.messenger.transport.network.SocketCloseCode
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
+import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OnMessageRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.TextMessage
@@ -36,9 +37,9 @@ class MessagingClientImplTest {
             TextMessage("Hello world")
         )
     }
-    private val mockAttachmentHandler: AttachmentHandler = mockk(relaxed = true) {
+    private val mockAttachmentHandler: IAttachmentHandler = mockk(relaxed = true) {
         every {
-            prepareAttachment(
+            prepare(
                 any(),
                 any(),
                 any(),
@@ -50,6 +51,11 @@ class MessagingClientImplTest {
             fileName = "test_attachment.png",
             fileType = "image/png",
             errorsAsJson = true,
+        )
+
+        every { delete(any()) } returns DeleteAttachmentRequest(
+            "00000000-0000-0000-0000-000000000000",
+            "88888888-8888-8888-8888-888888888888"
         )
     }
     private val mockPlatformSocket: PlatformSocket = mockk {
@@ -142,7 +148,6 @@ class MessagingClientImplTest {
             connectSequence()
             configureSequence()
             mockMessageStore.prepareMessage(expectedText)
-            mockAttachmentHandler.clear()
             mockPlatformSocket.sendMessage(expectedMessage)
         }
     }
@@ -175,7 +180,7 @@ class MessagingClientImplTest {
         verifySequence {
             connectSequence()
             configureSequence()
-            mockAttachmentHandler.prepareAttachment(any(), any(), any())
+            mockAttachmentHandler.prepare(any(), any(), any())
             mockPlatformSocket.sendMessage(expectedMessage)
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -50,7 +50,6 @@ data class Attachment(
          */
         data class Uploaded(val downloadUrl: String) : State()
 
-
         /**
          * Message that holds this attachment was sent, but there were no confirmation of delivery or failure yet.
          */

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Transient
 @Serializable
 data class Attachment(
     val id: String,
-    @Transient val fileName: String = "",
+    @Transient val fileName: String? = null,
     @Transient val state: State = State.Presigning,
 ) {
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -18,6 +18,12 @@ data class Attachment(
     @Serializable
     sealed class State {
         /**
+         * Attachment was requested to be deleted from the conversation history,
+         * but there were no confirmation of deletion or failure yet.
+         */
+        object Deleting : State()
+
+        /**
          * Attachment was deleted from the conversation history.
          */
         object Deleted : State()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -50,6 +50,12 @@ data class Attachment(
          */
         data class Uploaded(val downloadUrl: String) : State()
 
+
+        /**
+         * Message that holds this attachment was sent, but there were no confirmation of delivery or failure yet.
+         */
+        object Sending : State()
+
         /**
          * Attachment was sent.
          *

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -5,7 +5,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
 
-internal interface IAttachmentHandler {
+internal interface AttachmentHandler {
 
     fun prepare(
         attachmentId: String,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -23,8 +23,8 @@ internal class AttachmentHandler(
     private val token: String,
     private val log: Log,
     private val updateAttachmentStateWith: (Attachment) -> Unit,
+    private val processedAttachments: MutableMap<String, ProcessedAttachment> = mutableMapOf()
 ) {
-    private val processedAttachments = mutableMapOf<String, ProcessedAttachment>()
     private val uploadDispatcher = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     fun prepareAttachment(
@@ -121,7 +121,7 @@ internal class AttachmentHandler(
         processedAttachments.remove(id)?.job?.cancel()
 }
 
-private class ProcessedAttachment(
+internal class ProcessedAttachment(
     var attachment: Attachment,
     var byteArray: ByteArray,
     var job: Job? = null,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -100,6 +100,7 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun delete(attachmentId: String): DeleteAttachmentRequest {
+        log.i { "Deleting attachment: $attachmentId" }
         updateAttachmentStateWith(Attachment(attachmentId, state = Deleting))
         return DeleteAttachmentRequest(
             token = token,
@@ -115,7 +116,7 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun onError(attachmentId: String, errorCode: ErrorCode, errorMessage: String) {
-        processedAttachments[attachmentId]?.let {
+        processedAttachments.remove(attachmentId)?.let {
             log.e { "Attachment error. ErrorCode: $errorCode, errorMessage: $errorMessage" }
             updateAttachmentStateWith(
                 it.attachment.copy(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -89,11 +89,11 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun detach(attachmentId: String, delete: () -> Unit) {
-        processedAttachments[attachmentId]?.let {
-            log.i { "Detaching: ${it.attachment}" }
-            when (it.attachment.state) {
-                is Uploaded -> delete()
-                else -> removeAttachment(it.attachment.id)
+        processedAttachments.remove(attachmentId)?.let {
+            log.i { "Attachment detached: $attachmentId" }
+            it.job?.cancel()
+            if (it.attachment.state is Uploaded) {
+                delete()
             }
             updateAttachmentStateWith(it.attachment.copy(state = Detached))
         }
@@ -125,9 +125,6 @@ internal class AttachmentHandlerImpl(
     override fun onSent() {
         // TODO("Not yet implemented")
     }
-
-    private fun removeAttachment(id: String) =
-        processedAttachments.remove(id)?.job?.cancel()
 }
 
 internal class ProcessedAttachment(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -109,24 +109,13 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun onDeleted(attachmentId: String) {
-        processedAttachments.remove(attachmentId)?.let {
-            log.i { "Attachment deleted: ${it.attachment}" }
-            updateAttachmentStateWith(it.attachment.copy(state = Deleted))
-        }
+        updateAttachmentStateWith(Attachment(attachmentId, state = Deleted))
     }
 
     override fun onError(attachmentId: String, errorCode: ErrorCode, errorMessage: String) {
-        processedAttachments.remove(attachmentId)?.let {
-            log.e { "Attachment error. ErrorCode: $errorCode, errorMessage: $errorMessage" }
-            updateAttachmentStateWith(
-                it.attachment.copy(
-                    state = Error(
-                        errorCode,
-                        errorMessage
-                    )
-                )
-            )
-        }
+        log.e { "Attachment error with id: $attachmentId. ErrorCode: $errorCode, errorMessage: $errorMessage" }
+        processedAttachments.remove(attachmentId)
+        updateAttachmentStateWith(Attachment(attachmentId, state = Error(errorCode, errorMessage)))
     }
 
     override fun onSending() {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -5,6 +5,7 @@ import com.genesys.cloud.messenger.transport.core.Attachment.State.Deleting
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Detached
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Error
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Presigning
+import com.genesys.cloud.messenger.transport.core.Attachment.State.Sending
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Uploaded
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Uploading
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
@@ -119,7 +120,13 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun onSending() {
-        // TODO("Not yet implemented")
+        processedAttachments.forEach { entry ->
+            entry.value.takeUploaded()?.let {
+                log.i { "Sending attachment: ${it.attachment.id}" }
+                it.attachment = it.attachment.copy(state = Sending)
+                    .also(updateAttachmentStateWith)
+            }
+        }
     }
 
     override fun onSent() {
@@ -133,3 +140,6 @@ internal class ProcessedAttachment(
     var job: Job? = null,
     val uploadProgress: ((Float) -> Unit)?,
 )
+
+private fun ProcessedAttachment.takeUploaded(): ProcessedAttachment? =
+    this.takeIf { it.attachment.state is Uploaded }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -155,7 +155,6 @@ internal class ProcessedAttachment(
     val uploadProgress: ((Float) -> Unit)?,
 )
 
-
 private fun ProcessedAttachment.takeSendingId(): String? =
     this.takeIf { it.attachment.state is Sending }?.attachment?.id
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -131,8 +131,11 @@ internal class AttachmentHandlerImpl(
 
     override fun onSent(attachments: Map<String, Attachment>) {
         log.i { "Attachments sent: $attachments" }
-        attachments.forEach { updateAttachmentStateWith(it.value) }
-        processedAttachments.keys.removeAll(attachments.keys)
+        attachments.forEach { entry ->
+            processedAttachments.remove(entry.key)?.also {
+                updateAttachmentStateWith(entry.value)
+            }
+        }
     }
 }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -30,7 +30,7 @@ internal class AttachmentHandlerImpl(
     private val log: Log,
     private val updateAttachmentStateWith: (Attachment) -> Unit,
     private val processedAttachments: MutableMap<String, ProcessedAttachment> = mutableMapOf()
-) : IAttachmentHandler {
+) : AttachmentHandler {
     private val uploadDispatcher = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
     override fun prepare(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -129,8 +129,10 @@ internal class AttachmentHandlerImpl(
         }
     }
 
-    override fun onSent() {
-        // TODO("Not yet implemented")
+    override fun onSent(attachments: Map<String, Attachment>) {
+        log.i { "Attachments sent: $attachments" }
+        attachments.forEach { updateAttachmentStateWith(it.value) }
+        processedAttachments.keys.removeAll(attachments.keys)
     }
 }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
@@ -29,4 +29,8 @@ internal interface IAttachmentHandler {
     fun onSending()
 
     fun onSent(attachments: Map<String, Attachment>)
+
+    fun onMessageError(code: ErrorCode, message: String?)
+
+    fun clearAll()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
@@ -28,5 +28,5 @@ internal interface IAttachmentHandler {
 
     fun onSending()
 
-    fun onSent()
+    fun onSent(attachments: Map<String, Attachment>)
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/IAttachmentHandler.kt
@@ -1,0 +1,32 @@
+package com.genesys.cloud.messenger.transport.core
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
+import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
+import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
+
+internal interface IAttachmentHandler {
+
+    fun prepare(
+        attachmentId: String,
+        byteArray: ByteArray,
+        fileName: String,
+        uploadProgress: ((Float) -> Unit)? = null
+    ): OnAttachmentRequest
+
+    fun upload(presignedUrlResponse: PresignedUrlResponse)
+
+    fun detach(attachmentId: String, delete: () -> Unit)
+
+    fun delete(attachmentId: String): DeleteAttachmentRequest
+
+    fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)
+
+    fun onDeleted(attachmentId: String)
+
+    fun onError(attachmentId: String, errorCode: ErrorCode, errorMessage: String)
+
+    fun onSending()
+
+    fun onSent()
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -218,8 +218,12 @@ internal class MessagingClientImpl(
                         attachmentHandler.upload(decoded.body)
                     is UploadSuccessEvent ->
                         attachmentHandler.onUploadSuccess(decoded.body)
-                    is StructuredMessage ->
-                        messageStore.update(decoded.body.toMessage())
+                    is StructuredMessage -> {
+                        with(decoded.body.toMessage()) {
+                            messageStore.update(this)
+                            attachmentHandler.onSent(this.attachments)
+                        }
+                    }
                     is AttachmentDeletedResponse ->
                         attachmentHandler.onDeleted(decoded.body.attachmentId)
                     is GenerateUrlError -> {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -98,6 +98,7 @@ internal class MessagingClientImpl(
     override fun sendMessage(text: String) {
         log.i { "sendMessage(text = $text)" }
         val request = messageStore.prepareMessage(text)
+        attachmentHandler.onSending()
         val encodedJson = WebMessagingJson.json.encodeToString(request)
         send(encodedJson)
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -36,7 +36,7 @@ internal class MessagingClientImpl(
     private val log: Log,
     private val jwtHandler: JwtHandler,
     private val token: String,
-    private val attachmentHandler: IAttachmentHandler,
+    private val attachmentHandler: AttachmentHandler,
     private val messageStore: MessageStore,
 ) : MessagingClient {
 

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -26,13 +26,12 @@ object MobileMessenger {
         val token =
             TokenStoreImpl(configuration.tokenStoreKey, log.withTag(LogTag.TOKEN_STORE)).token
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
-        val attachmentHandler =
-            AttachmentHandler(
-                api,
-                token,
-                log.withTag(LogTag.ATTACHMENT_HANDLER),
-                messageStore.updateAttachmentStateWith,
-            )
+        val attachmentHandler = AttachmentHandlerImpl(
+            api,
+            token,
+            log.withTag(LogTag.ATTACHMENT_HANDLER),
+            messageStore.updateAttachmentStateWith,
+        )
         return MessagingClientImpl(
             api = api,
             log = log,


### PR DESCRIPTION
### Additions:
- Abstract AttachmentHandler.
-    Add Attachment.State.Deleting - when  Attachment was requested to be deleted from the conversation history, but there were no confirmation of deletion or failure yet.
- Add Attachment.State.Sending when attachment was sent along with the parent message, but there were no confirmation of success or error yet.
- Update unit tests.
### Bug Fixes:
- Fix Bug with ios TestBed app crashing when trying to display the size of the loaded asset.

