### PR TITLE
Update GenesysCloudMessengerTransport.podspec_template

### DIFF
--- a/transport/GenesysCloudMessengerTransport.podspec_template
+++ b/transport/GenesysCloudMessengerTransport.podspec_template
@@ -39,7 +39,4 @@ SOFTWARE.
 
   s.vendored_frameworks    = 'MessengerTransport.xcframework'
   s.libraries              = 'c++'
-
-  s.pod_target_xcconfig    = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig   = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
remove simulator arm64 exclusions since Messenger Transport frameworks are built with apple silicon slices now