### PR TITLE
Feature/gmdx 527

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
@@ -59,7 +59,7 @@ fun TestBedContent(
             style = typography.h5
         )
         Text(
-            "Commands: connect, configure, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
+            "Commands: connect, configure, connectToSession, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
             style = typography.caption,
             softWrap = true
         )

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
@@ -59,7 +59,7 @@ fun TestBedContent(
             style = typography.h5
         )
         Text(
-            "Commands: connect, configure, connectToSession, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
+            "Commands: connect, configure, connectWithConfigure, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>",
             style = typography.caption,
             softWrap = true
         )

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -95,7 +95,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "connect" -> doConnect()
             "bye" -> doDisconnect()
             "configure" -> doConfigureSession()
-            "connectToSession" -> doConnectToSession()
+            "connectWithConfigure" -> doConnectWithConfigure()
             "send" -> doSendMessage(input)
             "history" -> fetchNextPage()
             "healthCheck" -> doSendHealthCheck()
@@ -151,11 +151,11 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         }
     }
 
-    private suspend fun doConnectToSession() {
+    private suspend fun doConnectWithConfigure() {
         try {
-            client.connectToSession()
+            client.connect(shouldConfigure = true)
         } catch (t: Throwable) {
-            handleException(t, "connect to session")
+            handleException(t, "connect with configure")
         }
     }
 

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -95,6 +95,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "connect" -> doConnect()
             "bye" -> doDisconnect()
             "configure" -> doConfigureSession()
+            "connectToSession" -> doConnectToSession()
             "send" -> doSendMessage(input)
             "history" -> fetchNextPage()
             "healthCheck" -> doSendHealthCheck()
@@ -147,6 +148,14 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             client.configureSession()
         } catch (t: Throwable) {
             handleException(t, "configure session")
+        }
+    }
+
+    private suspend fun doConnectToSession() {
+        try {
+            client.connectToSession()
+        } catch (t: Throwable) {
+            handleException(t, "connect to session")
         }
     }
 

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -75,7 +75,7 @@ class ContentViewController: UIViewController {
     enum UserCommand: String, CaseIterable {
         case connect
         case configure
-        case connectToSession
+        case connectWithConfigure
         case send
         case history
         case selectAttachment
@@ -258,8 +258,8 @@ extension ContentViewController : UITextFieldDelegate {
                 try messenger.disconnect()
             case (.configure, _):
                 try messenger.configureSession()
-            case (.connectToSession, _):
-                try messenger.connectToSession()
+            case (.connectWithConfigure, _):
+                try messenger.connect(shouldConfigure: true)
             case (.send, let msg?):
                 try messenger.sendMessage(text: msg.trimmingCharacters(in: .whitespaces), customAttributes: customAttributes)
                 customAttributes = [:]

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -75,6 +75,7 @@ class ContentViewController: UIViewController {
     enum UserCommand: String, CaseIterable {
         case connect
         case configure
+        case connectToSession
         case send
         case history
         case selectAttachment
@@ -257,6 +258,8 @@ extension ContentViewController : UITextFieldDelegate {
                 try messenger.disconnect()
             case (.configure, _):
                 try messenger.configureSession()
+            case (.connectToSession, _):
+                try messenger.connectToSession()
             case (.send, let msg?):
                 try messenger.sendMessage(text: msg.trimmingCharacters(in: .whitespaces), customAttributes: customAttributes)
                 customAttributes = [:]

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -55,11 +55,11 @@ class MessengerHandler {
         }
     }
     
-    func connectToSession() throws {
+    func connect(shouldConfigure: Bool) throws {
         do {
-            try client.connectToSession()
+            try client.connect(shouldConfigure: shouldConfigure)
         } catch {
-            print("connectToSession() failed. \(error.localizedDescription)")
+            print("connectWithConfigure() failed. \(error.localizedDescription)")
             throw error
         }
     }

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -54,6 +54,15 @@ class MessengerHandler {
             throw error
         }
     }
+    
+    func connectToSession() throws {
+        do {
+            try client.connectToSession()
+        } catch {
+            print("connectToSession() failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func disconnect() throws {
         do {

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -108,8 +108,6 @@ class TestContentController: MessengerHandler {
         client.stateListener = { [weak self] state in
             print("State Event: \(state)")
             switch state {
-            case _ as MessagingClientState.Connected:
-                self?.testExpectation?.fulfill()
             case _ as MessagingClientState.Configured:
                 self?.testExpectation?.fulfill()
             case _ as MessagingClientState.Closed:
@@ -151,22 +149,15 @@ class TestContentController: MessengerHandler {
 
     func startMessengerConnection(file: StaticString = #file, line: UInt = #line) {
         do {
-            try connect()
-            try configureSession()
+            try connect(shouldConfigure: true)
         } catch {
             XCTFail("Possible issue with connecting to the backend: \(error.localizedDescription)", file: file, line: line)
         }
     }
 
-    override func connect() throws {
-        testExpectation = XCTestExpectation(description: "Wait for Connection.")
-        try super.connect()
-        waitForExpectation()
-    }
-
-    override func configureSession() throws {
+    override func connect(shouldConfigure: Bool) throws {
         testExpectation = XCTestExpectation(description: "Wait for Configuration.")
-        try super.configureSession()
+        try super.connect(shouldConfigure: shouldConfigure)
         waitForExpectation()
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -91,7 +91,7 @@ interface MessagingClient {
      * Open a secure WebSocket connection to the Web Messaging service with the url and
      * deploymentId configured on this MessagingClient instance.
      *
-     * @param shouldConfigure when true, Configure a Web Messaging session.
+     * @param shouldConfigure a Boolean value indicating whether to configure a Web Messaging session after the WebSocket is opened.
      * @throws IllegalStateException
      */
     @Throws(IllegalStateException::class)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -83,14 +83,26 @@ interface MessagingClient {
      *
      * @throws IllegalStateException
      */
+    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
     @Throws(IllegalStateException::class)
     fun connect()
 
     /**
      * Configure a Web Messaging session.
      */
+    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
     @Throws(IllegalStateException::class)
     fun configureSession()
+
+    /**
+     * Simplify commonly used api to start a new chat. Calling this function will execute a series of action:
+     * 1. Connect to the websocket.
+     * 2. Configure a Web Messaging session.
+     *
+     * @throws IllegalStateException
+     */
+    @Throws(IllegalStateException::class)
+    fun connectToSession()
 
     /**
      * Send a message to the conversation as plain text.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -95,7 +95,7 @@ interface MessagingClient {
      * @throws IllegalStateException
      */
     @Throws(IllegalStateException::class)
-    fun connect(shouldConfigure: Boolean = false)
+    fun connect(shouldConfigure: Boolean = true)
 
     /**
      * Configure a Web Messaging session.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -83,26 +83,26 @@ interface MessagingClient {
      *
      * @throws IllegalStateException
      */
-    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
+    @Deprecated("Use the connect(shouldConfigure: Boolean) instead", ReplaceWith("connect(shouldConfigure: Boolean)"))
     @Throws(IllegalStateException::class)
     fun connect()
 
     /**
-     * Configure a Web Messaging session.
-     */
-    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
-    @Throws(IllegalStateException::class)
-    fun configureSession()
-
-    /**
-     * Simplify commonly used api to start a new chat. Calling this function will execute a series of action:
-     * 1. Connect to the websocket.
-     * 2. Configure a Web Messaging session.
+     * Open a secure WebSocket connection to the Web Messaging service with the url and
+     * deploymentId configured on this MessagingClient instance.
      *
+     * @param shouldConfigure when true, Configure a Web Messaging session.
      * @throws IllegalStateException
      */
     @Throws(IllegalStateException::class)
-    fun connectToSession()
+    fun connect(shouldConfigure: Boolean = false)
+
+    /**
+     * Configure a Web Messaging session.
+     */
+    @Deprecated("Use the connect(shouldConfigure: Boolean) instead", ReplaceWith("connect(shouldConfigure: Boolean)"))
+    @Throws(IllegalStateException::class)
+    fun configureSession()
 
     /**
      * Send a message to the conversation as plain text.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -72,6 +72,11 @@ internal class MessagingClientImpl(
         webSocket.openSocket(socketListener)
     }
 
+    override fun connect(shouldConfigure: Boolean) {
+        shouldConfigureAfterConnect = shouldConfigure
+        connect()
+    }
+
     @Throws(IllegalStateException::class)
     override fun disconnect() {
         log.i { "disconnect()" }
@@ -97,13 +102,6 @@ internal class MessagingClientImpl(
         )
         val encodedJson = WebMessagingJson.json.encodeToString(request)
         webSocket.sendMessage(encodedJson)
-    }
-
-    @Throws(IllegalStateException::class)
-    override fun connectToSession() {
-        log.i { "connecting to the session." }
-        shouldConfigureAfterConnect = true
-        if (currentState is State.Connected) configureSession() else connect()
     }
 
     @Throws(IllegalStateException::class)

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
@@ -19,3 +19,6 @@ fun Assert<MessagingClient>.isClosing(code: Int, reason: String) =
 
 fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean?) =
     currentState().isEqualTo(MessagingClient.State.Configured(connected, newSession))
+
+fun Assert<MessagingClient>.isError(code: ErrorCode, message: String?) =
+    currentState().isEqualTo(MessagingClient.State.Error(code, message))


### PR DESCRIPTION
- Use parametrized connect(shouldConfigure: Boolean) to prepare for deprecation of connect/configure.
- Deprecate connect and configure. In the next major release they will become internal.
- Add connectWithConfigure command to the testbed application on ios and Android.
- Provide unit test coverage for newly added api.