### PR TITLE
MTSDK-25 Handle Typing Indicator Event

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -10,8 +10,8 @@ import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
-import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.Typing
+import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel.Metadata
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
@@ -706,7 +706,7 @@ private object Response {
     const val configureFail =
         """{"type":"response","class":"string","code":400,"body":"Deployment not found"}"""
     const val defaultStructuredEvents = """{"eventType": "Typing","typing": {"type": "Off","duration": 1000}},{"eventType": "Typing","typing": {"type": "On","duration": 5000}}"""
-    fun structuredMessageWithEvents(events: String = defaultStructuredEvents) : String {
+    fun structuredMessageWithEvents(events: String = defaultStructuredEvents): String {
         return """{"type": "message","class": "StructuredMessage","code": 200,"body": {"direction": "Inbound","id": "0000000-0000-0000-0000-0000000000","channel": {"time": "2022-03-09T13:35:31.104Z","messageId": "0000000-0000-0000-0000-0000000000"},"type": "Event","metadata": {"correlationId": "0000000-0000-0000-0000-0000000000"},"events": [$events]}}"""
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -3,12 +3,15 @@ package com.genesys.cloud.messenger.transport.core
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.genesys.cloud.messenger.transport.core.MessagingClient.State
+import com.genesys.cloud.messenger.transport.core.events.EventHandler
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.Typing
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel.Metadata
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
@@ -94,6 +97,8 @@ class MessagingClientImplTest {
         every { shouldReconnect } returns false
     }
 
+    private val mockEventHandler: EventHandler = mockk(relaxed = true)
+
     private val subject = MessagingClientImpl(
         log = log,
         configuration = configuration,
@@ -104,6 +109,7 @@ class MessagingClientImplTest {
         attachmentHandler = mockAttachmentHandler,
         messageStore = mockMessageStore,
         reconnectionHandler = mockReconnectionHandler,
+        eventHandler = mockEventHandler,
     ).also {
         it.stateChangedListener = mockStateChangedListener
     }
@@ -606,6 +612,35 @@ class MessagingClientImplTest {
         }
     }
 
+    @Test
+    fun whenStructuredMessageWithMultipleEventsReceived() {
+        val firstExpectedEvent = TypingEvent(Typing(type = "Off", duration = 1000))
+        val secondsExpectedEvent = TypingEvent(Typing(type = "On", duration = 5000))
+
+        subject.connect()
+
+        slot.captured.onMessage(Response.structuredMessageWithEvents())
+
+        verifySequence {
+            mockEventHandler.onEvent(eq(firstExpectedEvent))
+            mockEventHandler.onEvent(eq(secondsExpectedEvent))
+        }
+        verify(exactly = 0) { mockMessageStore.update(any()) }
+        verify(exactly = 0) { mockAttachmentHandler.onSent(any()) }
+    }
+
+    @Test
+    fun whenStructuredMessageWithUnknownEventTypeReceived() {
+        val givenUnknownEvent = """{"eventType": "Fake","bloop": {"bip": "bop"}}"""
+        subject.connect()
+
+        slot.captured.onMessage(Response.structuredMessageWithEvents(givenUnknownEvent))
+
+        verify(exactly = 0) { mockEventHandler.onEvent(any()) }
+        verify(exactly = 0) { mockMessageStore.update(any()) }
+        verify(exactly = 0) { mockAttachmentHandler.onSent(any()) }
+    }
+
     private fun connectAndConfigure() {
         subject.connect()
         subject.configureSession()
@@ -670,4 +705,8 @@ private object Response {
         """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":true,"newSession":true}}"""
     const val configureFail =
         """{"type":"response","class":"string","code":400,"body":"Deployment not found"}"""
+    const val defaultStructuredEvents = """{"eventType": "Typing","typing": {"type": "Off","duration": 1000}},{"eventType": "Typing","typing": {"type": "On","duration": 5000}}"""
+    fun structuredMessageWithEvents(events: String = defaultStructuredEvents) : String {
+        return """{"type": "message","class": "StructuredMessage","code": 200,"body": {"direction": "Inbound","id": "0000000-0000-0000-0000-0000000000","channel": {"time": "2022-03-09T13:35:31.104Z","messageId": "0000000-0000-0000-0000-0000000000"},"type": "Event","metadata": {"correlationId": "0000000-0000-0000-0000-0000000000"},"events": [$events]}}"""
+    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -1,6 +1,8 @@
 package com.genesys.cloud.messenger.transport.core
 
 import com.genesys.cloud.messenger.transport.core.MessagingClient.State
+import com.genesys.cloud.messenger.transport.core.events.EventHandler
+import com.genesys.cloud.messenger.transport.core.events.EventHandlerImpl
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.network.ReconnectionHandler
@@ -41,6 +43,7 @@ internal class MessagingClientImpl(
     private val messageStore: MessageStore,
     private val reconnectionHandler: ReconnectionHandler,
     private val stateMachine: StateMachine = StateMachineImpl(log.withTag(LogTag.STATE_MACHINE)),
+    private val eventHandler: EventHandler = EventHandlerImpl(log.withTag(LogTag.EVENT_HANDLER)),
 ) : MessagingClient {
     private var shouldConfigureAfterConnect = false
 
@@ -245,7 +248,9 @@ internal class MessagingClientImpl(
                 }
             }
             StructuredMessage.Type.Event -> {
-                TODO("Handle events here.")
+                structuredMessage.events.forEach {
+                    eventHandler.onEvent(it)
+                }
             }
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -1,0 +1,13 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+/**
+ * Base class for Transport events.
+ */
+sealed class Event {
+    /**
+     *  This event indicates that the agent has begun typing a message.
+     *
+     *  @param durationInMilliseconds amount of time to display visual typing indicator in UI.
+     */
+    data class Typing(val durationInMilliseconds: Int) : Event()
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandler.kt
@@ -1,0 +1,7 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
+
+internal interface EventHandler {
+    fun onEvent(event: StructuredMessageEvent)
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -1,0 +1,23 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import com.genesys.cloud.messenger.transport.util.logs.LogTag
+
+internal class EventHandlerImpl(
+    val log: Log = Log(enableLogs = false, LogTag.EVENT_HANDLER),
+) : EventHandler {
+
+    override fun onEvent(event: StructuredMessageEvent) {
+        log.i { "on event: ${event.toTransportEvent()}" }
+    }
+}
+
+private fun StructuredMessageEvent.toTransportEvent(): Event {
+    return when (this) {
+        is TypingEvent -> {
+            Event.Typing(durationInMilliseconds = typing.duration)
+        }
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
@@ -20,7 +20,8 @@ internal data class StructuredMessage(
     val direction: String,
     val channel: Channel? = null,
     val content: List<Content> = emptyList(),
-    val metadata: Map<String, String> = emptyMap()
+    val metadata: Map<String, String> = emptyMap(),
+    val events: List<StructuredMessageEvent> = emptyList(),
 ) {
     @Serializable
     data class Participant(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -1,0 +1,41 @@
+package com.genesys.cloud.messenger.transport.shyrka.receive
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent.Type
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+@Serializable(with = StructuredMessageEventSerializer::class)
+internal sealed class StructuredMessageEvent {
+    @Serializable
+    enum class Type {
+        @SerialName("Typing")
+        Typing,
+    }
+}
+
+@Serializable
+internal data class TypingEvent(
+    val typing: Typing,
+) : StructuredMessageEvent()
+
+@Serializable
+internal data class Typing(
+    val type: String,
+    val duration: Int,
+)
+
+internal object StructuredMessageEventSerializer :
+    JsonContentPolymorphicSerializer<StructuredMessageEvent>(StructuredMessageEvent::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out StructuredMessageEvent> {
+        return when (element.jsonObject["eventType"]?.jsonPrimitive?.content) {
+            Type.Typing.name -> TypingEvent.serializer()
+            else -> throw SerializationException("Unknown EventType: key 'eventType' not found or does not matches any known event type.")
+        }
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -11,4 +11,5 @@ internal object LogTag {
     const val HTTP_CLIENT = "MMSDKHttpClient"
     const val STATE_MACHINE = "Transport State Machine"
     const val RECONNECTION_HANDLER = "TransportReconnectionHandler"
+    const val EVENT_HANDLER = "TransportEventHandler"
 }


### PR DESCRIPTION
- Add EventHandler.kt to be responsible for events aggregation/maping/dispatch.
- Deserialize `events` node from StructuredMessage.kt response.
- Map StructuredMessageEvent.kt to Event.kt.
- Event node containing unknown event type will throw SerializationException (handled inside MessagingClientImpl.kt)
- Add unit tests.
- Add KDoc to publicly exposed Events.