### PR TITLE
MTSDK-105 Prefetch DeploymentConfig.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -15,6 +15,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent.Typing
+import com.genesys.cloud.messenger.transport.shyrka.receive.fakeDeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel.Metadata
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
@@ -123,6 +124,7 @@ class MessagingClientImplTest {
         healthCheckProvider = HealthCheckProvider(mockk(relaxed = true), mockTimestampFunction),
     ).also {
         it.stateChangedListener = mockStateChangedListener
+        it.deploymentConfig = fakeDeploymentConfig()
     }
 
     @AfterTest

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -6,6 +6,7 @@ import com.genesys.cloud.messenger.transport.core.events.EventHandler
 import com.genesys.cloud.messenger.transport.core.events.EventHandlerImpl
 import com.genesys.cloud.messenger.transport.core.events.HealthCheckProvider
 import com.genesys.cloud.messenger.transport.core.events.UserTypingProvider
+import com.genesys.cloud.messenger.transport.network.DeploymentConfigUseCase
 import com.genesys.cloud.messenger.transport.network.PlatformSocket
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.network.ReconnectionHandler
@@ -13,6 +14,7 @@ import com.genesys.cloud.messenger.transport.network.SocketCloseCode
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.receive.AttachmentDeletedResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.GenerateUrlError
 import com.genesys.cloud.messenger.transport.shyrka.receive.HealthCheckEvent
@@ -35,6 +37,10 @@ import com.genesys.cloud.messenger.transport.util.extensions.toMessage
 import com.genesys.cloud.messenger.transport.util.extensions.toMessageList
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 
@@ -52,7 +58,10 @@ internal class MessagingClientImpl(
     private val eventHandler: EventHandler = EventHandlerImpl(log.withTag(LogTag.EVENT_HANDLER)),
     private val userTypingProvider: UserTypingProvider = UserTypingProvider(log.withTag(LogTag.TYPING_INDICATOR_PROVIDER)),
     private val healthCheckProvider: HealthCheckProvider = HealthCheckProvider(log.withTag(LogTag.HEALTH_CHECK_PROVIDER)),
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main + SupervisorJob()),
 ) : MessagingClient {
+
+    internal var deploymentConfig: DeploymentConfig? = null
 
     override val currentState: State
         get() {
@@ -87,7 +96,17 @@ internal class MessagingClientImpl(
     override fun connect() {
         log.i { "connect()" }
         stateMachine.onConnect()
-        webSocket.openSocket(socketListener)
+        if (deploymentConfig == null) {
+            try {
+                coroutineScope.launch { fetchDeploymentConfig() }
+            } catch (e: Exception) {
+                log.w { "Failed to fetch deployment config. Proceed with default." }
+            } finally {
+                webSocket.openSocket(socketListener)
+            }
+        } else {
+            webSocket.openSocket(socketListener)
+        }
     }
 
     @Throws(IllegalStateException::class)
@@ -265,6 +284,15 @@ internal class MessagingClientImpl(
                 }
             }
         }
+    }
+
+    @Throws(Exception::class)
+    private suspend fun fetchDeploymentConfig() {
+        log.i { "Fetching deployment config." }
+        deploymentConfig = DeploymentConfigUseCase(
+            configuration.logging,
+            configuration.deploymentConfigUrl.toString(),
+        ).fetch()
     }
 
     private val socketListener = SocketListener(

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -1,0 +1,33 @@
+package com.genesys.cloud.messenger.transport.shyrka.receive
+
+fun fakeDeploymentConfig() = DeploymentConfig(
+    id = "id",
+    version = "1",
+    languages = listOf("en-us", "zh-cn"),
+    defaultLanguage = "en-us",
+    apiEndpoint = "api_endpoint",
+    messenger = fakeMessenger,
+    journeyEvents = JourneyEvents(enabled = false),
+    status = DeploymentConfig.Status.Active,
+)
+
+private val fakeMessenger = Messenger(
+    enabled = true,
+    apps = Apps(
+        conversations = Conversations(
+            messagingEndpoint = "messaging_endpoint",
+            showAgentTypingIndicator = true,
+            showUserTypingIndicator = true,
+        )
+    ),
+    styles = Styles(primaryColor = "red"),
+    launcherButton = LauncherButton(visibility = "On"),
+    fileUpload = FileUpload(
+        listOf(
+            Mode(
+                fileTypes = listOf("png"),
+                maxFileSizeKB = 100,
+            ),
+        )
+    )
+)


### PR DESCRIPTION
- MessengerTransport.kt will update MessagingClientImpl.kt with deploymentConfig when they are fetched.
- Add DeploymentConfig nullable property to MessagingClientImpl.kt
- During `connect()` check if deploymentConfig requires fetching and if so fetch them.
- If MessagingClientImpl.kt failed to fetch deploymentConfig proceed with default.
- Add FakeDeploymentConfig.kt to simplify future DeploymentConfig testing.