### PR TITLE
Feature/gmdx 528 reconnect

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -61,7 +61,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             configuration = mmsdkConfiguration,
         )
         with(client) {
-            stateListener = { runBlocking { onClientState(it) } }
+            stateChangedListener = { runBlocking { onClientStateChanged(oldState = it.oldState, newState = it.newState) } }
             messageListener = { onEvent(it) }
             clientState = client.currentState
         }
@@ -223,14 +223,14 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         onSocketMessageReceived(consoleMessage)
     }
 
-    private suspend fun onClientState(state: State) {
-        Log.v(TAG, "onClientState(state = $state)")
-        clientState = state
-        val statePayloadMessage = when (state) {
-            is State.Configured -> "connected: ${state.connected}, newSession: ${state.newSession}"
-            is State.Closing -> "code: ${state.code}, reason: ${state.reason}"
-            is State.Closed -> "code: ${state.code}, reason: ${state.reason}"
-            is State.Error -> "code: ${state.code}, message: ${state.message}"
+    private suspend fun onClientStateChanged(oldState: State, newState: State) {
+        Log.v(TAG, "onClientStateChanged(oldState = $oldState, newState = $newState)")
+        clientState = newState
+        val statePayloadMessage = when (newState) {
+            is State.Configured -> "connected: ${newState.connected}, newSession: ${newState.newSession}, wasReconnecting: ${oldState is State.Reconnecting}"
+            is State.Closing -> "code: ${newState.code}, reason: ${newState.reason}"
+            is State.Closed -> "code: ${newState.code}, reason: ${newState.reason}"
+            is State.Error -> "code: ${newState.code}, message: ${newState.message}"
             else -> ""
         }
         onSocketMessageReceived(statePayloadMessage)

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -24,15 +24,16 @@ class ContentViewController: UIViewController {
         
         // set up MessengerHandler callbacks
         
-        messenger.onStateChange = { [weak self] state in
-            var stateMessage = "\(state)"
-            switch state {
+        messenger.onStateChange = { [weak self] stateChange in
+            let newState = stateChange.newState
+            var stateMessage = "\(newState)"
+            switch newState {
             case _ as MessagingClientState.Connecting:
                 stateMessage = "Connecting"
             case _ as MessagingClientState.Connected:
                 stateMessage = "Connected"
             case let configured as MessagingClientState.Configured:
-                stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession?.description ?? "nil"))"
+                stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState.isEqual(MessagingClientState.Reconnecting()))"
             case let closing as MessagingClientState.Closing:
                 stateMessage = "Closing, code=\(closing.code) reason=\(closing.reason)"
             case let closed as MessagingClientState.Closed:
@@ -43,7 +44,7 @@ class ContentViewController: UIViewController {
                 break
             }
             self?.status.text = "Messenger Status: " + stateMessage
-            self?.info.text = "State changed to \(state)"
+            self?.info.text = "State changed from \(stateChange.oldState) to \(newState)"
         }
         
         messenger.onMessageEvent = { [weak self] event in

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -16,7 +16,7 @@ class MessengerHandler {
     private let config: Configuration
     let client: MessagingClient
     
-    public var onStateChange: ((MessagingClientState) -> Void)?
+    public var onStateChange: ((StateChange) -> Void)?
     public var onMessageEvent: ((MessageEvent) -> Void)?
     
     init(deployment: Deployment) {
@@ -27,9 +27,9 @@ class MessengerHandler {
                                     logging: true)
         self.client = MobileMessenger().createMessagingClient(configuration: self.config)
         
-        client.stateListener = { [weak self] state in
-            print("State Change: \(state)")
-            self?.onStateChange?(state)
+        client.stateChangedListener = { [weak self] stateChange in
+            print("State Change: \(stateChange)")
+            self?.onStateChange?(stateChange)
         }
         client.messageListener = { [weak self] event in
             print("Message Event: \(event)")

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -24,7 +24,8 @@ class MessengerHandler {
         self.config = Configuration(deploymentId: deployment.deploymentId!,
                                     domain: deployment.domain!,
                                     tokenStoreKey: "com.genesys.cloud.messenger",
-                                    logging: true)
+                                    logging: true,
+                                    reconnectionTimeoutInSeconds: 60 * 5)
         self.client = MobileMessenger().createMessagingClient(configuration: self.config)
         
         client.stateChangedListener = { [weak self] stateChange in

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -105,9 +105,10 @@ class TestContentController: MessengerHandler {
     override init(deployment: Deployment) {
         super.init(deployment: deployment)
         
-        client.stateListener = { [weak self] state in
-            print("State Event: \(state)")
-            switch state {
+        client.stateChangedListener = { [weak self] stateChange in
+            print("State Event. New state: \(stateChange.newState), old state: \(stateChange.oldState)")
+            let newState = stateChange.newState
+            switch newState {
             case _ as MessagingClientState.Configured:
                 self?.testExpectation?.fulfill()
             case _ as MessagingClientState.Closed:
@@ -117,7 +118,7 @@ class TestContentController: MessengerHandler {
             default:
                 break
             }
-            self?.onStateChange?(state)
+            self?.onStateChange?(stateChange)
         }
         
         client.messageListener = { [weak self] event in

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -28,7 +28,7 @@ object MobileMessenger {
         val token =
             TokenStoreImpl(context = context, configuration.tokenStoreKey).token
         val api = WebMessagingApi(configuration)
-        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
+        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration.webSocketUrl)
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
         val attachmentHandler = AttachmentHandlerImpl(
             api,

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.core
 import android.content.Context
 import com.genesys.cloud.messenger.transport.network.DeploymentConfigUseCase
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
+import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.util.logs.Log
@@ -44,6 +45,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
+            reconnectionHandler = ReconnectionHandlerImpl(),
         )
     }
 

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -45,7 +45,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
-            reconnectionHandler = ReconnectionHandlerImpl(),
+            reconnectionHandler = ReconnectionHandlerImpl(configuration.reconnectionTimeoutInSeconds, log.withTag(LogTag.RECONNECTION_HANDLER)),
         )
     }
 

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.network
 
+import com.genesys.cloud.messenger.transport.core.ErrorMessage
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import io.ktor.http.Url
 import okhttp3.OkHttpClient
@@ -33,7 +34,7 @@ internal actual class PlatformSocket actual constructor(
             object : okhttp3.WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) = listener.onOpen()
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
-                    listener.onFailure(t)
+                    listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t))
 
                 override fun onMessage(webSocket: WebSocket, text: String) =
                     listener.onMessage(text)

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,7 +1,7 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -11,10 +11,9 @@ import java.util.concurrent.TimeUnit
 
 internal actual class PlatformSocket actual constructor(
     private val log: Log,
-    configuration: Configuration,
-    actual val pingInterval: Long
+    private val url: Url,
+    actual val pingInterval: Int,
 ) {
-    private val url = configuration.webSocketUrl
     private var webSocket: WebSocket? = null
 
     actual fun openSocket(listener: PlatformSocketListener) {
@@ -22,7 +21,7 @@ internal actual class PlatformSocket actual constructor(
             Request.Builder().url(url.toString()).header(name = "Origin", value = url.host).build()
         val webClient = OkHttpClient()
             .newBuilder()
-            .pingInterval(pingInterval, TimeUnit.MILLISECONDS)
+            .pingInterval(pingInterval.toLong(), TimeUnit.SECONDS)
             .addInterceptor(
                 HttpLoggingInterceptor(logger = log.okHttpLogger()).apply {
                     level = HttpLoggingInterceptor.Level.BODY

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,13 +1,46 @@
 package com.genesys.cloud.messenger.transport.network
 
-internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val TIMEOUT_INTERVAL_IN_SECONDS: Long = 15
+
+internal class ReconnectionHandlerImpl(
+    reconnectionTimeoutInSeconds: Long,
+    private val log: Log,
+) : ReconnectionHandler {
+    private var attempts = 0
+    private var maxAttempts: Int = (reconnectionTimeoutInSeconds / TIMEOUT_INTERVAL_IN_SECONDS).toInt()
+    private var reconnectJob: Job? = null
+    private val dispatcher = CoroutineScope(Dispatchers.Default)
+
+    override val shouldReconnect: Boolean
+        get() = attempts < maxAttempts
+
     override fun reconnect(reconnectFun: () -> Unit) {
-        TODO("Implement in the upcoming pr.")
+        if (!shouldReconnect) return
+        resetDispatcher()
+        reconnectJob = dispatcher.launch {
+            log.i { "Trying to reconnect. Attempt number: $attempts out of $maxAttempts" }
+            delay(TIMEOUT_INTERVAL_IN_SECONDS.toMilliseconds())
+            attempts++
+            reconnectFun()
+        }
     }
 
-    override fun resetAttempts() {
-        TODO("Implement in the upcoming pr.")
+    override fun clear() {
+        attempts = 0
+        resetDispatcher()
     }
 
-    override fun shouldReconnect(): Boolean = false
+    private fun resetDispatcher() {
+        reconnectJob?.cancel()
+        reconnectJob = null
+    }
 }
+
+private fun Long.toMilliseconds(): Long = this * 1000

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,0 +1,13 @@
+package com.genesys.cloud.messenger.transport.network
+
+internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+    override fun reconnect(reconnectFun: () -> Unit) {
+        TODO("Implement in the upcoming pr.")
+    }
+
+    override fun resetAttempts() {
+        TODO("Implement in the upcoming pr.")
+    }
+
+    override fun shouldReconnect(): Boolean = false
+}

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -90,8 +90,8 @@ class MessagingClientImplTest {
         } returns TestWebMessagingApiResponses.testMessageEntityList
     }
 
-    private val mockReconnectionHandler: ReconnectionHandlerImpl = mockk {
-        every { shouldReconnect() } returns false
+    private val mockReconnectionHandler: ReconnectionHandlerImpl = mockk(relaxed = true) {
+        every { shouldReconnect } returns false
     }
 
     private val subject = MessagingClientImpl(
@@ -285,7 +285,7 @@ class MessagingClientImplTest {
         verifySequence {
             connectSequence()
             mockMessageStore.invalidateConversationCache()
-            mockReconnectionHandler.shouldReconnect()
+            mockReconnectionHandler.shouldReconnect
             mockStateChangedListener(fromConnectedToError(expectedErrorState))
             mockAttachmentHandler.clearAll()
         }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -2,9 +2,10 @@ package com.genesys.cloud.messenger.transport.core
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import com.genesys.cloud.messenger.transport.core.MessagingClient.State
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
-import com.genesys.cloud.messenger.transport.network.SocketCloseCode
+import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
@@ -36,7 +37,7 @@ class MessagingClientImplTest {
     private val configuration = configuration()
     private val log: Log = Log(configuration.logging, "Log")
     private val slot = slot<PlatformSocketListener>()
-    private val mockStateListener: (MessagingClient.State) -> Unit = spyk()
+    private val mockStateChangedListener: (StateChange) -> Unit = spyk()
     private val mockMessageStore: MessageStore = mockk(relaxed = true) {
         every { prepareMessage(any(), any()) } returns OnMessageRequest(
             "00000000-0000-0000-0000-000000000000",
@@ -89,6 +90,10 @@ class MessagingClientImplTest {
         } returns TestWebMessagingApiResponses.testMessageEntityList
     }
 
+    private val mockReconnectionHandler: ReconnectionHandlerImpl = mockk {
+        every { shouldReconnect() } returns false
+    }
+
     private val subject = MessagingClientImpl(
         log = log,
         configuration = configuration,
@@ -98,8 +103,9 @@ class MessagingClientImplTest {
         jwtHandler = mockk(),
         attachmentHandler = mockAttachmentHandler,
         messageStore = mockMessageStore,
+        reconnectionHandler = mockReconnectionHandler,
     ).also {
-        it.stateListener = mockStateListener
+        it.stateChangedListener = mockStateChangedListener
     }
 
     @AfterTest
@@ -117,8 +123,7 @@ class MessagingClientImplTest {
 
     @Test
     fun whenConnectAndThenDisconnect() {
-        val expectedState =
-            MessagingClient.State.Closed(1000, "The user has closed the connection.")
+        val expectedState = State.Closed(1000, "The user has closed the connection.")
         subject.connect()
 
         subject.disconnect()
@@ -136,6 +141,7 @@ class MessagingClientImplTest {
 
         subject.configureSession()
 
+        assertThat(subject).isConfigured(true, true)
         verifySequence {
             connectSequence()
             configureSequence()
@@ -267,27 +273,20 @@ class MessagingClientImplTest {
     }
 
     @Test
-    fun whenConfigureFailsAndSocketListenerRespondWithOnFailure() {
+    fun whenConfigureFailsAndSocketListenerRespondWithOnFailureAndThereAreNoReconnectionAttemptsLeft() {
         val expectedException = Exception("Some error message")
-        val expectedErrorState =
-            MessagingClient.State.Error(ErrorCode.WebsocketError, "Some error message")
-        val expectedState =
-            MessagingClient.State.Closed(SocketCloseCode.GOING_AWAY.value, "Going away.")
-        every { mockPlatformSocket.closeSocket(any(), any()) } answers {
-            slot.captured.onClosed(1001, "Going away.")
-        }
+        val expectedErrorState = State.Error(ErrorCode.WebsocketError, "Failed to reconnect.")
+
         subject.connect()
 
         slot.captured.onFailure(expectedException)
 
-        assertThat(subject).isClosed(expectedState.code, expectedState.reason)
+        assertThat(subject).isError(expectedErrorState.code, expectedErrorState.message)
         verifySequence {
             connectSequence()
-            mockStateListener(expectedErrorState)
-            mockAttachmentHandler.clearAll()
-            mockPlatformSocket.closeSocket(expectedState.code, expectedState.reason)
-            mockStateListener(expectedState)
             mockMessageStore.invalidateConversationCache()
+            mockReconnectionHandler.shouldReconnect()
+            mockStateChangedListener(fromConnectedToError(expectedErrorState))
             mockAttachmentHandler.clearAll()
         }
     }
@@ -295,27 +294,25 @@ class MessagingClientImplTest {
     @Test
     fun whenSocketListenerInvokeOnMessageWithProperlyStructuredMessage() {
         val expectedSessionResponse = SessionResponse(connected = true, newSession = true)
+        val expectedConfigureState = State.Configured(connected = true, newSession = true)
         subject.connect()
 
         slot.captured.onMessage(Response.configureSuccess)
 
         assertThat(subject).isConfigured(
             expectedSessionResponse.connected,
-            expectedSessionResponse.newSession
+            expectedSessionResponse.newSession,
         )
         verifySequence {
             connectSequence()
-            mockStateListener(MessagingClient.State.Configured(connected = true, newSession = true))
+            mockStateChangedListener(fromConnectedToConfigured(expectedConfigureState))
         }
     }
 
     @Test
     fun whenSocketListenerInvokeOnMessageWithSessionExpiredStringMessage() {
         val expectedErrorState =
-            MessagingClient.State.Error(
-                ErrorCode.SessionHasExpired,
-                "session expired error message"
-            )
+            State.Error(ErrorCode.SessionHasExpired, "session expired error message")
         val givenRawMessage =
             """
             {
@@ -331,17 +328,14 @@ class MessagingClientImplTest {
 
         verifySequence {
             connectSequence()
-            mockStateListener(expectedErrorState)
+            mockStateChangedListener(fromConnectedToError(expectedErrorState))
         }
     }
 
     @Test
     fun whenSocketListenerInvokeOnMessageWithSessionNotFoundStringMessage() {
         val expectedErrorState =
-            MessagingClient.State.Error(
-                ErrorCode.SessionNotFound,
-                "session not found error message"
-            )
+            State.Error(ErrorCode.SessionNotFound, "session not found error message")
         val givenRawMessage =
             """
             {
@@ -357,7 +351,7 @@ class MessagingClientImplTest {
 
         verifySequence {
             connectSequence()
-            mockStateListener(expectedErrorState)
+            mockStateChangedListener(fromConnectedToError(expectedErrorState))
         }
     }
 
@@ -405,8 +399,7 @@ class MessagingClientImplTest {
 
     @Test
     fun whenSocketListenerInvokeOnMessageWitSessionExpiredEvent() {
-        val expectedErrorState =
-            MessagingClient.State.Error(ErrorCode.SessionHasExpired, null)
+        val expectedErrorState = State.Error(ErrorCode.SessionHasExpired, null)
         val givenRawMessage =
             """
             {
@@ -422,7 +415,7 @@ class MessagingClientImplTest {
 
         verifySequence {
             connectSequence()
-            mockStateListener(expectedErrorState)
+            mockStateChangedListener(fromConnectedToError(expectedErrorState))
         }
     }
 
@@ -581,6 +574,7 @@ class MessagingClientImplTest {
     fun whenConnectWithConfigureHasClientResponseError() {
         val expectedErrorCode = ErrorCode.ClientResponseError(400)
         val expectedErrorMessage = "Deployment not found"
+        val expectedErrorState = State.Error(expectedErrorCode, expectedErrorMessage)
         every { mockPlatformSocket.sendMessage(Request.configureRequest) } answers {
             slot.captured.onMessage(Response.configureFail)
         }
@@ -591,7 +585,7 @@ class MessagingClientImplTest {
         verifySequence {
             connectSequence()
             mockPlatformSocket.sendMessage(Request.configureRequest)
-            mockStateListener(MessagingClient.State.Error(expectedErrorCode, expectedErrorMessage))
+            mockStateChangedListener(fromConnectedToError(expectedErrorState))
         }
     }
 
@@ -608,26 +602,45 @@ class MessagingClientImplTest {
     )
 
     private fun MockKVerificationScope.connectSequence() {
-        mockStateListener(MessagingClient.State.Connecting)
+        val fromIdleToConnecting =
+            StateChange(oldState = State.Idle, newState = State.Connecting)
+        val fromConnectingToConnected =
+            StateChange(oldState = State.Connecting, newState = State.Connected)
+        mockStateChangedListener(fromIdleToConnecting)
         mockPlatformSocket.openSocket(any())
-        mockStateListener(MessagingClient.State.Connected)
+        mockStateChangedListener(fromConnectingToConnected)
     }
 
     private fun MockKVerificationScope.disconnectSequence(
         expectedCloseCode: Int = any(),
         expectedCloseReason: String = any(),
     ) {
-        mockStateListener(MessagingClient.State.Closing(expectedCloseCode, expectedCloseReason))
+        val fromConnectedToClosing = StateChange(
+            oldState = State.Connected,
+            newState = State.Closing(expectedCloseCode, expectedCloseReason)
+        )
+        val fromClosingToClosed = StateChange(
+            oldState = State.Closing(expectedCloseCode, expectedCloseReason),
+            newState = State.Closed(expectedCloseCode, expectedCloseReason)
+        )
+        mockStateChangedListener(fromConnectedToClosing)
         mockPlatformSocket.closeSocket(expectedCloseCode, expectedCloseReason)
-        mockStateListener(MessagingClient.State.Closed(expectedCloseCode, expectedCloseReason))
+        mockStateChangedListener(fromClosingToClosed)
         mockMessageStore.invalidateConversationCache()
         mockAttachmentHandler.clearAll()
     }
 
     private fun MockKVerificationScope.configureSequence() {
+        val expectedConfigureState = State.Configured(connected = true, newSession = true)
         mockPlatformSocket.sendMessage(Request.configureRequest)
-        mockStateListener(MessagingClient.State.Configured(connected = true, newSession = true))
+        mockStateChangedListener(fromConnectedToConfigured(expectedConfigureState))
     }
+
+    private fun fromConnectedToConfigured(configured: State) =
+        StateChange(oldState = State.Connected, newState = configured)
+
+    private fun fromConnectedToError(errorState: State) =
+        StateChange(oldState = State.Connected, newState = errorState)
 }
 
 private object Request {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
@@ -1,0 +1,244 @@
+package com.genesys.cloud.messenger.transport.core
+
+import assertk.Assert
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.prop
+import com.genesys.cloud.messenger.transport.core.MessagingClient.State
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.Before
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class StateMachineTest {
+    private val subject = StateMachineImpl()
+    private val mockStateListener: (State) -> Unit = spyk()
+    private val mockStateChangedListener: (StateChange) -> Unit = spyk()
+
+    @Before
+    fun setup() {
+        subject.stateListener = mockStateListener
+        subject.stateChangedListener = mockStateChangedListener
+    }
+
+    @Test
+    fun whenSubjectWasInitialized() {
+        assertThat(subject).isIdle()
+    }
+
+    @Test
+    fun whenOnConnectionOpened() {
+        val expectedStateChange = StateChange(State.Idle, State.Connected)
+
+        subject.onConnectionOpened()
+
+        assertThat(subject).isConnected()
+        verify { mockStateListener(State.Connected) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnConnectionOpenedAfterOnReconnect() {
+        val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
+
+        subject.onReconnect()
+        subject.onConnectionOpened()
+
+        assertThat(subject).isReconnecting()
+        verify { mockStateListener(State.Reconnecting) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnConnect() {
+        val expectedStateChange = StateChange(State.Idle, State.Connecting)
+
+        subject.onConnect()
+
+        assertThat(subject).isConnecting()
+        verify { mockStateListener(State.Connecting) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnConnectAfterOnReconnect() {
+        val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
+
+        subject.onReconnect()
+        subject.onConnect()
+
+        assertThat(subject).isReconnecting()
+        verify { mockStateListener(State.Reconnecting) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnConnectAndCurrentStateIsConnected() {
+        subject.onConnectionOpened()
+
+        assertFailsWith<IllegalStateException> { subject.onConnect() }
+    }
+
+    @Test
+    fun whenOnConnectAndCurrentStateIsConfigured() {
+        subject.onSessionConfigured(connected = true, newSession = true)
+
+        assertFailsWith<IllegalStateException> { subject.onConnect() }
+    }
+
+    @Test
+    fun whenOnReconnect() {
+        val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
+
+        subject.onReconnect()
+
+        assertThat(subject).isReconnecting()
+        verify { mockStateListener(State.Reconnecting) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnSessionConfigured() {
+        val expectedStateChange =
+            StateChange(State.Idle, State.Configured(connected = true, newSession = true))
+
+        subject.onSessionConfigured(connected = true, newSession = true)
+
+        assertThat(subject).isConfigured(
+            connected = true,
+            newSession = true,
+        )
+        verify {
+            mockStateListener(State.Configured(connected = true, newSession = true))
+        }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnSessionConfiguredAfterOnReconnect() {
+        val expectedStateChange =
+            StateChange(State.Reconnecting, State.Configured(connected = true, newSession = true))
+
+        subject.onReconnect()
+        subject.onSessionConfigured(connected = true, newSession = true)
+
+        assertThat(subject).isConfigured(
+            connected = true,
+            newSession = true,
+        )
+        verify {
+            mockStateListener(
+                State.Configured(
+                    connected = true,
+                    newSession = true,
+                )
+            )
+        }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnClosingAfterConnectionWasOpened() {
+        val expectedStateChange =
+            StateChange(State.Connected, State.Closing(code = 1, reason = "A reason."))
+
+        subject.onConnectionOpened()
+        subject.onClosing(code = 1, reason = "A reason.")
+
+        assertThat(subject).isClosing(code = 1, reason = "A reason.")
+        verify { mockStateListener(State.Closing(code = 1, reason = "A reason.")) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnClosingAndCurrentStateIsIdle() {
+        assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
+    }
+
+    @Test
+    fun whenOnClosingAndCurrentStateIsClosed() {
+        subject.onClosed(code = 1, reason = "A reason.")
+
+        assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
+    }
+
+    @Test
+    fun whenOnClosingWhenStateIsError() {
+        subject.onError(code = ErrorCode.WebsocketError, message = "A message.")
+
+        assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
+    }
+
+    @Test
+    fun whenOnClosed() {
+        val expectedStateChange =
+            StateChange(State.Idle, State.Closed(code = 1, reason = "A reason."))
+
+        subject.onClosed(code = 1, reason = "A reason.")
+
+        assertThat(subject).isClosed(code = 1, reason = "A reason.")
+        verify { mockStateListener(State.Closed(code = 1, reason = "A reason.")) }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    @Test
+    fun whenOnError() {
+        val expectedStateChange =
+            StateChange(State.Idle, State.Error(ErrorCode.WebsocketError, "A message."))
+
+        subject.onError(code = ErrorCode.WebsocketError, message = "A message.")
+
+        assertThat(subject).isError(
+            code = ErrorCode.WebsocketError,
+            message = "A message."
+        )
+        verify {
+            mockStateListener(
+                State.Error(
+                    code = ErrorCode.WebsocketError,
+                    message = "A message."
+                )
+            )
+        }
+        verify { mockStateChangedListener(expectedStateChange) }
+    }
+
+    private fun Assert<StateMachine>.currentState() = prop(StateMachine::currentState)
+    private fun Assert<StateMachine>.isIdle() = currentState().isEqualTo(State.Idle)
+    private fun Assert<StateMachine>.isClosed(code: Int, reason: String) =
+        currentState().isEqualTo(State.Closed(code, reason))
+
+    private fun Assert<StateMachine>.isConnecting() =
+        currentState().isEqualTo(State.Connecting)
+
+    private fun Assert<StateMachine>.isConnected() =
+        currentState().isEqualTo(State.Connected)
+
+    private fun Assert<StateMachine>.isReconnecting() =
+        currentState().isEqualTo(State.Reconnecting)
+
+    private fun Assert<StateMachine>.isClosing(code: Int, reason: String) =
+        currentState().isEqualTo(State.Closing(code, reason))
+
+    private fun Assert<StateMachine>.isConfigured(
+        connected: Boolean,
+        newSession: Boolean,
+    ) =
+        currentState().isEqualTo(
+            State.Configured(
+                connected,
+                newSession,
+            )
+        )
+
+    private fun Assert<StateMachine>.isError(
+        code: ErrorCode,
+        message: String?,
+    ) =
+        currentState().isEqualTo(
+            State.Error(
+                code, message
+            )
+        )
+}

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
@@ -204,6 +204,30 @@ class StateMachineTest {
         verify { mockStateChangedListener(expectedStateChange) }
     }
 
+    @Test
+    fun verifyFullStateTransitionCycle() {
+        subject.onConnect()
+        assertThat(subject).isConnecting()
+        subject.onConnectionOpened()
+        assertThat(subject).isConnected()
+        subject.onConfiguring()
+        subject.onSessionConfigured(connected = true, newSession = true)
+        assertThat(subject).isConfigured(connected = true, newSession = true)
+        subject.onReconnect()
+        assertThat(subject).isReconnecting()
+        subject.onConnect()
+        assertThat(subject).isReconnecting()
+        subject.onConnectionOpened()
+        assertThat(subject).isReconnecting()
+        subject.onConfiguring()
+        subject.onSessionConfigured(connected = true, newSession = false)
+        assertThat(subject).isConfigured(connected = true, newSession = false)
+        subject.onClosing(100, "sss")
+        assertThat(subject).isClosing(100, "sss")
+        subject.onClosed(100, "sss")
+        assertThat(subject).isClosed(100, "sss")
+    }
+
     private fun Assert<StateMachine>.currentState() = prop(StateMachine::currentState)
     private fun Assert<StateMachine>.isIdle() = currentState().isEqualTo(State.Idle)
     private fun Assert<StateMachine>.isClosed(code: Int, reason: String) =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
@@ -8,12 +8,14 @@ import io.ktor.http.Url
  * @param domain the regional base domain address for a Genesys Cloud Web Messaging service. For example, "mypurecloud.com".
  * @param tokenStoreKey the key to access local storage.
  * @param logging indicates if logging should be enabled.
+ * @param reconnectionTimeoutInSeconds period of time during which Transport will try to reconnect to the web socket in case of connectivity lost.
  */
 data class Configuration(
     val deploymentId: String,
     private val domain: String,
     val tokenStoreKey: String,
-    val logging: Boolean = false
+    val logging: Boolean = false,
+    val reconnectionTimeoutInSeconds: Long = 60 * 5,
 ) {
 
     internal val webSocketUrl: Url by lazy {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -21,6 +21,7 @@ sealed class ErrorCode(val code: Int) {
     object RequestRateTooHigh : ErrorCode(4029)
     object UnexpectedError : ErrorCode(5000)
     object WebsocketError : ErrorCode(1001)
+    object NetworkDisabled : ErrorCode(-1009)
     data class RedirectResponseError(val value: Int) : ErrorCode(value)
     data class ClientResponseError(val value: Int) : ErrorCode(value)
     data class ServerResponseError(val value: Int) : ErrorCode(value)
@@ -51,4 +52,10 @@ sealed class ErrorCode(val code: Int) {
             }
         }
     }
+}
+
+object ErrorMessage {
+    const val FailedToReconnect = "Failed to reconnect."
+    const val InternetConnectionIsOffline =
+        "Network is disabled. Please enable wifi or cellular and try again."
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -26,12 +26,17 @@ interface MessagingClient {
         object Connected : State()
 
         /**
+         * Trying to reconnect after WebSocket failure.
+         */
+        object Reconnecting : State()
+
+        /**
          * Session was successfully configured.
          *
          * @property connected true if session has been configured and connection is established.
          * @property newSession indicates if configured session is new. When configuring an existing session, [newSession] will be false.
          */
-        data class Configured(val connected: Boolean, val newSession: Boolean?) : State()
+        data class Configured(val connected: Boolean, val newSession: Boolean) : State()
 
         /**
          * Remote peer has indicated that no more incoming messages will be transmitted.
@@ -60,7 +65,13 @@ interface MessagingClient {
     /**
      * Listener for MessagingClient state changes.
      */
+    @Deprecated("Use stateChangedListener() instead", ReplaceWith("stateChangedListener"))
     var stateListener: ((State) -> Unit)?
+
+    /**
+     * Listener for MessagingClient state changes.
+     */
+    var stateChangedListener: ((StateChange) -> Unit)?
 
     /**
      * Listener for Message events.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.core
 import com.genesys.cloud.messenger.transport.core.MessagingClient.State
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
+import com.genesys.cloud.messenger.transport.network.ReconnectionHandler
 import com.genesys.cloud.messenger.transport.network.SocketCloseCode
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
@@ -38,18 +39,28 @@ internal class MessagingClientImpl(
     private val token: String,
     private val attachmentHandler: AttachmentHandler,
     private val messageStore: MessageStore,
+    private val reconnectionHandler: ReconnectionHandler,
+    private val stateMachine: StateMachine = StateMachineImpl(log.withTag(LogTag.STATE_MACHINE)),
 ) : MessagingClient {
     private var shouldConfigureAfterConnect = false
 
-    override var currentState: State = State.Idle
-        private set(value) {
-            if (field != value) {
-                field = value
-                stateListener?.invoke(value)
-            }
+    override val currentState: State
+        get() {
+            return stateMachine.currentState
         }
 
+    @Deprecated("Use stateChangedListener() instead", ReplaceWith("stateChangedListener"))
     override var stateListener: ((State) -> Unit)? = null
+        set(value) {
+            stateMachine.stateListener = value
+            field = value
+        }
+
+    override var stateChangedListener: ((StateChange) -> Unit)? = null
+        set(value) {
+            stateMachine.stateChangedListener = value
+            field = value
+        }
 
     override var messageListener: ((MessageEvent) -> Unit)? = null
         set(value) {
@@ -63,12 +74,11 @@ internal class MessagingClientImpl(
     override val conversation: List<Message>
         get() = messageStore.getConversation()
 
-    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
+    @Deprecated("Use the connect(shouldConfigure: Boolean) instead", ReplaceWith("connect(shouldConfigure: Boolean)"))
     @Throws(IllegalStateException::class)
     override fun connect() {
         log.i { "connect()" }
-        check(currentState is State.Closed || currentState is State.Idle || currentState is State.Error) { "MessagingClient state must be Closed, Idle or Error" }
-        currentState = State.Connecting
+        stateMachine.onConnect()
         webSocket.openSocket(socketListener)
     }
 
@@ -80,18 +90,17 @@ internal class MessagingClientImpl(
     @Throws(IllegalStateException::class)
     override fun disconnect() {
         log.i { "disconnect()" }
-        check(currentState !is State.Closed && currentState !is State.Idle && currentState !is State.Error) { "MessagingClient state must not already be Closed, Idle or Error" }
         val code = SocketCloseCode.NORMAL_CLOSURE.value
         val reason = "The user has closed the connection."
-        currentState = State.Closing(code, reason)
+        stateMachine.onClosing(code, reason)
         webSocket.closeSocket(code, reason)
     }
 
-    @Deprecated("Use the connectToSession() instead", ReplaceWith("connectToSession()"))
+    @Deprecated("Use the connect(shouldConfigure: Boolean) instead", ReplaceWith("connect(shouldConfigure: Boolean)"))
     @Throws(IllegalStateException::class)
     override fun configureSession() {
         log.i { "configureSession(token = $token)" }
-        if (currentState !is State.Connected) throw IllegalStateException("WebMessaging client is not connected.")
+        stateMachine.onConfiguring()
         val request = ConfigureSessionRequest(
             token = token,
             deploymentId = configuration.deploymentId,
@@ -106,7 +115,7 @@ internal class MessagingClientImpl(
 
     @Throws(IllegalStateException::class)
     override fun sendMessage(text: String, customAttributes: Map<String, String>) {
-        checkConfigured()
+        check(stateMachine.isConfigured())
         log.i { "sendMessage(text = $text, customAttributes = $customAttributes)" }
         val request = messageStore.prepareMessage(text, customAttributes)
         attachmentHandler.onSending()
@@ -148,14 +157,16 @@ internal class MessagingClientImpl(
         }
     }
 
+    @Throws(IllegalStateException::class)
     private fun send(message: String) {
-        checkConfigured()
+        check(stateMachine.isConfigured())
         log.i { "Will send message" }
         webSocket.sendMessage(message)
     }
 
+    @Throws(Exception::class)
     override suspend fun fetchNextPage() {
-        checkConfigured()
+        check(stateMachine.isConfigured())
         if (messageStore.startOfConversation) {
             log.i { "All history has been fetched." }
             messageStore.updateMessageHistory(emptyList(), conversation.size)
@@ -179,8 +190,9 @@ internal class MessagingClientImpl(
     private fun handleError(code: ErrorCode, message: String? = null) {
         when (code) {
             is ErrorCode.SessionHasExpired,
-            is ErrorCode.SessionNotFound ->
-                currentState = State.Error(code, message)
+            is ErrorCode.SessionNotFound,
+            ->
+                stateMachine.onError(code, message)
             is ErrorCode.MessageTooLong,
             is ErrorCode.RequestRateTooHigh,
             is ErrorCode.CustomAttributeSizeTooLarge,
@@ -192,12 +204,23 @@ internal class MessagingClientImpl(
             is ErrorCode.ServerResponseError,
             is ErrorCode.RedirectResponseError,
             -> {
-                if (currentState is State.Connected) {
+                if (stateMachine.isConnected()) {
                     shouldConfigureAfterConnect = false
-                    currentState = State.Error(code, message)
+                    stateMachine.onError(code, message)
                 }
             }
+            is ErrorCode.WebsocketError -> handleWebSocketError()
             else -> log.w { "Unhandled ErrorCode: $code with optional message: $message" }
+        }
+    }
+
+    private fun handleWebSocketError() {
+        invalidateConversationCache()
+        if (reconnectionHandler.shouldReconnect()) {
+            stateMachine.onReconnect()
+        } else {
+            stateMachine.onError(ErrorCode.WebsocketError, "Failed to reconnect.")
+            attachmentHandler.clearAll()
         }
     }
 
@@ -211,7 +234,7 @@ internal class MessagingClientImpl(
 
         override fun onOpen() {
             log.i { "onOpen()" }
-            currentState = State.Connected
+            stateMachine.onConnectionOpened()
             if (shouldConfigureAfterConnect) {
                 try {
                     configureSession()
@@ -223,9 +246,7 @@ internal class MessagingClientImpl(
 
         override fun onFailure(t: Throwable) {
             log.e(throwable = t) { "onFailure(message: ${t.message})" }
-            currentState = State.Error(ErrorCode.WebsocketError, t.message)
-            attachmentHandler.clearAll()
-            webSocket.closeSocket(SocketCloseCode.GOING_AWAY.value, "Going away.")
+            handleWebSocketError()
         }
 
         override fun onMessage(text: String) {
@@ -244,7 +265,7 @@ internal class MessagingClientImpl(
                     is SessionResponse -> {
                         decoded.body.run {
                             shouldConfigureAfterConnect = false
-                            currentState = State.Configured(connected, newSession)
+                            stateMachine.onSessionConfigured(connected, newSession)
                         }
                     }
                     is JwtResponse ->
@@ -289,17 +310,14 @@ internal class MessagingClientImpl(
 
         override fun onClosing(code: Int, reason: String) {
             log.i { "onClosing(code = $code, reason = $reason)" }
-            currentState = State.Closing(code, reason)
+            stateMachine.onClosing(code, reason)
         }
 
         override fun onClosed(code: Int, reason: String) {
             log.i { "onClosed(code = $code, reason = $reason)" }
-            currentState = State.Closed(code, reason)
+            stateMachine.onClosed(code, reason)
             invalidateConversationCache()
             attachmentHandler.clearAll()
         }
     }
-
-    private fun checkConfigured() =
-        check(currentState is State.Configured) { "WebMessaging client is not configured." }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateChange.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateChange.kt
@@ -1,0 +1,12 @@
+package com.genesys.cloud.messenger.transport.core
+
+/**
+ * Data class that represents state transition.
+ *
+ * @param oldState the previous MessagingClient state.
+ * @param newState the new MessagingClient state.
+ */
+data class StateChange(
+    val oldState: MessagingClient.State,
+    val newState: MessagingClient.State,
+)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachine.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachine.kt
@@ -1,0 +1,19 @@
+package com.genesys.cloud.messenger.transport.core
+
+internal interface StateMachine {
+    var currentState: MessagingClient.State
+    var stateListener: ((MessagingClient.State) -> Unit)?
+    var stateChangedListener: ((StateChange) -> Unit)?
+
+    fun onConnectionOpened()
+    @Throws(IllegalStateException::class)
+    fun onConnect()
+    fun onReconnect()
+    @Throws(IllegalStateException::class)
+    fun onConfiguring()
+    fun onSessionConfigured(connected: Boolean, newSession: Boolean)
+    @Throws(IllegalStateException::class)
+    fun onClosing(code: Int, reason: String)
+    fun onClosed(code: Int, reason: String)
+    fun onError(code: ErrorCode, message: String?)
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -11,7 +11,7 @@ internal class StateMachineImpl(
     override var currentState: State = State.Idle
         set(value) {
             if (field != value) {
-                log.i { "State changed from: $field, to: $value" }
+                log.i { "State changed from: ${field::class.simpleName}, to: ${value::class.simpleName}" }
                 val oldState = field
                 field = value
                 stateListener?.invoke(value)
@@ -66,7 +66,9 @@ internal class StateMachineImpl(
 
 internal fun StateMachine.isConnected(): Boolean = currentState is State.Connected
 
-internal fun StateMachine.isConfigured(): Boolean = currentState is State.Configured
+@Throws(IllegalStateException::class)
+internal fun StateMachine.checkIfConfigured() =
+    check(currentState is State.Configured) { "WebMessaging client is not configured." }
 
 internal fun StateMachine.isClosed(): Boolean = currentState is State.Closed
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -1,0 +1,73 @@
+package com.genesys.cloud.messenger.transport.core
+
+import com.genesys.cloud.messenger.transport.core.MessagingClient.State
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import com.genesys.cloud.messenger.transport.util.logs.LogTag
+
+internal class StateMachineImpl(
+    val log: Log = Log(enableLogs = false, LogTag.STATE_MACHINE),
+) : StateMachine {
+    private val canConnect: Boolean by lazy { currentState is State.Closed || currentState is State.Idle || currentState is State.Error || currentState is State.Reconnecting }
+    private val canConfigure: Boolean by lazy { currentState is State.Connected || currentState is State.Reconnecting }
+    private val isReconnecting: Boolean by lazy { currentState is State.Reconnecting }
+    private val canDisconnect: Boolean by lazy { currentState !is State.Closed && currentState !is State.Idle && currentState !is State.Error }
+
+    override var currentState: State = State.Idle
+        set(value) {
+            if (field != value) {
+                log.i { "State changed from: $field, to: $value" }
+                val oldState = field
+                field = value
+                stateListener?.invoke(value)
+                stateChangedListener?.invoke(StateChange(oldState, value))
+            }
+        }
+
+    override var stateListener: ((State) -> Unit)? = null
+
+    override var stateChangedListener: ((StateChange) -> Unit)? = null
+
+    override fun onConnectionOpened() {
+        currentState = if (isReconnecting) State.Reconnecting else State.Connected
+    }
+
+    @Throws(IllegalStateException::class)
+    override fun onConnect() {
+        check(canConnect) { "MessagingClient state must be Closed, Idle or Error" }
+        currentState = if (isReconnecting) State.Reconnecting else State.Connecting
+    }
+
+    override fun onReconnect() {
+        currentState = State.Reconnecting
+    }
+
+    @Throws(IllegalStateException::class)
+    override fun onConfiguring() {
+        check(canConfigure) { "WebMessaging client is not connected." }
+    }
+
+    override fun onSessionConfigured(
+        connected: Boolean,
+        newSession: Boolean,
+    ) {
+        currentState = State.Configured(connected, newSession)
+    }
+
+    @Throws(IllegalStateException::class)
+    override fun onClosing(code: Int, reason: String) {
+        check(canDisconnect) { "MessagingClient state must not already be Closed, Idle or Error" }
+        currentState = State.Closing(code, reason)
+    }
+
+    override fun onClosed(code: Int, reason: String) {
+        currentState = State.Closed(code, reason)
+    }
+
+    override fun onError(code: ErrorCode, message: String?) {
+        currentState = State.Error(code, message)
+    }
+}
+
+internal fun StateMachine.isConnected(): Boolean = currentState is State.Connected
+
+internal fun StateMachine.isConfigured(): Boolean = currentState is State.Configured

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,21 +1,23 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
+
+const val DEFAULT_PING_INTERVAL_IN_SECONDS = 15
 
 /**
  * Common WebSocket class
  *
  * @param log the logger
- * @param configuration the transport configuration
- * @param pingInterval the interval in milliseconds for sending ping frames until the connection fails or is closed. Pinging may help keep the connection from timing out. The default value of 0 disables pinging.
+ * @param url the WS endpoint.
+ * @param pingInterval the interval in seconds for sending ping frames until the connection fails or is closed. Pinging may help keep the connection from timing out. The default value of 0 disables pinging.
  */
 internal expect class PlatformSocket(
     log: Log,
-    configuration: Configuration,
-    pingInterval: Long = 0
+    url: Url,
+    pingInterval: Int = DEFAULT_PING_INTERVAL_IN_SECONDS,
 ) {
-    val pingInterval: Long
+    val pingInterval: Int
 
     fun openSocket(listener: PlatformSocketListener)
     fun closeSocket(code: Int, reason: String)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocketListener.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocketListener.kt
@@ -1,8 +1,10 @@
 package com.genesys.cloud.messenger.transport.network
 
+import com.genesys.cloud.messenger.transport.core.ErrorCode
+
 internal interface PlatformSocketListener {
     fun onOpen()
-    fun onFailure(t: Throwable)
+    fun onFailure(t: Throwable, errorCode: ErrorCode = ErrorCode.WebsocketError)
     fun onMessage(text: String)
     fun onClosing(code: Int, reason: String)
     fun onClosed(code: Int, reason: String)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
@@ -1,0 +1,10 @@
+package com.genesys.cloud.messenger.transport.network
+
+internal interface ReconnectionHandler {
+
+    fun reconnect(reconnectFun: () -> Unit)
+
+    fun resetAttempts()
+
+    fun shouldReconnect(): Boolean
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandler.kt
@@ -1,10 +1,18 @@
 package com.genesys.cloud.messenger.transport.network
 
 internal interface ReconnectionHandler {
-
+    /**
+     * Attempt to reconnect to the web socket.
+     */
     fun reconnect(reconnectFun: () -> Unit)
 
-    fun resetAttempts()
+    /**
+     * @return true if [ReconnectionHandler] has room for another reconnect attempt, false otherwise.
+     */
+    val shouldReconnect: Boolean
 
-    fun shouldReconnect(): Boolean
+    /**
+     * Cancel and reset any ongoing reconnection attempt.
+     */
+    fun clear()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class SessionResponse(
     val connected: Boolean,
-    val newSession: Boolean? = null,
+    val newSession: Boolean,
 )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -10,4 +10,5 @@ internal object LogTag {
     const val TOKEN_STORE = "MMSDKTokenStore"
     const val HTTP_CLIENT = "MMSDKHttpClient"
     const val STATE_MACHINE = "Transport State Machine"
+    const val RECONNECTION_HANDLER = "TransportReconnectionHandler"
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -9,4 +9,5 @@ internal object LogTag {
     const val MESSAGE_STORE = "MMSDKMessageStore"
     const val TOKEN_STORE = "MMSDKTokenStore"
     const val HTTP_CLIENT = "MMSDKHttpClient"
+    const val STATE_MACHINE = "Transport State Machine"
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
@@ -17,7 +17,7 @@ fun Assert<MessagingClient>.isConnected() =
 fun Assert<MessagingClient>.isClosing(code: Int, reason: String) =
     currentState().isEqualTo(MessagingClient.State.Closing(code, reason))
 
-fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean?) =
+fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean) =
     currentState().isEqualTo(MessagingClient.State.Configured(connected, newSession))
 
 fun Assert<MessagingClient>.isError(code: ErrorCode, message: String?) =

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -2,6 +2,7 @@ package com.genesys.cloud.messenger.transport.core
 
 import com.genesys.cloud.messenger.transport.network.DeploymentConfigUseCase
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
+import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.util.logs.Log
@@ -41,6 +42,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
+            reconnectionHandler = ReconnectionHandlerImpl(),
         )
     }
 

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -42,7 +42,7 @@ object MobileMessenger {
             jwtHandler = JwtHandler(webSocket, token),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
-            reconnectionHandler = ReconnectionHandlerImpl(),
+            reconnectionHandler = ReconnectionHandlerImpl(configuration.reconnectionTimeoutInSeconds, log.withTag(LogTag.RECONNECTION_HANDLER)),
         )
     }
 

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/MobileMessenger.kt
@@ -23,7 +23,7 @@ object MobileMessenger {
     ): MessagingClient {
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
         val api = WebMessagingApi(configuration)
-        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration, 300000)
+        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration.webSocketUrl)
         val token =
             TokenStoreImpl(configuration.tokenStoreKey, log.withTag(LogTag.TOKEN_STORE)).token
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,9 +1,9 @@
 package com.genesys.cloud.messenger.transport.network
 
-import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.util.extensions.string
 import com.genesys.cloud.messenger.transport.util.extensions.toNSData
 import com.genesys.cloud.messenger.transport.util.logs.Log
+import io.ktor.http.Url
 import kotlinx.cinterop.convert
 import platform.Foundation.NSData
 import platform.Foundation.NSError
@@ -24,20 +24,20 @@ import platform.posix.ETIMEDOUT
 
 internal actual class PlatformSocket actual constructor(
     private val log: Log,
-    configuration: Configuration,
+    private val url: Url,
     /**
      * Interval to automatically send pings while active. If pong not received within `interval`,
      * client assumes connectivity is lost and will notify [PlatformSocketListener.onFailure].
      */
-    actual val pingInterval: Long
+    actual val pingInterval: Int,
 ) {
-    private val url = configuration.webSocketUrl
     private val socketEndpoint = NSURL.URLWithString(url.toString())!!
     private var webSocket: NSURLSessionWebSocketTask? = null
     private var pingTimer: NSTimer? = null
     private var listener: PlatformSocketListener? = null
     private val active: Boolean
         get() = webSocket != null
+    private var waitingOnPong = false
 
     actual fun openSocket(listener: PlatformSocketListener) {
         val urlRequest = NSMutableURLRequest(socketEndpoint)
@@ -48,17 +48,19 @@ internal actual class PlatformSocket actual constructor(
                 override fun URLSession(
                     session: NSURLSession,
                     webSocketTask: NSURLSessionWebSocketTask,
-                    didOpenWithProtocol: String?
+                    didOpenWithProtocol: String?,
                 ) {
-                    log.i { "Socket did open." }
-                    listener.onOpen()
-                    keepAlive()
+                    log.i { "Socket did open. Active: $active" }
+                    if (active) {
+                        keepAlive()
+                        listener.onOpen()
+                    }
                 }
                 override fun URLSession(
                     session: NSURLSession,
                     webSocketTask: NSURLSessionWebSocketTask,
                     didCloseWithCode: NSURLSessionWebSocketCloseCode,
-                    reason: NSData?
+                    reason: NSData?,
                 ) {
                     val why = reason?.string() ?: "Reason not specified."
                     log.i { "Socket did close. code: $didCloseWithCode, reason: $why" }
@@ -72,76 +74,6 @@ internal actual class PlatformSocket actual constructor(
         listenMessages(listener)
         webSocket?.resume()
         this.listener = listener
-    }
-
-    private fun deactivate() {
-        log.i { "deactivate" }
-        cancelPings()
-        webSocket = null
-    }
-
-    private fun handleErrorAndDeactivate(error: NSError, context: String? = null) {
-        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
-        if (active) {
-            deactivate()
-            listener?.onFailure(Throwable(error.localizedDescription))
-        }
-    }
-
-    private var waitingOnPong = false
-
-    private fun keepAlive() {
-        val isTimerScheduled = pingTimer?.valid ?: false
-        if (!isTimerScheduled && pingInterval > 0) {
-            waitingOnPong = false
-            pingTimer = NSTimer.scheduledTimerWithTimeInterval(
-                interval = pingInterval / 1000.0,
-                repeats = true
-            ) {
-                if (waitingOnPong) {
-                    // Prior pong not received within pingInterval. Assume connectivity is lost.
-                    val nsError = NSError(
-                        domain = NSPOSIXErrorDomain,
-                        code = ETIMEDOUT.convert(),
-                        userInfo = null
-                    )
-                    handleErrorAndDeactivate(nsError, "Pong not received within interval [$pingInterval]")
-                    return@scheduledTimerWithTimeInterval
-                }
-
-                log.i { "Sending ping" }
-                waitingOnPong = true
-                webSocket?.sendPingWithPongReceiveHandler { nsError ->
-                    waitingOnPong = false
-                    if (nsError != null) {
-                        handleErrorAndDeactivate(nsError, "Received pong error")
-                    } else {
-                        log.i { "Received pong" }
-                    }
-                }
-            }
-        }
-    }
-
-    private fun cancelPings() {
-        pingTimer?.invalidate()
-        pingTimer = null
-        waitingOnPong = false
-    }
-
-    private fun listenMessages(listener: PlatformSocketListener) {
-        webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
-            when {
-                nsError != null -> {
-                    handleErrorAndDeactivate(nsError, "Receive handler error")
-                    return@receiveMessageWithCompletionHandler
-                }
-                message != null -> {
-                    message.string?.let { listener.onMessage(it) }
-                }
-            }
-            listenMessages(listener)
-        }
     }
 
     actual fun closeSocket(code: Int, reason: String) {
@@ -159,4 +91,82 @@ internal actual class PlatformSocket actual constructor(
             }
         }
     }
+
+    private fun listenMessages(listener: PlatformSocketListener) {
+        webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
+            when {
+                nsError != null -> {
+                    handleErrorAndDeactivate(nsError, "Receive handler error")
+                    return@receiveMessageWithCompletionHandler
+                }
+                message != null -> {
+                    message.string?.let { listener.onMessage(it) }
+                }
+            }
+            listenMessages(listener)
+        }
+    }
+
+    private fun keepAlive() {
+        if (!pingTimer.isScheduled() && pingInterval > 0) {
+            waitingOnPong = false
+            pingTimer = NSTimer.scheduledTimerWithTimeInterval(
+                interval = pingInterval.toDouble(),
+                repeats = true
+            ) {
+                if (waitingOnPong) {
+                    // Prior pong not received within pingInterval. Assume connectivity is lost.
+                    val nsError = NSError(
+                        domain = NSPOSIXErrorDomain,
+                        code = ETIMEDOUT.convert(),
+                        userInfo = null
+                    )
+                    handleErrorAndDeactivate(nsError, "Pong not received within interval [$pingInterval]")
+                    return@scheduledTimerWithTimeInterval
+                }
+                sendPing()
+            }
+        }
+    }
+
+    private fun sendPing() {
+        log.i { "Sending ping" }
+        if (waitingOnPong) {
+            log.w { "Trying to send ping while still waiting for pong." }
+            return
+        }
+        waitingOnPong = true
+        webSocket?.sendPingWithPongReceiveHandler { nsError ->
+            waitingOnPong = false
+            if (nsError != null) {
+                handleErrorAndDeactivate(nsError, "Received pong error")
+            } else {
+                log.i { "Received pong" }
+            }
+        }
+    }
+
+    private fun deactivate() {
+        log.i { "deactivate" }
+        cancelPings()
+        webSocket = null
+    }
+
+    private fun handleErrorAndDeactivate(error: NSError, context: String? = null) {
+        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
+        if (active) {
+            deactivate()
+            listener?.onFailure(Throwable(error.localizedDescription))
+        }
+    }
+
+    private fun cancelPings() {
+        pingTimer?.invalidate()
+        pingTimer = null
+        waitingOnPong = false
+    }
+}
+
+internal fun NSTimer?.isScheduled(): Boolean {
+    return this?.valid ?: false
 }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -42,6 +42,7 @@ internal actual class PlatformSocket actual constructor(
     actual fun openSocket(listener: PlatformSocketListener) {
         val urlRequest = NSMutableURLRequest(socketEndpoint)
         urlRequest.setValue(url.host, forHTTPHeaderField = "Origin")
+        urlRequest.setTimeoutInterval(TIMEOUT_INTERVAL)
         val urlSession = NSURLSession.sessionWithConfiguration(
             configuration = NSURLSessionConfiguration.defaultSessionConfiguration(),
             delegate = object : NSObject(), NSURLSessionWebSocketDelegateProtocol {
@@ -50,8 +51,8 @@ internal actual class PlatformSocket actual constructor(
                     webSocketTask: NSURLSessionWebSocketTask,
                     didOpenWithProtocol: String?,
                 ) {
-                    log.i { "Socket did open. Active: $active" }
-                    if (active) {
+                    log.i { "Socket did open. Active: $active." }
+                    if (webSocketTask == webSocket) {
                         keepAlive()
                         listener.onOpen()
                     }
@@ -63,23 +64,25 @@ internal actual class PlatformSocket actual constructor(
                     reason: NSData?,
                 ) {
                     val why = reason?.string() ?: "Reason not specified."
-                    log.i { "Socket did close. code: $didCloseWithCode, reason: $why" }
-                    deactivate()
-                    listener.onClosed(code = didCloseWithCode.toInt(), reason = why)
+                    log.i { "Socket did close (code: $didCloseWithCode, reason: $why). Active: $active." }
+                    if (webSocketTask == webSocket) {
+                        deactivate()
+                        listener.onClosed(code = didCloseWithCode.toInt(), reason = why)
+                    }
                 }
             },
             delegateQueue = NSOperationQueue.currentQueue()
         )
         webSocket = urlSession.webSocketTaskWithRequest(urlRequest)
-        listenMessages(listener)
         webSocket?.resume()
         this.listener = listener
+        listenMessages(listener)
     }
 
     actual fun closeSocket(code: Int, reason: String) {
         log.i { "closeSocket(code = $code, reason = $reason)" }
-        webSocket?.cancelWithCloseCode(code.toLong(), reason.toNSData())
-        deactivate()
+        deactivateAndCancelWebSocket(code, reason)
+        listener?.onClosed(code, reason)
     }
 
     actual fun sendMessage(text: String) {
@@ -87,7 +90,7 @@ internal actual class PlatformSocket actual constructor(
         val message = NSURLSessionWebSocketMessage(text)
         webSocket?.sendMessage(message) { nsError ->
             if (nsError != null) {
-                handleErrorAndDeactivate(nsError, "Send message error")
+                handleError(nsError, "Send message error")
             }
         }
     }
@@ -96,7 +99,10 @@ internal actual class PlatformSocket actual constructor(
         webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
             when {
                 nsError != null -> {
-                    handleErrorAndDeactivate(nsError, "Receive handler error")
+                    log.e { "receiveMessageWithCompletionHandler: message: $message" }
+                    handleError(
+                        nsError, "Receive handler error"
+                    )
                     return@receiveMessageWithCompletionHandler
                 }
                 message != null -> {
@@ -121,7 +127,7 @@ internal actual class PlatformSocket actual constructor(
                         code = ETIMEDOUT.convert(),
                         userInfo = null
                     )
-                    handleErrorAndDeactivate(nsError, "Pong not received within interval [$pingInterval]")
+                    handleError(nsError, "Pong not received within interval [$pingInterval]")
                     return@scheduledTimerWithTimeInterval
                 }
                 sendPing()
@@ -139,24 +145,10 @@ internal actual class PlatformSocket actual constructor(
         webSocket?.sendPingWithPongReceiveHandler { nsError ->
             waitingOnPong = false
             if (nsError != null) {
-                handleErrorAndDeactivate(nsError, "Received pong error")
+                handleError(nsError, "Received pong error")
             } else {
                 log.i { "Received pong" }
             }
-        }
-    }
-
-    private fun deactivate() {
-        log.i { "deactivate" }
-        cancelPings()
-        webSocket = null
-    }
-
-    private fun handleErrorAndDeactivate(error: NSError, context: String? = null) {
-        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
-        if (active) {
-            deactivate()
-            listener?.onFailure(Throwable(error.localizedDescription))
         }
     }
 
@@ -164,6 +156,34 @@ internal actual class PlatformSocket actual constructor(
         pingTimer?.invalidate()
         pingTimer = null
         waitingOnPong = false
+    }
+
+    private fun deactivate() {
+        log.i { "deactivate()" }
+        cancelPings()
+        webSocket = null
+    }
+
+    /**
+     * Deactivates the webSocket connection per `deactivate()`.
+     * Attempt to send a final close frame with the given code and reason without `listener.onClosed()` being called.
+     */
+    private fun deactivateAndCancelWebSocket(code: Int, reason: String?) {
+        log.i { "deactivateWithCloseCode(code = $code, reason = $reason)" }
+        val webSocketRef = webSocket
+        deactivate()
+        webSocketRef?.cancelWithCloseCode(code.toLong(), reason?.toNSData())
+    }
+
+    private fun handleError(error: NSError, context: String? = null) {
+        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
+        if (active) {
+            deactivateAndCancelWebSocket(
+                SocketCloseCode.GOING_AWAY.value,
+                "Closing due to error code ${error.code}"
+            )
+            listener?.onFailure(Throwable(error.localizedDescription))
+        }
     }
 }
 

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,0 +1,13 @@
+package com.genesys.cloud.messenger.transport.network
+
+internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+    override fun reconnect(reconnectFun: () -> Unit) {
+        TODO("Implement in the upcoming pr.")
+    }
+
+    override fun resetAttempts() {
+        TODO("Implement in the upcoming pr.")
+    }
+
+    override fun shouldReconnect(): Boolean = false
+}

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/ReconnectionHandlerImpl.kt
@@ -1,13 +1,28 @@
 package com.genesys.cloud.messenger.transport.network
 
-internal class ReconnectionHandlerImpl() : ReconnectionHandler {
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import kotlin.native.concurrent.AtomicInt
+
+internal const val TIMEOUT_INTERVAL = 30.0
+
+internal class ReconnectionHandlerImpl(
+    reconnectionTimeoutInSeconds: Long,
+    private val log: Log,
+) : ReconnectionHandler {
+    private var attempts = AtomicInt(0)
+    private var maxAttempts: Int = (reconnectionTimeoutInSeconds / TIMEOUT_INTERVAL).toInt()
+
+    override val shouldReconnect: Boolean
+        get() = attempts.value < maxAttempts
+
     override fun reconnect(reconnectFun: () -> Unit) {
-        TODO("Implement in the upcoming pr.")
+        if (!shouldReconnect) return
+        log.i { "Trying to reconnect. Attempt number: $attempts out of $maxAttempts" }
+        attempts.value++
+        reconnectFun()
     }
 
-    override fun resetAttempts() {
-        TODO("Implement in the upcoming pr.")
+    override fun clear() {
+        attempts.value = 0
     }
-
-    override fun shouldReconnect(): Boolean = false
 }


### PR DESCRIPTION
Reconnect feature branch into develop. 
Note, all parts of this pr were previously reviewed as a separate pr`s.

### Common:
- Add `reconnectionTimeoutInSeconds` to Configuration.kt.
- When Transport fails to reconnect during period of time set in `reconnectionTimeoutInSeconds` it will transition itself to State.Error.
- Add `Reconnecting` state. MessagingClient will be transitioned to this state when socket reports a failure.
- Add StateChange data class that represents state transition information.
- Decouple MessagingClient state management from MessagingClient.kt itself using StateMachine.kt.
- Successful reconnection or disconnection will reset the attempts count.
- Slightly modify PlatformSocket.kt constructor to use kotlin default values.
- Deprecate stateListener. Users should use `onStateChanged: ((StateChange) -> Unit)?` instead.

### iOS
- Add ping-based network monitoring on iOS.
- Pings will be sent every 15 seconds. Failure to receive a pong will cause websocket failure.
- Implement iOS specific Reconnection logic.
- Update iOS PlatformSocket to close properly.
 
### Android
- Implement Android specific Reconnection logic.
- Default value for `reconnectionTimeoutInSeconds` is set to 5 minutes.

### General
- Add documentation for public api.
- Update Test applications to reflect the changes.
- Add unit tests to capture newly added functionality.
