### PR TITLE
MTSDK-23 Typing Indicator.

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -36,7 +36,11 @@ data class Messenger(
 data class Apps(val conversations: Conversations)
 
 @Serializable
-data class Conversations(val messagingEndpoint: String)
+data class Conversations(
+    val messagingEndpoint: String,
+    val showAgentTypingIndicator: Boolean = false,
+    val showUserTypingIndicator: Boolean = false,
+)
 
 @Serializable
 data class Styles(val primaryColor: String)


### PR DESCRIPTION
- Parse `showAgentTypingIndicator` with default value of `false`.
- Parse `showUserTypingIndicator` with default value of `false`.