### PR TITLE
GMDX-511- Incorrect Timestamp

### DIFF
--- a/androidComposePrototype/build.gradle
+++ b/androidComposePrototype/build.gradle
@@ -31,7 +31,7 @@ android {
 
     defaultConfig {
         applicationId "com.genesys.cloud.webmessaging.androidcomposeprototype"
-        minSdkVersion 26
+        minSdkVersion 21
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -4,18 +4,19 @@ object Deps {
     private const val junitVersion = "4.13.2"
     private const val kermitVersion = "0.1.9"
     private const val kotlinxSerializationJsonVersion = "1.3.1"
-    private const val kotlinxDateTimeVersion = "0.3.1"
     private const val ktorVersion = "1.6.4"
     private const val logbackVersion = "1.2.10"
     private const val mockWebServerVersion = "4.9.0"
     private const val mockkVersion = "1.12.2"
     private const val okhttpVersion = "4.9.1"
+    private const val klockVersion = "2.4.13"
 
     object Libs {
         const val junit = "junit:junit:$junitVersion"
         const val logback = "ch.qos.logback:logback-classic:$logbackVersion"
         const val mockk = "io.mockk:mockk:$mockkVersion"
         const val kermit = "co.touchlab:kermit:$kermitVersion"
+        const val klock = "com.soywiz.korlibs.klock:klock:$klockVersion"
 
         object Assertk {
             const val common = "com.willowtreeapps.assertk:assertk:$assertkVersion"
@@ -37,8 +38,6 @@ object Deps {
                 "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
             const val coroutinesTest =
                 "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"
-            const val dateTime =
-                "org.jetbrains.kotlinx:kotlinx-datetime:$kotlinxDateTimeVersion"
         }
 
         object Ktor {

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -93,12 +93,12 @@ kotlin {
                 implementation(kotlin("stdlib-common"))
                 implementation(Deps.Libs.Kotlinx.serializationJson)
                 implementation(Deps.Libs.Kotlinx.coroutinesCore)
-                implementation(Deps.Libs.Kotlinx.dateTime)
                 implementation(Deps.Libs.Ktor.core)
                 implementation(Deps.Libs.Ktor.serialization)
                 implementation(Deps.Libs.Ktor.json)
                 implementation(Deps.Libs.Ktor.logging)
                 implementation(Deps.Libs.logback)
+                implementation(Deps.Libs.klock)
                 api(Deps.Libs.kermit)
             }
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -5,7 +5,7 @@ import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
-import kotlinx.datetime.toInstant
+import com.soywiz.klock.DateTime
 
 internal fun MessageEntityList.toMessageList(): List<Message> {
     return this.entities.map {
@@ -36,7 +36,9 @@ internal fun Message.getUploadedAttachments(): List<Message.Content> {
 
 internal fun String?.fromIsoToEpochMilliseconds(): Long? {
     return try {
-        this?.toInstant()?.toEpochMilliseconds()
+        this?.let {
+            DateTime.fromString(it).local.unixMillisLong
+        }
     } catch (t: Throwable) {
         null
     }


### PR DESCRIPTION
### Problem:
Message timestamp becomes null on API <= 26.

### Solution:

Replace kotlinx.date-time library that consumes Instant api that was added on Android 26 with klock library that use the standard DateTime api.

- Downgrade the minSdkVersion on TestBed app to 21.
- Replace `kotlinx.date-time` library with `klock` library that does not use `Instant` api.