### PR TITLE
MTSDK-26 Send Typing Indicator.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -4,10 +4,13 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses.isoTestTimestamp
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
+import com.genesys.cloud.messenger.transport.shyrka.receive.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.fromIsoToEpochMilliseconds
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
@@ -147,5 +150,27 @@ internal class MessageExtensionTest {
         val result = null.fromIsoToEpochMilliseconds()
 
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun whenOutboundStructuredMessageCheckedForIsOutbound() {
+        val givenStructuredMessage = StructuredMessage(
+            id = "some_id",
+            type = StructuredMessage.Type.Text,
+            direction = "Outbound"
+        )
+
+        assertThat(givenStructuredMessage.isOutbound()).isTrue()
+    }
+
+    @Test
+    fun whenInboundStructuredMessageCheckedForIsOutbound() {
+        val givenStructuredMessage = StructuredMessage(
+            id = "some_id",
+            type = StructuredMessage.Type.Text,
+            direction = "Inbound"
+        )
+
+        assertThat(givenStructuredMessage.isOutbound()).isFalse()
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -668,11 +668,11 @@ class MessagingClientImplTest {
     }
 
     @Test
-    fun whenUserIsTyping() {
+    fun whenIndicateTyping() {
         val expectedMessage = Request.userTypingRequest
         connectAndConfigure()
 
-        subject.userIsTyping()
+        subject.indicateTyping()
 
         verifySequence {
             connectSequence()
@@ -682,45 +682,45 @@ class MessagingClientImplTest {
     }
 
     @Test
-    fun whenNotConnectedAndUserIsTypingInvoked() {
+    fun whenNotConnectedAndIndicateTypingInvoked() {
         assertFailsWith<IllegalStateException> {
-            subject.userIsTyping()
+            subject.indicateTyping()
         }
     }
 
     @Test
-    fun whenUserIsTypingInvokedTwiceWithoutCoolDown() {
+    fun whenIndicateTypingTwiceWithoutCoolDown() {
         val expectedMessage = Request.userTypingRequest
         connectAndConfigure()
 
-        subject.userIsTyping()
-        subject.userIsTyping()
+        subject.indicateTyping()
+        subject.indicateTyping()
 
         verify(exactly = 1) { mockPlatformSocket.sendMessage(expectedMessage) }
     }
 
     @Test
-    fun whenUserIsTypingInvokedTwiceWithCoolDown() {
+    fun whenIndicateTypingTwiceWithCoolDown() {
         val expectedMessage = Request.userTypingRequest
 
         connectAndConfigure()
 
-        subject.userIsTyping()
+        subject.indicateTyping()
         // Fast forward epochMillis by TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND.
         every { mockTimestampFunction.invoke() } answers { Platform().epochMillis() + TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND }
-        subject.userIsTyping()
+        subject.indicateTyping()
 
         verify(exactly = 2) { mockPlatformSocket.sendMessage(expectedMessage) }
     }
 
     @Test
-    fun whenUserIsTypingInvokedTwiceWithoutCoolDownButAfterMessageWasSent() {
+    fun whenIndicateTypingTwiceWithoutCoolDownButAfterMessageWasSent() {
         val expectedMessage = Request.userTypingRequest
         connectAndConfigure()
 
-        subject.userIsTyping()
+        subject.indicateTyping()
         slot.captured.onMessage(Response.onMessageResponse)
-        subject.userIsTyping()
+        subject.indicateTyping()
 
         verify(exactly = 2) { mockPlatformSocket.sendMessage(expectedMessage) }
     }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
@@ -51,5 +51,4 @@ class EventHandlerTest {
 
         verify { mockEventListener.invoke(eq(expectedEvent)) }
     }
-
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
@@ -17,9 +17,9 @@ class EventHandlerTest {
     fun whenTypingEventOccurs() {
         val givenStructuredMessageEvent = TypingEvent(
             eventType = StructuredMessageEvent.Type.Typing,
-            typing = Typing(type = "On", duration = 5000)
+            typing = Typing(type = "On", duration = 3000)
         )
-        val expectedEvent = Event.Typing(5000)
+        val expectedEvent = Event.Typing(3000)
 
         subject.onEvent(givenStructuredMessageEvent)
 
@@ -38,4 +38,18 @@ class EventHandlerTest {
 
         verify(exactly = 0) { mockEventListener.invoke(any()) }
     }
+
+    @Test
+    fun whenTypingEventWithNullDuration() {
+        val givenStructuredMessageEvent = TypingEvent(
+            eventType = StructuredMessageEvent.Type.Typing,
+            typing = Typing(type = "On", duration = null)
+        )
+        val expectedEvent = Event.Typing(5000)
+
+        subject.onEvent(givenStructuredMessageEvent)
+
+        verify { mockEventListener.invoke(eq(expectedEvent)) }
+    }
+
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.core.events
 
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent.Typing
 import io.mockk.mockk
@@ -14,7 +15,10 @@ class EventHandlerTest {
 
     @Test
     fun whenTypingEventOccurs() {
-        val givenStructuredMessageEvent = TypingEvent(Typing(type = "On", duration = 5000))
+        val givenStructuredMessageEvent = TypingEvent(
+            eventType = StructuredMessageEvent.Type.Typing,
+            typing = Typing(type = "On", duration = 5000)
+        )
         val expectedEvent = Event.Typing(5000)
 
         subject.onEvent(givenStructuredMessageEvent)
@@ -24,7 +28,10 @@ class EventHandlerTest {
 
     @Test
     fun whenNoEventListenerSetAndOnEventInvoked() {
-        val givenStructuredMessageEvent = TypingEvent(Typing(type = "On", duration = 5000))
+        val givenStructuredMessageEvent = TypingEvent(
+            eventType = StructuredMessageEvent.Type.Typing,
+            typing = Typing(type = "On", duration = 5000)
+        )
         subject.eventListener = null
 
         subject.onEvent(givenStructuredMessageEvent)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProviderTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProviderTest.kt
@@ -1,0 +1,62 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.genesys.cloud.messenger.transport.util.Platform
+import com.genesys.cloud.messenger.transport.util.Request
+import io.mockk.every
+import io.mockk.spyk
+import org.junit.Test
+
+class UserTypingProviderTest {
+    private val mockTimestampFunction: () -> Long = spyk<() -> Long>().also {
+        every { it.invoke() } answers { Platform().epochMillis() }
+    }
+
+    private val subject = UserTypingProvider(mockTimestampFunction)
+
+    @Test
+    fun whenEncode() {
+        val expected = Request.userTypingRequest
+
+        val result = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun whenEncodeWithCoolDown() {
+        val expected = Request.userTypingRequest
+
+        val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+        every { mockTimestampFunction.invoke() } answers { Platform().epochMillis() + TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND }
+        val secondResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+
+        assertThat(firstResult).isEqualTo(expected)
+        assertThat(secondResult).isEqualTo(expected)
+    }
+
+    @Test
+    fun whenEncodeWithoutCoolDown() {
+        val expected = Request.userTypingRequest
+
+        val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+        val secondResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+
+        assertThat(firstResult).isEqualTo(expected)
+        assertThat(secondResult).isNull()
+    }
+
+    @Test
+    fun whenEncodeWithoutCoolDownButWithClear() {
+        val expected = Request.userTypingRequest
+
+        val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+        subject.clear()
+        val secondResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+
+        assertThat(firstResult).isEqualTo(expected)
+        assertThat(secondResult).isEqualTo(expected)
+    }
+}

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -1,0 +1,8 @@
+package com.genesys.cloud.messenger.transport.util
+
+internal object Request {
+    const val configureRequest =
+        """{"token":"00000000-0000-0000-0000-000000000000","deploymentId":"deploymentId","journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
+    const val userTypingRequest =
+        """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On","duration":5000}}],"type":"Event"}}"""
+}

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -4,5 +4,5 @@ internal object Request {
     const val configureRequest =
         """{"token":"00000000-0000-0000-0000-000000000000","deploymentId":"deploymentId","journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
     const val userTypingRequest =
-        """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On","duration":5000}}],"type":"Event"}}"""
+        """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -142,7 +142,7 @@ interface MessagingClient {
 
     /**
      * Attach a file to the message. This file will be uploaded and cached locally
-     * until user decides to send a message.
+     * until customer decides to send a message.
      * After the message has been sent, attachment will be cleared from cache.
      *
      * @param byteArray data to upload.
@@ -193,10 +193,12 @@ interface MessagingClient {
     fun invalidateConversationCache()
 
     /**
-     * Notify the Agent that the User is typing a message.
+     * Notify the agent that the customer is typing a message.
+     * This command sends a single typing indicator event and should be called a maximum of once every 5 seconds.
+     * If called more frequently, this command will be rate limited in order to optimize network traffic.
      *
      * @throws IllegalStateException if called before session was connected.
      */
     @Throws(IllegalStateException::class)
-    fun userIsTyping()
+    fun indicateTyping()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -191,4 +191,12 @@ interface MessagingClient {
      * latest available history.
      */
     fun invalidateConversationCache()
+
+    /**
+     * Notify the Agent that the User is typing a message.
+     *
+     * @throws IllegalStateException if called before session was connected.
+     */
+    @Throws(IllegalStateException::class)
+    fun userIsTyping()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -203,13 +203,13 @@ internal class MessagingClientImpl(
     }
 
     @Throws(IllegalStateException::class)
-    override fun userIsTyping() {
+    override fun indicateTyping() {
         val encodedJson = userTypingProvider.encodeRequest(token)
         if (encodedJson == null) {
             log.w { "Typing event can be sent only once every $TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND milliseconds." }
             return
         }
-        log.i { "sendUserIsTyping()" }
+        log.i { "indicateTyping()" }
         send(encodedJson)
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -9,5 +9,5 @@ sealed class Event {
      *
      *  @param durationInMilliseconds amount of time to display visual typing indicator in UI.
      */
-    data class Typing(val durationInMilliseconds: Int) : Event()
+    data class Typing(val durationInMilliseconds: Long) : Event()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -5,6 +5,8 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
 
+private const val FALLBACK_TYPING_INDICATOR_DURATION = 5000L
+
 internal class EventHandlerImpl(
     val log: Log = Log(enableLogs = false, LogTag.EVENT_HANDLER),
 ) : EventHandler {
@@ -21,7 +23,7 @@ internal class EventHandlerImpl(
 private fun StructuredMessageEvent.toTransportEvent(): Event {
     return when (this) {
         is TypingEvent -> {
-            Event.Typing(durationInMilliseconds = typing.duration)
+            Event.Typing(typing.duration ?: FALLBACK_TYPING_INDICATOR_DURATION)
         }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
@@ -5,7 +5,7 @@ import com.genesys.cloud.messenger.transport.shyrka.send.UserTypingRequest
 import com.genesys.cloud.messenger.transport.util.Platform
 import kotlinx.serialization.encodeToString
 
-const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
+internal const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
 
 internal class UserTypingProvider(val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
     private var lastSentUserTypingTimestamp = 0L

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
@@ -1,0 +1,29 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
+import com.genesys.cloud.messenger.transport.shyrka.send.UserTypingRequest
+import com.genesys.cloud.messenger.transport.util.Platform
+import kotlinx.serialization.encodeToString
+
+const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
+
+internal class UserTypingProvider(val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
+    private var lastSentUserTypingTimestamp = 0L
+
+    @Throws(Exception::class)
+    fun encodeRequest(token: String): String? {
+        val currentTimestamp = getCurrentTimestamp()
+        val delta = currentTimestamp - lastSentUserTypingTimestamp
+        return if (delta > TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND) {
+            lastSentUserTypingTimestamp = currentTimestamp
+            val request = UserTypingRequest(token = token)
+            WebMessagingJson.json.encodeToString(request)
+        } else {
+            null
+        }
+    }
+
+    fun clear() {
+        lastSentUserTypingTimestamp = 0L
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
+import com.genesys.cloud.messenger.transport.core.Message
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -65,3 +66,5 @@ internal data class StructuredMessage(
         Event,
     }
 }
+
+internal fun StructuredMessage.isOutbound(): Boolean = this.direction == Message.Direction.Outbound.name

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -28,7 +28,7 @@ internal data class TypingEvent(
     @Serializable
     internal data class Typing(
         val type: String,
-        val duration: Long,
+        val duration: Long? = null,
     )
 }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.json.jsonPrimitive
 
 @Serializable(with = StructuredMessageEventSerializer::class)
 internal sealed class StructuredMessageEvent {
+    abstract val eventType: Type
     @Serializable
     enum class Type {
         @SerialName("Typing")
@@ -21,12 +22,13 @@ internal sealed class StructuredMessageEvent {
 
 @Serializable
 internal data class TypingEvent(
+    override val eventType: Type,
     val typing: Typing,
 ) : StructuredMessageEvent() {
     @Serializable
     internal data class Typing(
         val type: String,
-        val duration: Int,
+        val duration: Long,
     )
 }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/BaseMessageProtocol.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/BaseMessageProtocol.kt
@@ -1,0 +1,14 @@
+package com.genesys.cloud.messenger.transport.shyrka.send
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+interface BaseMessageProtocol {
+    @Required
+    val type: Type
+    @Serializable
+    enum class Type {
+        Text,
+        Event,
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EventMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EventMessage.kt
@@ -1,0 +1,12 @@
+package com.genesys.cloud.messenger.transport.shyrka.send
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class EventMessage(
+    val events: List<StructuredMessageEvent>,
+) : BaseMessageProtocol {
+    @Required override val type = BaseMessageProtocol.Type.Event
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
@@ -9,6 +9,6 @@ internal data class TextMessage(
     val text: String,
     val metadata: Map<String, String>? = null,
     val content: List<Message.Content> = emptyList()
-) {
-    @Required val type = "Text"
+) : BaseMessageProtocol {
+    @Required override val type = BaseMessageProtocol.Type.Text
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/UserTypingRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/UserTypingRequest.kt
@@ -1,6 +1,5 @@
 package com.genesys.cloud.messenger.transport.shyrka.send
 
-import com.genesys.cloud.messenger.transport.core.events.TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import kotlinx.serialization.Required
@@ -18,10 +17,7 @@ internal data class UserTypingRequest(
         listOf(
             TypingEvent(
                 eventType = StructuredMessageEvent.Type.Typing,
-                typing = TypingEvent.Typing(
-                    type = "On",
-                    duration = TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND
-                )
+                typing = TypingEvent.Typing(type = "On"),
             )
         )
     )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/UserTypingRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/UserTypingRequest.kt
@@ -1,0 +1,28 @@
+package com.genesys.cloud.messenger.transport.shyrka.send
+
+import com.genesys.cloud.messenger.transport.core.events.TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class UserTypingRequest(
+    override val token: String,
+) : WebMessagingRequest {
+    @Required
+    override val action: String = RequestAction.ON_MESSAGE.value
+
+    @Required
+    val message = EventMessage(
+        listOf(
+            TypingEvent(
+                eventType = StructuredMessageEvent.Type.Typing,
+                typing = TypingEvent.Typing(
+                    type = "On",
+                    duration = TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND
+                )
+            )
+        )
+    )
+}


### PR DESCRIPTION
- Add `userIsTyping` public api to send `typing` events from user.
- Ensure that `typing` indicator not sent more that once every 5 seconds.
- Extract commonality between EventMessage.kt and TextMessage.kt to BaseMessageProtocol.kt
- Add EventMessage.kt data class for `events` sent to Shyrka.
- Ensure that UI is notified about Outbound events only.
- Include eventType in StructuredMessageEvent.kt
- Just to be on the safe side, use type Long for `duration` field instead of Int.
- Add/Update unit tests.
- Add KDocs for public API.