### PR TITLE
MTSDK-88 Notify about healthcheck result.

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -168,6 +168,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
     private suspend fun doSendHealthCheck() {
         try {
             client.sendHealthCheck()
+            commandWaiting = false
         } catch (t: Throwable) {
             handleException(t, "send health check")
         }

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -74,6 +74,8 @@ class ContentViewController: UIViewController {
                 displayEvent = "Event received: \(typing.description)"
             case let error as Event.Error:
                 displayEvent = "Event received: \(error.description)"
+            case let healthChecked as Event.HealthChecked:
+                displayEvent = "Event received: \(healthChecked.description)"
             default:
                 break
             }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.core.events
 import com.genesys.cloud.messenger.transport.core.CorrectiveAction
 import com.genesys.cloud.messenger.transport.core.ErrorCode
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.HealthCheckEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent.Typing
@@ -67,6 +68,16 @@ class EventHandlerTest {
             message = "some message",
             correctiveAction = CorrectiveAction.Forbidden,
         )
+
+        subject.onEvent(givenStructuredMessageEvent)
+
+        verify { mockEventListener.invoke(eq(expectedEvent)) }
+    }
+
+    @Test
+    fun whenHealthCheckedOccurs() {
+        val givenStructuredMessageEvent = HealthCheckEvent()
+        val expectedEvent = Event.HealthChecked
 
         subject.onEvent(givenStructuredMessageEvent)
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/HealthCheckProviderTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/HealthCheckProviderTest.kt
@@ -10,16 +10,16 @@ import io.mockk.mockk
 import io.mockk.spyk
 import org.junit.Test
 
-class UserTypingProviderTest {
+class HealthCheckProviderTest {
     private val mockTimestampFunction: () -> Long = spyk<() -> Long>().also {
         every { it.invoke() } answers { Platform().epochMillis() }
     }
 
-    private val subject = UserTypingProvider(mockk(relaxed = true), mockTimestampFunction)
+    private val subject = HealthCheckProvider(mockk(relaxed = true), mockTimestampFunction)
 
     @Test
     fun whenEncode() {
-        val expected = Request.userTypingRequest
+        val expected = Request.echoRequest
 
         val result = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
 
@@ -28,11 +28,11 @@ class UserTypingProviderTest {
 
     @Test
     fun whenEncodeWithCoolDown() {
-        val typingIndicatorCoolDownInMilliseconds = 5000
-        val expected = Request.userTypingRequest
+        val healthCheckCoolDownInMilliseconds = 30000
+        val expected = Request.echoRequest
 
         val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
-        every { mockTimestampFunction.invoke() } answers { Platform().epochMillis() + typingIndicatorCoolDownInMilliseconds }
+        every { mockTimestampFunction.invoke() } answers { Platform().epochMillis() + healthCheckCoolDownInMilliseconds }
         val secondResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
 
         assertThat(firstResult).isEqualTo(expected)
@@ -41,7 +41,7 @@ class UserTypingProviderTest {
 
     @Test
     fun whenEncodeWithoutCoolDown() {
-        val expected = Request.userTypingRequest
+        val expected = Request.echoRequest
 
         val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
         val secondResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
@@ -52,7 +52,7 @@ class UserTypingProviderTest {
 
     @Test
     fun whenEncodeWithoutCoolDownButWithClear() {
-        val expected = Request.userTypingRequest
+        val expected = Request.echoRequest
 
         val firstResult = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
         subject.clear()

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -5,4 +5,6 @@ internal object Request {
         """{"token":"00000000-0000-0000-0000-000000000000","deploymentId":"deploymentId","journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
     const val userTypingRequest =
         """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
+    const val echoRequest =
+        """{"token":"00000000-0000-0000-0000-000000000000","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -110,6 +110,8 @@ interface MessagingClient {
 
     /**
      * Perform a health check of the connection by sending an echo message.
+     * This command sends a single echo request and should be called a maximum of once every 30 seconds.
+     * If called more frequently, this command will be rate limited in order to optimize network traffic.
      *
      * @throws IllegalStateException
      */

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -15,11 +15,21 @@ sealed class Event {
     data class AgentTyping(val durationInMilliseconds: Long) : Event()
 
     /**
+     * This event indicates a successful health check response to the
+     * [com.genesys.cloud.messenger.transport.core.MessagingClient.sendHealthCheck] call.
+     */
+    object HealthChecked : Event()
+
+    /**
      * This event indicates error.
      *
      * @param errorCode indicating what went wrong.
      * @param message is an optional message.
      * @param correctiveAction is an action that can help resolve this error.
      */
-    data class Error(val errorCode: ErrorCode, val message: String?, val correctiveAction: CorrectiveAction) : Event()
+    data class Error(
+        val errorCode: ErrorCode,
+        val message: String?,
+        val correctiveAction: CorrectiveAction,
+    ) : Event()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -2,6 +2,7 @@ package com.genesys.cloud.messenger.transport.core.events
 
 import com.genesys.cloud.messenger.transport.core.toCorrectiveAction
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.HealthCheckEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.util.logs.Log
@@ -34,5 +35,6 @@ private fun StructuredMessageEvent.toTransportEvent(): Event {
                 correctiveAction = errorCode.toCorrectiveAction()
             )
         }
+        is HealthCheckEvent -> Event.HealthChecked
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/HealthCheckProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/HealthCheckProvider.kt
@@ -1,0 +1,31 @@
+package com.genesys.cloud.messenger.transport.core.events
+
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
+import com.genesys.cloud.messenger.transport.shyrka.send.EchoRequest
+import com.genesys.cloud.messenger.transport.util.Platform
+import com.genesys.cloud.messenger.transport.util.logs.Log
+import kotlinx.serialization.encodeToString
+
+private const val HEALTH_CHECK_COOL_DOWN_IN_MILLISECOND = 30000L
+
+internal class HealthCheckProvider(val log: Log, val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
+    private var lastSentHealthCheckTimestamp = 0L
+
+    @Throws(Exception::class)
+    fun encodeRequest(token: String): String? {
+        val currentTimestamp = getCurrentTimestamp()
+        val delta = currentTimestamp - lastSentHealthCheckTimestamp
+        return if (delta > HEALTH_CHECK_COOL_DOWN_IN_MILLISECOND) {
+            lastSentHealthCheckTimestamp = currentTimestamp
+            val request = EchoRequest(token = token)
+            WebMessagingJson.json.encodeToString(request)
+        } else {
+            log.w { "Health check can be sent only once every $HEALTH_CHECK_COOL_DOWN_IN_MILLISECOND milliseconds." }
+            null
+        }
+    }
+
+    fun clear() {
+        lastSentHealthCheckTimestamp = 0L
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
@@ -3,11 +3,12 @@ package com.genesys.cloud.messenger.transport.core.events
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.send.UserTypingRequest
 import com.genesys.cloud.messenger.transport.util.Platform
+import com.genesys.cloud.messenger.transport.util.logs.Log
 import kotlinx.serialization.encodeToString
 
-internal const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
+private const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
 
-internal class UserTypingProvider(val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
+internal class UserTypingProvider(val log: Log, val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
     private var lastSentUserTypingTimestamp = 0L
 
     @Throws(Exception::class)
@@ -19,6 +20,7 @@ internal class UserTypingProvider(val getCurrentTimestamp: () -> Long = { Platfo
             val request = UserTypingRequest(token = token)
             WebMessagingJson.json.encodeToString(request)
         } else {
+            log.w { "Typing event can be sent only once every $TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND milliseconds." }
             null
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
 import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.shyrka.send.HealthCheckID
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -67,4 +68,8 @@ internal data class StructuredMessage(
     }
 }
 
-internal fun StructuredMessage.isOutbound(): Boolean = this.direction == Message.Direction.Outbound.name
+internal fun StructuredMessage.isOutbound(): Boolean =
+    this.direction == Message.Direction.Outbound.name
+
+internal fun StructuredMessage.isHealthCheckResponse(): Boolean =
+    this.metadata["customMessageId"] == HealthCheckID

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -19,6 +19,7 @@ internal sealed class StructuredMessageEvent {
         @SerialName("Typing")
         Typing,
         Error,
+        HealthChecked,
     }
 }
 
@@ -38,6 +39,10 @@ internal data class ErrorEvent(
     override val eventType: Type = Type.Error,
     val errorCode: ErrorCode,
     val message: String?,
+) : StructuredMessageEvent()
+
+internal data class HealthCheckEvent(
+    override val eventType: Type = Type.HealthChecked,
 ) : StructuredMessageEvent()
 
 internal object StructuredMessageEventSerializer :

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EchoRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EchoRequest.kt
@@ -3,10 +3,12 @@ package com.genesys.cloud.messenger.transport.shyrka.send
 import kotlinx.serialization.Required
 import kotlinx.serialization.Serializable
 
+internal const val HealthCheckID = "SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="
+
 @Serializable
 internal data class EchoRequest(
     override val token: String
 ) : WebMessagingRequest {
     @Required override val action: String = RequestAction.ECHO_MESSAGE.value
-    @Required val message: TextMessage = TextMessage("ping")
+    @Required val message: TextMessage = TextMessage("ping", metadata = mapOf("customMessageId" to HealthCheckID))
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogTag.kt
@@ -12,4 +12,6 @@ internal object LogTag {
     const val STATE_MACHINE = "Transport State Machine"
     const val RECONNECTION_HANDLER = "TransportReconnectionHandler"
     const val EVENT_HANDLER = "TransportEventHandler"
+    const val TYPING_INDICATOR_PROVIDER = "TypingIndicatorProvider"
+    const val HEALTH_CHECK_PROVIDER = "HealthCheckProvider"
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -20,6 +20,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
 import com.genesys.cloud.messenger.transport.shyrka.send.ConfigureSessionRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.EchoRequest
+import com.genesys.cloud.messenger.transport.shyrka.send.HealthCheckID
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyContext
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomer
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomerSession
@@ -58,7 +59,7 @@ class SerializationTest {
         val encodedString = WebMessagingJson.json.encodeToString(echoRequest)
 
         assertThat(encodedString, "encoded EchoRequest")
-            .isEqualTo("""{"token":"<token>","action":"echo","message":{"text":"ping","type":"Text"}}""")
+            .isEqualTo("""{"token":"<token>","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"$HealthCheckID"},"type":"Text"}}""")
     }
 
     @Test


### PR DESCRIPTION
- Add HealthChecked event to inform UI of successful healthchecks.
- Rate-limit healthChecks to maximum of once every 30 seconds.
- Use customMessageId with unique id for healthcheck requests.
- Add/Update KDocs.
- Add/Update unit tests.