### PR TITLE
MTSDK-32: Integration test for iOS typing indicators.

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -19,6 +19,7 @@
 		8C4A6A23273C696C008B8150 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A6A22273C696C008B8150 /* Deployment.swift */; };
 		8CF6294F27074EB400AE0CA8 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */; };
 		8CF62953270754C000AE0CA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF80242A565900829871 /* SceneDelegate.swift */; };
+		BA5B8CD428CA2FEC007C8160 /* TestContentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */; };
 		BA88FE14284953CA009AA1F8 /* MessengerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE13284953CA009AA1F8 /* MessengerHandler.swift */; };
 		BA88FE16284A54E7009AA1F8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = BA88FE15284A54E6009AA1F8 /* config.json */; };
 		BA88FE22284A5501009AA1F8 /* TestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE18284A5501009AA1F8 /* TestConfig.swift */; };
@@ -69,6 +70,7 @@
 		8C4A6A19273C3CD8008B8150 /* deployment.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = deployment.properties; path = ../../deployment.properties; sourceTree = "<group>"; };
 		8C4A6A22273C696C008B8150 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
+		BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestContentController.swift; sourceTree = "<group>"; };
 		BA88FE13284953CA009AA1F8 /* MessengerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerHandler.swift; sourceTree = "<group>"; };
 		BA88FE15284A54E6009AA1F8 /* config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config.json; sourceTree = "<group>"; };
 		BA88FE18284A5501009AA1F8 /* TestConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConfig.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				BA88FE1C284A5501009AA1F8 /* ConversationInfo.swift */,
 				BA88FE1D284A5501009AA1F8 /* extensions.swift */,
 				BA88FE2A284A57E2009AA1F8 /* WaitHandler.swift */,
+				BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -242,7 +245,7 @@
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
-				5D1BB332E141DF44B408E7B0 /* [CP] Embed Pods Frameworks */,
+				DE828D6A2F904488DF0DABF5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -386,7 +389,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		5D1BB332E141DF44B408E7B0 /* [CP] Embed Pods Frameworks */ = {
+		DE828D6A2F904488DF0DABF5 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -453,6 +456,7 @@
 				7555FF96242A565B00829871 /* iosAppTests.swift in Sources */,
 				BA88FE22284A5501009AA1F8 /* TestConfig.swift in Sources */,
 				BA88FE2B284A57E2009AA1F8 /* WaitHandler.swift in Sources */,
+				BA5B8CD428CA2FEC007C8160 /* TestContentController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosAppTests/Support/PublicAPI/Conversations.swift
+++ b/iosApp/iosAppTests/Support/PublicAPI/Conversations.swift
@@ -52,6 +52,12 @@ extension ApiHelper {
         _ = publicAPICall(httpMethod: "POST", httpURL: "/api/v2/conversations/messages/\(conversationId)/communications/\(communicationId)/messages", jsonBody: payload)
     }
 
+    public func sendTypingIndicator(conversationId: String, communicationId: String) {
+        let conversationEventTyping: [String: Any] = ["type": "On"]
+        let payload: [String: Any] = ["typing": conversationEventTyping]
+        _ = publicAPICall(httpMethod: "POST", httpURL: "/api/v2/conversations/messages/\(conversationId)/communications/\(communicationId)/typing", jsonBody: payload)
+    }
+
     public func getCommunicationId(conversationId: String) -> String? {
         guard let results = publicAPICall(httpMethod: "GET", httpURL: "/api/v2/conversations/\(conversationId)"), let participants = results.value(forKey: "participants") as? [JsonDictionary] else {
             print("There was an issue getting the conversation information.")

--- a/iosApp/iosAppTests/Support/TestContentController.swift
+++ b/iosApp/iosAppTests/Support/TestContentController.swift
@@ -1,0 +1,177 @@
+//
+//  TestContentController.swift
+//  iosAppTests
+//
+//  Created by Morehouse, Matthew on 9/8/22.
+//  Copyright © 2022 orgName. All rights reserved.
+//
+
+import XCTest
+import MessengerTransport
+@testable import iosApp
+
+class TestContentController: MessengerHandler {
+
+    var testExpectation: XCTestExpectation? = nil
+    var errorExpectation: XCTestExpectation? = nil
+    var receivedMessageText: String? = nil
+    var receivedDownloadUrl: String? = nil
+
+    override init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
+        super.init(deployment: deployment, reconnectTimeout: reconnectTimeout)
+
+        client.stateChangedListener = { [weak self] stateChange in
+            print("State Event. New state: \(stateChange.newState), old state: \(stateChange.oldState)")
+            let newState = stateChange.newState
+            switch newState {
+            case _ as MessagingClientState.Configured:
+                self?.testExpectation?.fulfill()
+            case _ as MessagingClientState.Closed:
+                self?.testExpectation?.fulfill()
+            case let error as MessagingClientState.Error:
+                print("Socket <error>. code: <\(error.code.description)> , message: <\(error.message ?? "No message")>")
+                self?.errorExpectation?.fulfill()
+            default:
+                break
+            }
+            self?.onStateChange?(stateChange)
+        }
+
+        client.messageListener = { [weak self] message in
+            switch message {
+            case let messageInserted as MessageEvent.MessageInserted:
+                print("Message Inserted: <\(messageInserted.message.description)>")
+                self?.receivedMessageText = messageInserted.message.text
+                self?.testExpectation?.fulfill()
+            case let messageUpdated as MessageEvent.MessageUpdated:
+                print("Message Updated: <\(messageUpdated.message.description)>")
+                self?.testExpectation?.fulfill()
+            case let attachmentUpdated as MessageEvent.AttachmentUpdated:
+                print("Attachment Updated: <\(attachmentUpdated.attachment.description)>")
+                // Only finish the wait when the attachment has finished uploading.
+                if let uploadedAttachment = attachmentUpdated.attachment.state as? Attachment.StateUploaded {
+                    self?.receivedDownloadUrl = uploadedAttachment.downloadUrl
+                    self?.testExpectation?.fulfill()
+                }
+            case let history as MessageEvent.HistoryFetched:
+                print("start of conversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)>")
+                self?.testExpectation?.fulfill()
+            default:
+                print("Unexpected messageListener event: \(message)")
+            }
+            self?.onMessageEvent?(message)
+        }
+
+        client.eventListener = { [weak self] event in
+            switch event {
+            case let typing as Event.AgentTyping:
+                print("Agent is typing: \(typing)")
+                self?.testExpectation?.fulfill()
+            default:
+                print("Other event. \(event)")
+            }
+        }
+
+    }
+
+    func startMessengerConnection(file: StaticString = #file, line: UInt = #line) {
+        do {
+            try connect(shouldConfigure: true)
+        } catch {
+            XCTFail("Possible issue with connecting to the backend: \(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
+    override func connect(shouldConfigure: Bool) throws {
+        testExpectation = XCTestExpectation(description: "Wait for Configuration.")
+        try super.connect(shouldConfigure: shouldConfigure)
+        waitForExpectation()
+    }
+
+    func disconnectMessenger(file: StaticString = #file, line: UInt = #line) {
+        do {
+            try disconnect()
+        } catch {
+            XCTFail("Failed to disconnect the session.\n\(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
+    override func disconnect() throws {
+        testExpectation = XCTestExpectation(description: "Wait for Disconnect.")
+        try super.disconnect()
+        waitForExpectation()
+    }
+
+    func sendText(text: String, file: StaticString = #file, line: UInt = #line) {
+        do {
+            try sendMessage(text: text)
+        } catch {
+            XCTFail("Failed to send the message '\(text)'\n\(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
+    func sendTextWithAttribute(text: String, attributes: [String: String], file: StaticString = #file, line: UInt = #line) {
+        do {
+            try sendMessage(text: text, customAttributes: attributes)
+        } catch {
+            XCTFail("Failed to send the message \(text) with the attributes: \(attributes)\n\(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
+    override func sendMessage(text: String, customAttributes: [String: String] = [:]) throws {
+        testExpectation = XCTestExpectation(description: "Wait for message to send.")
+        try super.sendMessage(text: text, customAttributes: customAttributes)
+        waitForExpectation()
+        verifyReceivedMessage(expectedMessage: text)
+    }
+
+    func attemptImageAttach(kotlinByteArray: KotlinByteArray, file: StaticString = #file, line: UInt = #line) {
+        do {
+            try attachImage(kotlinByteArray: kotlinByteArray)
+        } catch {
+            XCTFail("Failed to attach image.\n\(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
+    override func attachImage(kotlinByteArray: KotlinByteArray) throws {
+        testExpectation = XCTestExpectation(description: "Wait for image to attach successfully.")
+        try super.attachImage(kotlinByteArray: kotlinByteArray)
+        waitForExpectation()
+    }
+
+    func sendUploadedImage(file: StaticString = #file, line: UInt = #line) {
+        testExpectation = XCTestExpectation(description: "Wait for the uploaded image url to send.")
+        guard let receivedDownloadUrl = receivedDownloadUrl else {
+            XCTFail("There was no download URL received.")
+            return
+        }
+        do {
+            try super.sendMessage(text: receivedDownloadUrl)
+        } catch {
+            XCTFail("Failed to upload an image.\n\(error.localizedDescription)", file: file, line: line)
+        }
+        waitForExpectation()
+        verifyReceivedMessage(expectedMessage: receivedDownloadUrl)
+    }
+
+    override func indicateTyping() throws {
+        // No need to wait for an expectation. Just need to make sure the request doesn't fail.
+        do {
+            try super.indicateTyping()
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func waitForExpectation() {
+        let result = XCTWaiter().wait(for: [testExpectation!], timeout: 60)
+        XCTAssertEqual(result, .completed, "Expectation never fullfilled: \(testExpectation?.description ?? "No description.")")
+    }
+
+    func verifyReceivedMessage(expectedMessage: String) {
+        print("Checking the received message...")
+        XCTAssertEqual(expectedMessage, receivedMessageText, "The received message: '\(receivedMessageText ?? "")' didn't match what was expected: '\(expectedMessage)'.")
+        receivedMessageText = nil
+    }
+
+}


### PR DESCRIPTION
- New test to verify that we can send a typing indicator and that we can receive one.
    - For sending a typing indicator, tests can only verify that we do not receive an error while attempting to do so.
- Moving the TestContentController to a separate file.
- New API request for sending a typing indicator from the agent that can be received in tests.