### PR TITLE
Feature/mtsdk 90

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline{
         }
         stage("CI Build - transport POM creation"){
             steps{
-                sh './gradlew :transport:generatePomFileForMavenPublication'
+                sh './gradlew :transport:generatePomFileForKotlinMultiplatformPublication'
             }
         }
         stage("CI Build - iOS Testbed"){

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - transport (1.2.2)
+  - transport (2.0.0)
 
 DEPENDENCIES:
   - transport (from `../transport`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../transport"
 
 SPEC CHECKSUMS:
-  transport: 36866941541c2166295efd94e0284f1c16f70154
+  transport: c0247d0684803a3804c480e6ff2461b0e1ffa616
 
 PODFILE CHECKSUM: c3105f0698090ba6d9702820eb0f13f123776417
 

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -187,7 +187,7 @@ tasks {
                 .replace(oldValue = "<VERSION>", newValue = version.toString())
                 .replace(
                     oldValue = "<SOURCE_HTTP_URL>",
-                    newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v${version}/MessengerTransport.xcframework.zip"
+                    newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/${version}/MessengerTransport.xcframework.zip"
                 )
             file(podspecFileName, PathValidation.NONE).writeText(content)
             println("CocoaPods podspec for Pod $iosCocoaPodName written to: ${this.project.projectDir}/$podspecFileName")

--- a/transport/transport.podspec
+++ b/transport/transport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'transport'
-    spec.version                  = '1.2.2'
+    spec.version                  = '2.0.0'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http=> ''}
     spec.authors                  = 'Genesys Cloud Services, Inc.'


### PR DESCRIPTION
If we're changing release tag naming from `v{major}.{minor}.{patch}` to `{major}.{minor}.{patch}` we need this change to generate the right podspec path to the released xcframework zip.