### PR TITLE
GMDX-407 - Ignore Ktor Snyk vulnerability.

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JAVA-IOKTOR-2823334:
+    - '*':
+        reason: Upgrade to Ktor 2.0 requires enabling of Non-Production ready feature.
+        expires: 2022-07-20T00:00:00.000Z
+patch: {}


### PR DESCRIPTION
Suggested version upgrade to Ktor 2.0.1 is problematic, as this version upgrade requires from us to OptIn feature that is in "Not production ready state".


- Ignore Ktor Snyk vulnerability for 90 days.