### PR TITLE
GMDX-528-Reconnect

### DIFF
--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -27,7 +27,7 @@ object MobileMessenger {
         val token =
             TokenStoreImpl(context = context, configuration.tokenStoreKey).token
         val api = WebMessagingApi(configuration)
-        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
+        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration.webSocketUrl)
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
         val attachmentHandler = AttachmentHandlerImpl(
             api,

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,7 +1,7 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit
 
 internal actual class PlatformSocket actual constructor(
     private val log: Log,
-    configuration: Configuration,
-    actual val pingInterval: Long
+    private val url: Url,
+    actual val pingInterval: Int,
+    actual val pongInterval: Int,
 ) {
-    private val url = configuration.webSocketUrl
     private var webSocket: WebSocket? = null
 
     actual fun openSocket(listener: PlatformSocketListener) {
@@ -22,7 +22,7 @@ internal actual class PlatformSocket actual constructor(
             Request.Builder().url(url.toString()).header(name = "Origin", value = url.host).build()
         val webClient = OkHttpClient()
             .newBuilder()
-            .pingInterval(pingInterval, TimeUnit.MILLISECONDS)
+            .pingInterval(pingInterval.toLong(), TimeUnit.SECONDS)
             .addInterceptor(
                 HttpLoggingInterceptor(logger = log.okHttpLogger()).apply {
                     level = HttpLoggingInterceptor.Level.BODY

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,21 +1,27 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
+
+const val DEFAULT_PING_INTERVAL_IN_SECONDS = 20
+const val DEFAULT_PONG_INTERVAL_IN_SECONDS = 10
 
 /**
  * Common WebSocket class
  *
  * @param log the logger
- * @param configuration the transport configuration
- * @param pingInterval the interval in milliseconds for sending ping frames until the connection fails or is closed. Pinging may help keep the connection from timing out. The default value of 0 disables pinging.
+ * @param url the WS endpoint.
+ * @param pingInterval the interval in seconds for sending ping frames until the connection fails or is closed. Pinging may help keep the connection from timing out. The default value of 0 disables pinging.
+ * @param pongInterval the interval in seconds for receiving a pong. Failing to receive a pong in specified amount of time will result in socket failure. When set to 0 pongs will be disabled.
  */
 internal expect class PlatformSocket(
     log: Log,
-    configuration: Configuration,
-    pingInterval: Long = 0
+    url: Url,
+    pingInterval: Int = DEFAULT_PING_INTERVAL_IN_SECONDS,
+    pongInterval: Int = DEFAULT_PONG_INTERVAL_IN_SECONDS,
 ) {
-    val pingInterval: Long
+    val pingInterval: Int
+    val pongInterval: Int
 
     fun openSocket(listener: PlatformSocketListener)
     fun closeSocket(code: Int, reason: String)

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -22,7 +22,7 @@ object MobileMessenger {
     ): MessagingClient {
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
         val api = WebMessagingApi(configuration)
-        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
+        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration.webSocketUrl)
         val token =
             TokenStoreImpl(configuration.tokenStoreKey, log.withTag(LogTag.TOKEN_STORE)).token
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,9 +1,9 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.extensions.string
 import com.genesys.cloud.messenger.transport.util.extensions.toNSData
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
 import kotlinx.cinterop.convert
 import platform.Foundation.NSData
 import platform.Foundation.NSError
@@ -24,20 +24,26 @@ import platform.posix.ETIMEDOUT
 
 internal actual class PlatformSocket actual constructor(
     private val log: Log,
-    configuration: Configuration,
+    private val url: Url,
     /**
-     * Interval to automatically send pings while active. If pong not received within `interval`,
+     * Interval to automatically send pings while active.
+     * Note that [pingInterval] should not be lower than [pongInterval]
+     */
+    actual val pingInterval: Int,
+    /**
+     * Interval to wait for successful pong after ping was sent. If pong not received within `interval`,
      * client assumes connectivity is lost and will notify [PlatformSocketListener.onFailure].
      */
-    actual val pingInterval: Long
+    actual val pongInterval: Int,
 ) {
-    private val url = configuration.webSocketUrl
     private val socketEndpoint = NSURL.URLWithString(url.toString())!!
     private var webSocket: NSURLSessionWebSocketTask? = null
     private var pingTimer: NSTimer? = null
+    private var pongTimer: NSTimer? = null
     private var listener: PlatformSocketListener? = null
     private val active: Boolean
         get() = webSocket != null
+    private var pongReceived = false
 
     actual fun openSocket(listener: PlatformSocketListener) {
         val urlRequest = NSMutableURLRequest(socketEndpoint)
@@ -48,17 +54,21 @@ internal actual class PlatformSocket actual constructor(
                 override fun URLSession(
                     session: NSURLSession,
                     webSocketTask: NSURLSessionWebSocketTask,
-                    didOpenWithProtocol: String?
+                    didOpenWithProtocol: String?,
                 ) {
-                    log.i { "Socket did open." }
-                    listener.onOpen()
-                    keepAlive()
+                    log.i { "Socket did open. Active: $active" }
+                    if (active) {
+                        listener.onOpen()
+                        sendPing()
+                        keepAlive()
+                    }
                 }
+
                 override fun URLSession(
                     session: NSURLSession,
                     webSocketTask: NSURLSessionWebSocketTask,
                     didCloseWithCode: NSURLSessionWebSocketCloseCode,
-                    reason: NSData?
+                    reason: NSData?,
                 ) {
                     val why = reason?.string() ?: "Reason not specified."
                     log.i { "Socket did close. code: $didCloseWithCode, reason: $why" }
@@ -72,76 +82,6 @@ internal actual class PlatformSocket actual constructor(
         listenMessages(listener)
         webSocket?.resume()
         this.listener = listener
-    }
-
-    private fun deactivate() {
-        log.i { "deactivate" }
-        cancelPings()
-        webSocket = null
-    }
-
-    private fun handleErrorAndDeactivate(error: NSError, context: String? = null) {
-        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
-        if (active) {
-            deactivate()
-            listener?.onFailure(Throwable(error.localizedDescription))
-        }
-    }
-
-    private var waitingOnPong = false
-
-    private fun keepAlive() {
-        val isTimerScheduled = pingTimer?.valid ?: false
-        if (!isTimerScheduled && pingInterval > 0) {
-            waitingOnPong = false
-            pingTimer = NSTimer.scheduledTimerWithTimeInterval(
-                interval = pingInterval / 1000.0,
-                repeats = true
-            ) {
-                if (waitingOnPong) {
-                    // Prior pong not received within pingInterval. Assume connectivity is lost.
-                    val nsError = NSError(
-                        domain = NSPOSIXErrorDomain,
-                        code = ETIMEDOUT.convert(),
-                        userInfo = null
-                    )
-                    handleErrorAndDeactivate(nsError, "Pong not received within interval [$pingInterval]")
-                    return@scheduledTimerWithTimeInterval
-                }
-
-                log.i { "Sending ping" }
-                waitingOnPong = true
-                webSocket?.sendPingWithPongReceiveHandler { nsError ->
-                    waitingOnPong = false
-                    if (nsError != null) {
-                        handleErrorAndDeactivate(nsError, "Received pong error")
-                    } else {
-                        log.i { "Received pong" }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun cancelPings() {
-        pingTimer?.invalidate()
-        pingTimer = null
-        waitingOnPong = false
-    }
-
-    private fun listenMessages(listener: PlatformSocketListener) {
-        webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
-            when {
-                nsError != null -> {
-                    handleErrorAndDeactivate(nsError, "Receive handler error")
-                    return@receiveMessageWithCompletionHandler
-                }
-                message != null -> {
-                    message.string?.let { listener.onMessage(it) }
-                }
-            }
-            listenMessages(listener)
-        }
     }
 
     actual fun closeSocket(code: Int, reason: String) {
@@ -159,4 +99,109 @@ internal actual class PlatformSocket actual constructor(
             }
         }
     }
+
+    private fun listenMessages(listener: PlatformSocketListener) {
+        webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
+            when {
+                nsError != null -> {
+                    handleErrorAndDeactivate(nsError, "Receive handler error")
+                    return@receiveMessageWithCompletionHandler
+                }
+                message != null -> {
+                    message.string?.let { listener.onMessage(it) }
+                }
+            }
+            listenMessages(listener)
+        }
+    }
+
+    private fun keepAlive() {
+        if (!pingTimer.isScheduled() && pingInterval > 0) {
+            pingTimer = createActionableTimer(pingInterval, true) {
+                sendPing()
+            }
+        }
+    }
+
+    private fun sendPing() {
+        log.i { "Sending ping." }
+        pongReceived = false
+        schedulePong()
+        webSocket?.sendPingWithPongReceiveHandler { nsError ->
+            if (nsError != null) {
+                handleErrorAndDeactivate(nsError, "Received pong error.")
+            } else {
+                log.i { "Received pong." }
+                pongReceived = true
+            }
+        }
+    }
+
+    private fun schedulePong() {
+        if (pingInterval <= pongInterval) {
+            log.w { "Ping interval should NOT be lower than pong interval!" }
+            return
+        }
+        if (!pongTimer.isScheduled() && pongInterval > 0) {
+            log.i { "Waiting for pong." }
+            createActionableTimer(pongInterval, false) {
+                validatePongReceived()
+            }
+        }
+    }
+
+    private fun validatePongReceived() {
+        if (!pongReceived) {
+            // Prior pong not received within pingInterval. Assume connectivity is lost.
+            val nsError = NSError(
+                domain = NSPOSIXErrorDomain,
+                code = ETIMEDOUT.convert(),
+                userInfo = null
+            )
+            handleErrorAndDeactivate(
+                nsError,
+                "Pong not received within interval [$pingInterval] "
+            )
+        }
+    }
+
+    private fun handleErrorAndDeactivate(error: NSError, context: String? = null) {
+        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
+        if (active) {
+            deactivate()
+            listener?.onFailure(Throwable(error.localizedDescription))
+            listener = null
+        }
+    }
+
+    private fun deactivate() {
+        log.i { "deactivate" }
+        cancelPings()
+        webSocket = null
+    }
+
+    private fun cancelPings() {
+        pingTimer?.invalidate()
+        pongTimer?.invalidate()
+        pingTimer = null
+        pongTimer = null
+        pongReceived = false
+    }
+
+    private fun createActionableTimer(
+        interval: Int,
+        repeats: Boolean,
+        action: () -> Unit,
+    ): NSTimer {
+        return NSTimer.scheduledTimerWithTimeInterval(
+            interval = interval.toDouble(),
+            repeats = repeats,
+        ) {
+            action()
+        }
+    }
+}
+
+internal fun NSTimer?.isScheduled(): Boolean {
+    return this?.valid ?: false
 }


### PR DESCRIPTION
- Add ping-based network monitoring on iOS.
- Pings will be sent every 20 seconds.
- Expected interval for receiving a pong is 10 seconds.
- Failure to receive a pong in specified interval will cause websocket failure.
- Slightly modify PlatformSocket.kt constructor to use kotlin default values.
- Prevent cal to listener.onOpen() on iOS if ws is null (edge case)
- Reorder functions in PlatformSocket.kt (iOS) for better readability.
- Add kdocs.