### PR TITLE
update: iOS testbed state checking to match docs

### DIFF
--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -28,18 +28,20 @@ class ContentViewController: UIViewController {
             let newState = stateChange.newState
             var stateMessage = "\(newState)"
             switch newState {
-            case _ as MessagingClientState.Connecting:
+            case is MessagingClientState.Connecting:
                 stateMessage = "Connecting"
-            case _ as MessagingClientState.Connected:
+            case is MessagingClientState.Connected:
                 stateMessage = "Connected"
             case let configured as MessagingClientState.Configured:
-                stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState.isEqual(MessagingClientState.Reconnecting()))"
+                stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState is MessagingClientState.Reconnecting)"
             case let closing as MessagingClientState.Closing:
                 stateMessage = "Closing, code=\(closing.code) reason=\(closing.reason)"
             case let closed as MessagingClientState.Closed:
                 stateMessage = "Closed, code=\(closed.code) reason=\(closed.reason)"
             case let error as MessagingClientState.Error:
                 stateMessage = "Error, code=\(error.code) message=\(error.message?.description ?? "nil")"
+            case is MessagingClientState.Reconnecting:
+                stateMessage = "Reconnecting"
             default:
                 break
             }
@@ -129,7 +131,7 @@ class ContentViewController: UIViewController {
         let view = UITextField()
         view.font = UIFont.preferredFont(forTextStyle: .body)
         view.borderStyle = .line
-        view.placeholder = "Send a message"
+        view.placeholder = "Send a command"
         view.autocapitalizationType = .none
         view.autocorrectionType = .no
         view.accessibilityIdentifier = "Text-Field"

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -84,7 +84,7 @@ class MessengerHandler {
     }
 
     func fetchNextPage(completion: ((Error?) -> Void)? = nil) {
-        client.fetchNextPage() {_, error in
+        client.fetchNextPage() { _, error in
             completion?(error)
         }
     }

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -131,9 +131,9 @@ class TestContentController: MessengerHandler {
             print("State Event. New state: \(stateChange.newState), old state: \(stateChange.oldState)")
             let newState = stateChange.newState
             switch newState {
-            case _ as MessagingClientState.Configured:
+            case is MessagingClientState.Configured:
                 self?.testExpectation?.fulfill()
-            case _ as MessagingClientState.Closed:
+            case is MessagingClientState.Closed:
                 self?.testExpectation?.fulfill()
             case let error as MessagingClientState.Error:
                 print("Socket <error>. code: <\(error.code.description)> , message: <\(error.message ?? "No message")>")


### PR DESCRIPTION
Updating the testbed to reflect some of the examples currently used in the Developer Center where `is` is used to check type instead of `as` down-casting to an unnamed variable.