### PR TITLE
GMDX-272 Keep DeploymentConfig during minification.

### DIFF
--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -19,6 +19,7 @@ android {
     defaultConfig {
         minSdk = Deps.Android.minSdk
         targetSdk = Deps.Android.targetSdk
+        consumerProguardFiles("transport-proguard-rules.txt")
     }
     buildTypes {
         getByName("release") {

--- a/transport/transport-proguard-rules.txt
+++ b/transport/transport-proguard-rules.txt
@@ -1,0 +1,1 @@
+-keep class com.genesys.cloud.messenger.transport.shyrka.** { *; }


### PR DESCRIPTION
- Add proguard rule to keep DeploymentConfig during minification.


During minification optimization process compiler get rid of objects that it consider to be not in used. 
Some of kotlinx.serialization falls under this category resulting in runtime exception: 
 `Serializer for class 'DeploymentConfig' is not found. Mark the class as @Serializable or provide the serializer explicitly.`

Solution will be to explicitly tell compiler to keep this objects during optimization.

I found 2 possible approaches:

1. Add proguard rule to Transport sdk telling to keep `com.genesys.cloud.messenger.transport.shyrka` namespace.
https://developer.android.com/studio/projects/android-library#Considerations

2. Annotate with `@Keep` objects that required to survive optimization. 
https://developer.android.com/reference/androidx/annotation/Keep

Since second approach requires dependency on `androidx.annotation:annotation` and I do not see any strong downsides of using first approach I decided to proceed with the first option. 