### PR TITLE
MTSDK-30 Typing Indicator on iOS TestBed.

### DIFF
--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -47,9 +47,9 @@ class ContentViewController: UIViewController {
             self?.info.text = "State changed from \(stateChange.oldState) to \(newState)"
         }
         
-        messenger.onMessageEvent = { [weak self] event in
-            var displayMessage = "Unexpected message event: \(event)"
-            switch event {
+        messenger.onMessageEvent = { [weak self] message in
+            var displayMessage = "Unexpected message event: \(message)"
+            switch message {
             case let messageInserted as MessageEvent.MessageInserted:
                 displayMessage = "Message Inserted: \(messageInserted.message.description)"
             case let messageUpdated as MessageEvent.MessageUpdated:
@@ -63,6 +63,19 @@ class ContentViewController: UIViewController {
                 break
             }
             self?.info.text = displayMessage
+        }
+        
+        messenger.onEvent = { [weak self] event in
+            var displayEvent = "Unexpected event: \(event)"
+            switch event {
+            case let typing as Event.AgentTyping:
+                displayEvent = "Event received: \(typing.description)"
+            case let error as Event.Error:
+                displayEvent = "Event received: \(error.description)"
+            default:
+                break
+            }
+            self?.info.text = displayEvent
         }
     }
 
@@ -87,7 +100,8 @@ class ContentViewController: UIViewController {
         case healthCheck
         case clearConversation
         case addAttribute
-        
+        case typing
+
         var helpDescription: String {
             switch self {
             case .send: return "send <msg>"
@@ -311,6 +325,8 @@ extension ContentViewController : UITextFieldDelegate {
                 }  else {
                     self.info.text = "Custom attribute key cannot be nil or empty!"
                 }
+            case (.typing, _):
+                try messenger.indicateTyping()
             default:
                 self.info.text = "Invalid command"
             }

--- a/iosApp/iosApp/MessengerHandler.swift
+++ b/iosApp/iosApp/MessengerHandler.swift
@@ -18,6 +18,7 @@ class MessengerHandler {
     
     public var onStateChange: ((StateChange) -> Void)?
     public var onMessageEvent: ((MessageEvent) -> Void)?
+    public var onEvent: ((Event) -> Void)?
     
     init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
         self.deployment = deployment
@@ -32,9 +33,13 @@ class MessengerHandler {
             print("State Change: \(stateChange)")
             self?.onStateChange?(stateChange)
         }
-        client.messageListener = { [weak self] event in
-            print("Message Event: \(event)")
-            self?.onMessageEvent?(event)
+        client.messageListener = { [weak self] message in
+            print("Message Event: \(message)")
+            self?.onMessageEvent?(message)
+        }
+        client.eventListener = { [weak self] event in
+            print("Event: \(event)")
+            self?.onEvent?(event)
         }
     }
 
@@ -128,5 +133,14 @@ class MessengerHandler {
 
     func clearConversation() {
         client.invalidateConversationCache()
+    }
+
+    func indicateTyping() throws {
+        do {
+            try client.indicateTyping()
+        } catch {
+            print("indicateTyping() failed. \(error.localizedDescription)")
+            throw error
+        }
     }
 }


### PR DESCRIPTION
- Hook to eventListener.
- Add typing command to send indicateTyping events.
- Print received events in Response window.