### PR TITLE
Feature/gmdx-249 remove delete attachment api

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import com.genesys.cloud.messenger.androidcomposeprototype.BuildConfig
-import com.genesys.cloud.messenger.transport.core.Attachment.State.Deleted
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Detached
 import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.core.MessageEvent
@@ -97,8 +96,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "history" -> fetchNextPage()
             "healthCheck" -> doSendHealthCheck()
             "attach" -> doAttach()
-            "detach" -> doDetach()
-            "delete" -> doDeleteAttachment(components)
+            "detach" -> doDetach(components)
             "deployment" -> doDeployment()
             else -> {
                 Log.e(TAG, "Invalid command")
@@ -186,23 +184,10 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         }
     }
 
-    private suspend fun doDetach() {
-        try {
-            if (attachedIds.isEmpty()) {
-                socketMessage = "No attachments to detach"
-                commandWaiting = false
-                return
-            }
-            client.detach(attachmentId = attachedIds.first())
-        } catch (t: Throwable) {
-            handleException(t, "detach")
-        }
-    }
-
-    private suspend fun doDeleteAttachment(components: List<String>) {
+    private suspend fun doDetach(components: List<String>) {
         try {
             val attachmentId = components.getOrNull(1) ?: ""
-            client.deleteAttachment(attachmentId)
+            client.detach(attachmentId)
         } catch (t: Throwable) {
             handleException(t, "detach")
         }
@@ -256,10 +241,6 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             is AttachmentUpdated -> {
                 when (event.attachment.state) {
                     Detached -> {
-                        attachedIds.remove(event.attachment.id)
-                        event.attachment.toString()
-                    }
-                    Deleted -> {
                         attachedIds.remove(event.attachment.id)
                         event.attachment.toString()
                     }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -98,7 +98,7 @@ internal class MessageExtensionTest {
                     "second test attachment id" to Attachment(
                         id = "second test attachment id",
                         fileName = "test2.png",
-                        Attachment.State.Deleted,
+                        Attachment.State.Detached,
                     )
                 )
             )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -18,15 +18,10 @@ data class Attachment(
     @Serializable
     sealed class State {
         /**
-         * Attachment was requested to be deleted from the conversation history,
-         * but there were no confirmation of deletion or failure yet.
+         * Attachment was requested to be detached from the message,
+         * but there were no confirmation of success or failure yet.
          */
-        object Deleting : State()
-
-        /**
-         * Attachment was deleted from the conversation history.
-         */
-        object Deleted : State()
+        object Detaching : State()
 
         /**
          * Attachment was detached from the Message.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -16,13 +16,11 @@ internal interface AttachmentHandler {
 
     fun upload(presignedUrlResponse: PresignedUrlResponse)
 
-    fun detach(attachmentId: String, delete: () -> Unit)
-
-    fun delete(attachmentId: String): DeleteAttachmentRequest
+    fun detach(attachmentId: String): DeleteAttachmentRequest?
 
     fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)
 
-    fun onDeleted(attachmentId: String)
+    fun onDetached(attachmentId: String)
 
     fun onError(attachmentId: String, errorCode: ErrorCode, errorMessage: String)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -130,23 +130,14 @@ interface MessagingClient {
     ): String
 
     /**
-     * Detach file from message. If file was already uploaded
-     * or is uploading now - process will be stopped
-     * and [deleteAttachment] will be called.
+     * Detach file from message. If file was already uploaded it will be deleted.
+     * If file is uploading now - process will be stopped.
      *
      * @param attachmentId the ID of the attachment to remove
-     */
-    fun detach(attachmentId: String)
-
-    /**
-     * Attachments typically expire 72 hours after being uploaded. This method can be used to
-     * immediately delete the file prior to that expiration.
-     *
-     * @param attachmentId the ID of the attachment
-     * @throws IllegalStateException
+     * @throws IllegalStateException if called before session was connected.
      */
     @Throws(IllegalStateException::class)
-    fun deleteAttachment(attachmentId: String)
+    fun detach(attachmentId: String)
 
     /**
      * Get message history for a conversation.


### PR DESCRIPTION
- Remove deleteAttachment() from MessagingClient.kt
- Remove State.Deleted and State.Deleting.
- Add State.Detaching and dispatch it when file was already uploaded and confirmation of file deletion is required.
- When file detached report State.Detached.
- Update unit tests.