### PR TITLE
Feature/gmdx 259 convert timestamp to unix

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -4,6 +4,7 @@ object Deps {
     private const val junitVersion = "4.13.2"
     private const val kermitVersion = "0.1.9"
     private const val kotlinxSerializationJsonVersion = "1.3.1"
+    private const val kotlinxDateTimeVersion = "0.3.1"
     private const val ktorVersion = "1.6.0"
     private const val logbackVersion = "1.2.10"
     private const val mockWebServerVersion = "4.9.0"
@@ -36,6 +37,8 @@ object Deps {
                 "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
             const val coroutinesTest =
                 "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
+            const val dateTime =
+                "org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion"
         }
 
         object Ktor {

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -93,6 +93,7 @@ kotlin {
                 implementation(kotlin("stdlib-common"))
                 implementation(Deps.Libs.Kotlinx.serializationJson)
                 implementation(Deps.Libs.Kotlinx.coroutinesCore)
+                implementation(Deps.Libs.Kotlinx.dateTime)
                 implementation(Deps.Libs.Ktor.core)
                 implementation(Deps.Libs.Ktor.serialization)
                 implementation(Deps.Libs.Ktor.json)
@@ -154,7 +155,7 @@ tasks {
         group = "publishing"
         description = "Generates the $podspecFileName file for publication to CocoaPods."
         doLast {
-            var content = file("${podspecFileName}_template").readText()
+            val content = file("${podspecFileName}_template").readText()
                 .replace(oldValue = "<VERSION>", newValue = version.toString())
                 .replace(oldValue = "<SOURCE_HTTP_URL>", newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v${version}/MessengerTransport.xcframework.zip")
             file(podspecFileName, PathValidation.NONE).writeText(content)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -2,9 +2,9 @@ package com.genesys.cloud.messenger.transport.core
 
 import assertk.assertThat
 import assertk.assertions.containsExactly
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
-import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses.isoTestTimestamp
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
@@ -123,7 +123,7 @@ internal class MessageExtensionTest {
                 attachments = emptyMap()
             )
 
-        assertThat(givenMessage.getUploadedAttachments().isEmpty()).isTrue()
+        assertThat(givenMessage.getUploadedAttachments()).isEmpty()
     }
 
     @Test

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -307,7 +307,7 @@ internal class MessageStoreTest {
         direction = Message.Direction.Outbound,
         state = Message.State.Sent,
         text = "message from agent number $messageId",
-        timeStamp = "$messageId-09-02T15:05:57.293Z",
+        timeStamp = 100 * messageId.toLong(),
     )
 
     private fun attachment(

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -457,7 +457,7 @@ class MessagingClientImplTest {
             Message.State.Sent,
             "Text",
             "Hi",
-            "some_time",
+            null,
             mapOf("attachment_id" to expectedAttachment)
         )
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.Serializable
  *  @property direction is direction in which message was sent.
  *  @property state represents current message state.
  *  @property type is message type. With default type "Text".
- *  @property text optional text payload of the message
+ *  @property text optional text payload of the message.
  *  @property timeStamp optional timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
  *  @property attachments map of [Attachment] files to the message. Empty by default.
  */

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -5,6 +5,14 @@ import kotlinx.serialization.Serializable
 
 /**
  *  Container class with information about message.
+ *
+ *  @property id unique message identifier.
+ *  @property direction is direction in which message was sent.
+ *  @property state represents current message state.
+ *  @property type is message type. With default type "Text".
+ *  @property text optional text payload of the message
+ *  @property timeStamp optional timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
+ *  @property attachments map of [Attachment] files to the message. Empty by default.
  */
 @Serializable
 data class Message(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -13,7 +13,7 @@ data class Message(
     val state: State = State.Idle,
     val type: String = "Text",
     val text: String? = null,
-    val timeStamp: String? = null,
+    val timeStamp: Long? = null,
     val attachments: Map<String, Attachment> = emptyMap(),
 ) {
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -6,13 +6,13 @@ import kotlinx.serialization.Serializable
 /**
  *  Container class with information about message.
  *
- *  @property id unique message identifier.
- *  @property direction is direction in which message was sent.
- *  @property state represents current message state.
- *  @property type is message type. With default type "Text".
- *  @property text optional text payload of the message.
- *  @property timeStamp optional timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
- *  @property attachments map of [Attachment] files to the message. Empty by default.
+ *  @property id a unique message identifier.
+ *  @property direction the direction in which the message was sent.
+ *  @property state the current message state.
+ *  @property type the message type. The default type is "Text".
+ *  @property text the text payload of the message.
+ *  @property timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
+ *  @property attachments a map of [Attachment] files to the message. Empty by default.
  */
 @Serializable
 data class Message(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -5,6 +5,7 @@ import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
+import kotlinx.datetime.toInstant
 
 internal fun MessageEntityList.toMessageList(): List<Message> {
     return this.entities.map {
@@ -19,7 +20,7 @@ internal fun StructuredMessage.toMessage(): Message {
         state = Message.State.Sent,
         type = this.type,
         text = this.text,
-        timeStamp = this.channel?.time,
+        timeStamp = this.channel?.time.fromIsoToEpochMilliseconds(),
         attachments = this.content.toAttachments()
     )
 }
@@ -31,6 +32,14 @@ internal fun Message.getUploadedAttachments(): List<Message.Content> {
     }.map {
         Message.Content(contentType = Message.Content.Type.Attachment, attachment = it.value)
     }.toList()
+}
+
+internal fun String?.fromIsoToEpochMilliseconds(): Long? {
+    return try {
+        this?.toInstant()?.toEpochMilliseconds()
+    } catch (t: Throwable) {
+        null
+    }
 }
 
 private fun List<StructuredMessage.Content>.toAttachments(): Map<String, Attachment> {

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
@@ -14,8 +14,9 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.Styles
 
 object TestWebMessagingApiResponses {
 
+    internal const val isoTestTimestamp = "2014-04-30T21:09:51.411Z"
     internal const val messageEntityResponseWith2Messages =
-        """{"entities":[{"id":"5befde6373a23f32f20b59b4e1cba0e6","channel":{"time":"2021-03-26T21:11:01.464Z"},"type":"Text","text":"\uD83E\uDD2A","content":[],"direction":"Outbound"},{"id":"46e7001c24abed05e9bcd1a006eb54b7","channel":{"time":"2021-03-26T21:09:51.411Z"},"type":"Text","metadata":{"customMessageId":"1234567890"},"text":"customer msg 7","content":[],"direction":"Inbound"}],"pageSize":25,"pageNumber":1, "total": 2, "pageCount": 1}"""
+        """{"entities":[{"id":"5befde6373a23f32f20b59b4e1cba0e6","channel":{"time":"$isoTestTimestamp"},"type":"Text","text":"\uD83E\uDD2A","content":[],"direction":"Outbound"},{"id":"46e7001c24abed05e9bcd1a006eb54b7","channel":{"time":null},"type":"Text","metadata":{"customMessageId":"1234567890"},"text":"customer msg 7","content":[],"direction":"Inbound"}],"pageSize":25,"pageNumber":1, "total": 2, "pageCount": 1}"""
 
     internal const val messageEntityListResponseWithoutMessages =
         """{"entities":[],"pageSize":0,"pageNumber":1, "total": 0, "pageCount": 0}"""
@@ -67,13 +68,13 @@ object TestWebMessagingApiResponses {
         listOf(
             messageEntity(
                 id = "5befde6373a23f32f20b59b4e1cba0e6",
-                time = "2021-03-26T21:11:01.464Z",
+                time = isoTestTimestamp,
                 text = "\uD83E\uDD2A",
                 isInbound = false,
             ),
             messageEntity(
                 id = "46e7001c24abed05e9bcd1a006eb54b7",
-                time = "2021-03-26T21:09:51.411Z",
+                time = null,
                 text = "customer msg 7",
                 customMessageId = "1234567890",
             )
@@ -81,7 +82,7 @@ object TestWebMessagingApiResponses {
 
     private fun messageEntity(
         id: String,
-        time: String,
+        time: String?,
         text: String,
         isInbound: Boolean = true,
         customMessageId: String? = null,


### PR DESCRIPTION
- Add kotlinx.datetime library dependency to handle iso/unix conversation for multiplatform.
- Convert Message.timestamp from iso to unix. (breaking change as it modify the structure of Message.kt)
- Add unit tests to cover conversion.
- Update existing unit tests to support changes.