### PR TITLE
GMDX-527  Combine connect and configure into single call

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
@@ -59,7 +59,7 @@ fun TestBedContent(
             style = typography.h5
         )
         Text(
-            "Commands: connect, configure, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
+            "Commands: connect, configure, connectToSession, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
             style = typography.caption,
             softWrap = true
         )

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -95,6 +95,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "connect" -> doConnect()
             "bye" -> doDisconnect()
             "configure" -> doConfigureSession()
+            "connectToSession" -> doConnectToSession()
             "send" -> doSendMessage(input)
             "history" -> fetchNextPage()
             "healthCheck" -> doSendHealthCheck()
@@ -147,6 +148,14 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             client.configureSession()
         } catch (t: Throwable) {
             handleException(t, "configure session")
+        }
+    }
+
+    private suspend fun doConnectToSession() {
+        try {
+            client.connectToSession()
+        } catch (t: Throwable) {
+            handleException(t, "connect to session")
         }
     }
 

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -75,6 +75,7 @@ class ContentViewController: UIViewController {
     enum UserCommand: String, CaseIterable {
         case connect
         case configure
+        case connectToSession
         case send
         case history
         case selectAttachment
@@ -257,6 +258,8 @@ extension ContentViewController : UITextFieldDelegate {
                 try messenger.disconnect()
             case (.configure, _):
                 try messenger.configureSession()
+            case (.connectToSession, _):
+                try messenger.connectToSession()
             case (.send, let msg?):
                 try messenger.sendMessage(text: msg.trimmingCharacters(in: .whitespaces), customAttributes: customAttributes)
                 customAttributes = [:]

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -54,6 +54,15 @@ class MessengerHandler {
             throw error
         }
     }
+    
+    func connectToSession() throws {
+        do {
+            try client.connectToSession()
+        } catch {
+            print("connectToSession() failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func disconnect() throws {
         do {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -83,14 +83,26 @@ interface MessagingClient {
      *
      * @throws IllegalStateException
      */
+    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
     @Throws(IllegalStateException::class)
     fun connect()
 
     /**
      * Configure a Web Messaging session.
      */
+    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
     @Throws(IllegalStateException::class)
     fun configureSession()
+
+    /**
+     * Simplify commonly used api to start a new chat. Calling this function will execute a series of action:
+     * 1. Connect to the websocket.
+     * 2. Configure a Web Messaging session.
+     *
+     * @throws IllegalStateException
+     */
+    @Throws(IllegalStateException::class)
+    fun connectToSession()
 
     /**
      * Send a message to the conversation as plain text.

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
@@ -19,3 +19,6 @@ fun Assert<MessagingClient>.isClosing(code: Int, reason: String) =
 
 fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean?) =
     currentState().isEqualTo(MessagingClient.State.Configured(connected, newSession))
+
+fun Assert<MessagingClient>.isError(code: ErrorCode, message: String?) =
+    currentState().isEqualTo(MessagingClient.State.Error(code, message))


### PR DESCRIPTION
- Use parametrized `connect(shouldConfigure: Boolean)` to prepare for deprecation of connect/configure.  
- Deprecate connect and configure. In the next major release they will become internal.
- Add connectWithConfigure command to the testbed application on ios and Android.
- Provide unit test coverage for newly added api.