### PR TITLE
MTSDK-69 Clear reconnection handler on error

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -288,6 +288,7 @@ class MessagingClientImplTest {
             mockReconnectionHandler.shouldReconnect
             mockStateChangedListener(fromConnectedToError(expectedErrorState))
             mockAttachmentHandler.clearAll()
+            mockReconnectionHandler.clear()
         }
     }
 
@@ -305,6 +306,7 @@ class MessagingClientImplTest {
             connectSequence()
             mockStateChangedListener(fromConnectedToError(expectedErrorState))
             mockAttachmentHandler.clearAll()
+            mockReconnectionHandler.clear()
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -226,11 +226,13 @@ internal class MessagingClientImpl(
                 } else {
                     stateMachine.onError(errorCode, ErrorMessage.FailedToReconnect)
                     attachmentHandler.clearAll()
+                    reconnectionHandler.clear()
                 }
             }
             is ErrorCode.NetworkDisabled -> {
                 stateMachine.onError(errorCode, ErrorMessage.InternetConnectionIsOffline)
                 attachmentHandler.clearAll()
+                reconnectionHandler.clear()
             }
             else -> log.w { "Unhandled WebSocket errorCode. ErrorCode: $errorCode" }
         }


### PR DESCRIPTION
- Clear reconnection handler on error.
- Update unit tests.