### PR TITLE
MTSDK-98 Handle Autostart failures.

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
@@ -32,10 +32,16 @@ class MessengerTransport(
      * Creates an instance of [MessagingClient] based on the provided configuration.
      */
     fun createMessagingClient(): MessagingClient {
-        if (deploymentConfig == null) {
-            CoroutineScope(Dispatchers.Main + SupervisorJob()).launch { fetchDeploymentConfig() }
-        }
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
+        if (deploymentConfig == null) {
+            CoroutineScope(Dispatchers.Main + SupervisorJob()).launch {
+                try {
+                    fetchDeploymentConfig()
+                } catch (t: Throwable) {
+                    log.w { "Failed to fetch deployment config: $t" }
+                }
+            }
+        }
         val api = WebMessagingApi(configuration)
         val webSocket = PlatformSocket(
             log.withTag(LogTag.WEBSOCKET),


### PR DESCRIPTION
- Wrap the deploymentConfig fetch under try/catch to avoid hard failure when request fails with an exception.