### PR TITLE
remove beta note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mobile Messenger Transport SDK
+# Genesys Cloud Messenger Transport SDK
 
 Genesys Cloud Messenger Transport SDK provides a library of methods for connecting to Genesys Cloud Web Messaging APIs and WebSockets from Android and iOS native applications. 
 
@@ -17,7 +17,7 @@ implementation 'cloud.genesys:messenger-transport-mobile-sdk:<version>'
 
 ### Install Messenger Transport SDK on iOS
 
-Messenger Transport SDK supports versions of iOS 11.0 and up.
+Messenger Transport SDK supports versions of iOS 13.0 and up.
 
 #### Installation with CocoaPods
 
@@ -27,7 +27,6 @@ In your `Podfile`, configure your target to include the `GenesysCloudMessengerTr
 
 ```
 target 'TargetNameInYourXcodeProject' do
-  use_frameworks!
   pod 'GenesysCloudMessengerTransport'
 end
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,5 @@
 # Mobile Messenger Transport SDK
 
----
-
-> ⚠️ **NOTE:** The Messenger product is in beta currently. Functionality and methods are subject to change.
-
----
-
 Genesys Cloud Messenger Transport SDK provides a library of methods for connecting to Genesys Cloud Web Messaging APIs and WebSockets from Android and iOS native applications. 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Messenger Transport SDK supports versions of iOS 13.0 and up.
 
 #### Installation with CocoaPods
 
-To install the Messenger Transport SDK in your app with CocoaPods, follow this guidance.
+To install Messenger Transport SDK in your app with CocoaPods, follow this guidance.
 
-In your `Podfile`, configure your target to include the `GenesysCloudMessengerTransport` pod  dependency and specify the use of frameworks instead of static libraries.
+In your `Podfile`, configure your target to include the `GenesysCloudMessengerTransport` pod dependency.
 
 ```
 target 'TargetNameInYourXcodeProject' do
@@ -37,9 +37,13 @@ In a Terminal window, navigate to the project directory with your Podfile and Xc
 $ pod install
 ```
 
-CocoaPods will download and install the MessengerTransport pod and any necessary dependencies.
+CocoaPods will download and install the GenesysCloudMessengerTransport pod and any necessary dependencies.
 
 The `MessengerTransport` module may now be imported and used in your project.
+
+```
+import MessengerTransport
+```
 
 ## Documentation
 


### PR DESCRIPTION
This PR should probably merge before PR #79 is merged.
Realized the `ispreview` header was removed from the Developer Center docs, so we should remove from the project README too. Also, some of the documentation in the iOS installation needed some adjustment since we switched to Darwin native websocket.