### PR TITLE
Update okhttp to 4.10.0

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -8,7 +8,7 @@ object Deps {
     private const val logbackVersion = "1.2.10"
     private const val mockWebServerVersion = "4.9.0"
     private const val mockkVersion = "1.12.2"
-    private const val okhttpVersion = "4.9.1"
+    private const val okhttpVersion = "4.10.0"
     private const val klockVersion = "2.4.13"
 
     object Libs {


### PR DESCRIPTION
Updating okhttp due to Snyk report: https://app.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044