### PR TITLE
Feature/mtsdk 34 disable bitcode

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline{
                       -Pkotlin.native.cocoapods.configuration=Debug
                     cd iosApp
                     pod install --verbose
-                    xcodebuild clean build -verbose -workspace iosApp.xcworkspace -scheme iosApp -configuration Debug CODE_SIGNING_ALLOWED=NO EXCLUDED_ARCHS=armv7
+                    xcodebuild clean build -verbose -workspace iosApp.xcworkspace -scheme iosApp -configuration Debug CODE_SIGNING_ALLOWED=NO
                 '''
             }
         }

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
+import org.jetbrains.kotlin.gradle.plugin.mpp.BitcodeEmbeddingMode
 
 plugins {
     kotlin("multiplatform")
@@ -57,12 +58,14 @@ kotlin {
     val xcf = XCFramework(iosFrameworkName)
     ios {
         binaries.framework {
+            embedBitcode = BitcodeEmbeddingMode.DISABLE
             baseName = iosFrameworkName
             xcf.add(this)
         }
     }
     iosSimulatorArm64 {
         binaries.framework {
+            embedBitcode = BitcodeEmbeddingMode.DISABLE
             baseName = iosFrameworkName
             xcf.add(this)
         }


### PR DESCRIPTION
Disabling bitcode in the xcframework build artifacts.

Xcode 14 was officially released and brought with it a deprecation for supporting bitcode: https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes

> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols for past bitcode submissions remain available for download. (86118779)