### PR TITLE
GMDX-528-Reconnect

### DIFF
--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -24,7 +24,8 @@ class MessengerHandler {
         self.config = Configuration(deploymentId: deployment.deploymentId!,
                                     domain: deployment.domain!,
                                     tokenStoreKey: "com.genesys.cloud.messenger",
-                                    logging: true)
+                                    logging: true,
+                                    reconnectionTimeoutInSeconds: 60 * 5)
         self.client = MobileMessenger().createMessagingClient(configuration: self.config)
         
         client.stateChangedListener = { [weak self] stateChange in

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -45,7 +45,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
-            reconnectionHandler = ReconnectionHandlerImpl(),
+            reconnectionHandler = ReconnectionHandlerImpl(configuration.reconnectionTimeoutInSeconds, log.withTag(LogTag.RECONNECTION_HANDLER)),
         )
     }
 

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,13 +1,46 @@
 package com.genesys.cloud.messenger.transport.network
 
-internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val TIMEOUT_INTERVAL_IN_SECONDS: Long = 15
+
+internal class ReconnectionHandlerImpl(
+    reconnectionTimeoutInSeconds: Long,
+    private val log: Log,
+) : ReconnectionHandler {
+    private var attempts = 0
+    private var maxAttempts: Int = (reconnectionTimeoutInSeconds / TIMEOUT_INTERVAL_IN_SECONDS).toInt()
+    private var reconnectJob: Job? = null
+    private val dispatcher = CoroutineScope(Dispatchers.Default)
+
+    override val shouldReconnect: Boolean
+        get() = attempts < maxAttempts
+
     override fun reconnect(reconnectFun: () -> Unit) {
-        TODO("Implement in the upcoming pr.")
+        if (!shouldReconnect) return
+        resetDispatcher()
+        reconnectJob = dispatcher.launch {
+            log.i { "Trying to reconnect. Attempt number: $attempts out of $maxAttempts" }
+            delay(TIMEOUT_INTERVAL_IN_SECONDS.toMilliseconds())
+            attempts++
+            reconnectFun()
+        }
     }
 
-    override fun resetAttempts() {
-        TODO("Implement in the upcoming pr.")
+    override fun clear() {
+        attempts = 0
+        resetDispatcher()
     }
 
-    override fun shouldReconnect(): Boolean = false
+    private fun resetDispatcher() {
+        reconnectJob?.cancel()
+        reconnectJob = null
+    }
 }
+
+private fun Long.toMilliseconds(): Long = this * 1000

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -90,8 +90,8 @@ class MessagingClientImplTest {
         } returns TestWebMessagingApiResponses.testMessageEntityList
     }
 
-    private val mockReconnectionHandler: ReconnectionHandlerImpl = mockk {
-        every { shouldReconnect() } returns false
+    private val mockReconnectionHandler: ReconnectionHandlerImpl = mockk(relaxed = true) {
+        every { shouldReconnect } returns false
     }
 
     private val subject = MessagingClientImpl(
@@ -285,7 +285,7 @@ class MessagingClientImplTest {
         verifySequence {
             connectSequence()
             mockMessageStore.invalidateConversationCache()
-            mockReconnectionHandler.shouldReconnect()
+            mockReconnectionHandler.shouldReconnect
             mockStateChangedListener(fromConnectedToError(expectedErrorState))
             mockAttachmentHandler.clearAll()
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
@@ -8,12 +8,14 @@ import io.ktor.http.Url
  * @param domain the regional base domain address for a Genesys Cloud Web Messaging service. For example, "mypurecloud.com".
  * @param tokenStoreKey the key to access local storage.
  * @param logging indicates if logging should be enabled.
+ * @param reconnectionTimeoutInSeconds period of time during which Transport will try to reconnect to the web socket in case of connectivity lost.
  */
 data class Configuration(
     val deploymentId: String,
     private val domain: String,
     val tokenStoreKey: String,
-    val logging: Boolean = false
+    val logging: Boolean = false,
+    val reconnectionTimeoutInSeconds: Long = 60 * 5,
 ) {
 
     internal val webSocketUrl: Url by lazy {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -11,7 +11,7 @@ internal class StateMachineImpl(
     override var currentState: State = State.Idle
         set(value) {
             if (field != value) {
-                log.i { "State changed from: $field, to: $value" }
+                log.i { "State changed from: ${field::class.simpleName}, to: ${value::class.simpleName}" }
                 val oldState = field
                 field = value
                 stateListener?.invoke(value)
@@ -66,7 +66,9 @@ internal class StateMachineImpl(
 
 internal fun StateMachine.isConnected(): Boolean = currentState is State.Connected
 
-internal fun StateMachine.isConfigured(): Boolean = currentState is State.Configured
+@Throws(IllegalStateException::class)
+internal fun StateMachine.checkIfConfigured() =
+    check(currentState is State.Configured) { "WebMessaging client is not configured." }
 
 internal fun StateMachine.isClosed(): Boolean = currentState is State.Closed
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
@@ -1,10 +1,18 @@
 package com.genesys.cloud.messenger.transport.network
 
 internal interface ReconnectionHandler {
-
+    /**
+     * Attempt to reconnect to the web socket.
+     */
     fun reconnect(reconnectFun: () -> Unit)
 
-    fun resetAttempts()
+    /**
+     * @return true if [ReconnectionHandler] has room for another reconnect attempt, false otherwise.
+     */
+    val shouldReconnect: Boolean
 
-    fun shouldReconnect(): Boolean
+    /**
+     * Cancel and reset any ongoing reconnection attempt.
+     */
+    fun clear()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -10,4 +10,5 @@ internal object LogTag {
     const val TOKEN_STORE = "MMSDKTokenStore"
     const val HTTP_CLIENT = "MMSDKHttpClient"
     const val STATE_MACHINE = "Transport State Machine"
+    const val RECONNECTION_HANDLER = "TransportReconnectionHandler"
 }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -42,7 +42,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
-            reconnectionHandler = ReconnectionHandlerImpl(),
+            reconnectionHandler = ReconnectionHandlerImpl(configuration.reconnectionTimeoutInSeconds, log.withTag(LogTag.RECONNECTION_HANDLER)),
         )
     }
 

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -100,7 +100,8 @@ internal actual class PlatformSocket actual constructor(
             when {
                 nsError != null -> {
                     log.e { "receiveMessageWithCompletionHandler: message: $message" }
-                    handleError(nsError, "Receive handler error"
+                    handleError(
+                        nsError, "Receive handler error"
                     )
                     return@receiveMessageWithCompletionHandler
                 }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,13 +1,28 @@
 package com.genesys.cloud.messenger.transport.network
 
-internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import kotlin.native.concurrent.AtomicInt
+
+internal const val TIMEOUT_INTERVAL = 30.0
+
+internal class ReconnectionHandlerImpl(
+    reconnectionTimeoutInSeconds: Long,
+    private val log: Log,
+) : ReconnectionHandler {
+    private var attempts = AtomicInt(0)
+    private var maxAttempts: Int = (reconnectionTimeoutInSeconds / TIMEOUT_INTERVAL).toInt()
+
+    override val shouldReconnect: Boolean
+        get() = attempts.value < maxAttempts
+
     override fun reconnect(reconnectFun: () -> Unit) {
-        TODO("Implement in the upcoming pr.")
+        if (!shouldReconnect) return
+        log.i { "Trying to reconnect. Attempt number: $attempts out of $maxAttempts" }
+        attempts.value++
+        reconnectFun()
     }
 
-    override fun resetAttempts() {
-        TODO("Implement in the upcoming pr.")
+    override fun clear() {
+        attempts.value = 0
     }
-
-    override fun shouldReconnect(): Boolean = false
 }


### PR DESCRIPTION
- Implement Reconnection logic on both iOS and Android.
- Configuration will have the `reconnectionTimeoutInSeconds` field that represents amount of time that Transport will attempt to reconnect. In case Transport was not able to reconnect it will transition WS Client to Error state and notify UI layer about that. Default value is set to 5 minutes on Android. (Suggested to use the same value on iOS.)
- Because of difference in behaviour iOS and Android timeout/reconnect values and logic are implemented slightly different, but with an idea to respect the same `reconnectionTimeout` in mind while providing best experience on each platform.
    1) Since iOS WS constantly trying to reconnect, there are no need to delay the `reconnect`. The attempt will be counted if WS reconnection request timeout.  Timeout is set to 30 seconds.
    2) If there are no network on Android - WS will fail immediately forcing us to implement delay between reconnection attempts. The delay between attempts is set to 15 seconds. This in order to execute reconnection attempts more frequently. 
- Successful reconnection or disconnection will reset the attempts count.
 - Update iOS PlatformSocket to close properly.
- Add KDoc.