### PR TITLE
MTSDK-24 Support Event type.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -45,7 +45,7 @@ internal class MessageExtensionTest {
         val givenStructuredMessage = StructuredMessage(
             id = "id",
             channel = StructuredMessage.Channel(time = isoTestTimestamp),
-            type = "Text",
+            type = StructuredMessage.Type.Text,
             text = "test text",
             content = listOf(
                 StructuredMessage.Content(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -236,7 +236,7 @@ internal class MessagingClientImpl(
         }
     }
 
-    private fun handleStructureMessage(structuredMessage: StructuredMessage) {
+    private fun handleStructuredMessage(structuredMessage: StructuredMessage) {
         when (structuredMessage.type) {
             StructuredMessage.Type.Text -> {
                 with(structuredMessage.toMessage()) {
@@ -301,7 +301,7 @@ internal class MessagingClientImpl(
                         attachmentHandler.upload(decoded.body)
                     is UploadSuccessEvent ->
                         attachmentHandler.onUploadSuccess(decoded.body)
-                    is StructuredMessage -> handleStructureMessage(decoded.body)
+                    is StructuredMessage -> handleStructuredMessage(decoded.body)
                     is AttachmentDeletedResponse ->
                         attachmentHandler.onDetached(decoded.body.attachmentId)
                     is GenerateUrlError -> {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -236,6 +236,20 @@ internal class MessagingClientImpl(
         }
     }
 
+    private fun handleStructureMessage(structuredMessage: StructuredMessage) {
+        when (structuredMessage.type) {
+            StructuredMessage.Type.Text -> {
+                with(structuredMessage.toMessage()) {
+                    messageStore.update(this)
+                    attachmentHandler.onSent(this.attachments)
+                }
+            }
+            StructuredMessage.Type.Event -> {
+                TODO("Handle events here.")
+            }
+        }
+    }
+
     private val socketListener = SocketListener(
         log = log.withTag(LogTag.WEBSOCKET)
     )
@@ -287,12 +301,7 @@ internal class MessagingClientImpl(
                         attachmentHandler.upload(decoded.body)
                     is UploadSuccessEvent ->
                         attachmentHandler.onUploadSuccess(decoded.body)
-                    is StructuredMessage -> {
-                        with(decoded.body.toMessage()) {
-                            messageStore.update(this)
-                            attachmentHandler.onSent(this.attachments)
-                        }
-                    }
+                    is StructuredMessage -> handleStructureMessage(decoded.body)
                     is AttachmentDeletedResponse ->
                         attachmentHandler.onDetached(decoded.body.attachmentId)
                     is GenerateUrlError -> {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -14,7 +15,7 @@ internal data class MessageEntityList(
 @Serializable
 internal data class StructuredMessage(
     val id: String,
-    val type: String,
+    val type: Type,
     val text: String? = null,
     val direction: String,
     val channel: Channel? = null,
@@ -54,4 +55,12 @@ internal data class StructuredMessage(
         val contentType: String,
         val attachment: Attachment,
     )
+
+    @Serializable
+    enum class Type {
+        @SerialName("Text")
+        Text,
+        @SerialName("Event")
+        Event,
+    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -18,7 +18,7 @@ internal fun StructuredMessage.toMessage(): Message {
         id = this.metadata["customMessageId"] ?: this.id,
         direction = if (this.direction == "Inbound") Direction.Inbound else Direction.Outbound,
         state = Message.State.Sent,
-        type = this.type,
+        type = this.type.name,
         text = this.text,
         timeStamp = this.channel?.time.fromIsoToEpochMilliseconds(),
         attachments = this.content.toAttachments()

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -214,7 +214,7 @@ class SerializationTest {
             direction = "Outbound",
             id = "00000000-0000-0000-0000-000000000000",
             channel = channel,
-            type = "Text",
+            type = StructuredMessage.Type.Text,
             content = listOf()
         )
         val expectedUnsolicitedMessage = WebMessagingMessage(

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
@@ -90,7 +90,7 @@ object TestWebMessagingApiResponses {
         return StructuredMessage(
             id = id,
             channel = StructuredMessage.Channel(time = time),
-            type = "Text",
+            type = StructuredMessage.Type.Text,
             text = text,
             content = emptyList(),
             direction = if (isInbound) "Inbound" else "Outbound",


### PR DESCRIPTION
- MessagingClientImpl is capable to differ between Structured Messages with Type.Text and Type.Event.
- Add enum `Type` to StructuredMessage.kt
- Update unit tests.