### PR TITLE
Feature/gmdx 262 invert conversation order

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -242,7 +242,7 @@ class MessagingClientImplTest {
     }
 
     @Test
-    fun whenSendMessageWithoutToken() {
+    fun whenSendMessageWithoutConnection() {
         assertFailsWith<IllegalStateException> {
             subject.sendMessage("foo")
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -35,7 +35,7 @@ internal class MessageStore(
                 text,
                 metadata = mapOf("customMessageId" to messageToSend.id),
                 content = messageToSend.getUploadedAttachments()
-            ),
+            )
         )
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -96,6 +96,7 @@ internal class MessagingClientImpl(
 
     @Throws(IllegalStateException::class)
     override fun sendMessage(text: String) {
+        checkConfigured()
         log.i { "sendMessage(text = $text)" }
         val request = messageStore.prepareMessage(text)
         attachmentHandler.onSending()
@@ -138,13 +139,13 @@ internal class MessagingClientImpl(
     }
 
     private fun send(message: String) {
-        if (currentState !is State.Configured) throw IllegalStateException("WebMessaging client is not configured.")
+        checkConfigured()
         log.i { "Will send message" }
         webSocket.sendMessage(message)
     }
 
     override suspend fun fetchNextPage() {
-        check(currentState is State.Configured) { "WebMessaging client is not configured." }
+        checkConfigured()
         if (messageStore.startOfConversation) {
             log.i { "All history have been fetched." }
             return
@@ -262,4 +263,6 @@ internal class MessagingClientImpl(
             attachmentHandler.clearAll()
         }
     }
+
+    private fun checkConfigured() = check(currentState is State.Configured) { "WebMessaging client is not configured." }
 }


### PR DESCRIPTION
- Invert message order in conversation from `new-old` to `old-new`.
- Update unit tests to reflect changes.