### PR TITLE
Feature/mtsdk 73 conversation autostart

### DIFF
--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -76,6 +76,8 @@ class ContentViewController: UIViewController {
                 displayEvent = "Event received: \(error.description)"
             case let healthChecked as Event.HealthChecked:
                 displayEvent = "Event received: \(healthChecked.description)"
+            case let conversationAutostart as Event.ConversationAutostart:
+                displayEvent = "Event received: \(conversationAutostart.description)"
             default:
                 break
             }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -11,12 +11,17 @@ import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.network.ReconnectionHandlerImpl
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
+import com.genesys.cloud.messenger.transport.shyrka.receive.Apps
+import com.genesys.cloud.messenger.transport.shyrka.receive.Conversations
 import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent.Typing
-import com.genesys.cloud.messenger.transport.shyrka.receive.fakeDeploymentConfig
+import com.genesys.cloud.messenger.transport.shyrka.receive.createConversationsVOForTesting
+import com.genesys.cloud.messenger.transport.shyrka.receive.createDeploymentConfigForTesting
+import com.genesys.cloud.messenger.transport.shyrka.receive.createMessengerVOForTesting
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel.Metadata
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
@@ -111,7 +116,7 @@ class MessagingClientImplTest {
         every { it.invoke() } answers { Platform().epochMillis() }
     }
     private val mockDeploymentConfig = mockk<KProperty0<DeploymentConfig?>> {
-        every { get() } returns fakeDeploymentConfig()
+        every { get() } returns createDeploymentConfigForTesting()
     }
 
     private val subject = MessagingClientImpl(
@@ -692,6 +697,86 @@ class MessagingClientImplTest {
         verify { mockEventHandler.onEvent(expectedEvent) }
     }
 
+    @Test
+    fun whenNewSessionAndAutostartEnabled() {
+        every { mockDeploymentConfig.get() } returns createDeploymentConfigForTesting(
+            messenger = createMessengerVOForTesting(
+                apps = Apps(
+                    conversations = createConversationsVOForTesting(
+                        autoStart = Conversations.AutoStart(enabled = true)
+                    )
+                )
+            )
+        )
+
+        subject.connect()
+
+        verifySequence {
+            connectSequence()
+            mockPlatformSocket.sendMessage(Request.autostart)
+        }
+    }
+
+    @Test
+    fun whenOldSessionAndAutostartEnabled() {
+        every { mockPlatformSocket.sendMessage(Request.configureRequest) } answers {
+            slot.captured.onMessage(Response.configureSuccessWithNewSessionFalse)
+        }
+        every { mockDeploymentConfig.get() } returns createDeploymentConfigForTesting(
+            messenger = createMessengerVOForTesting(
+                apps = Apps(
+                    conversations = createConversationsVOForTesting(
+                        autoStart = Conversations.AutoStart(enabled = true)
+                    )
+                )
+            )
+        )
+
+        subject.connect()
+
+        verify(exactly = 0) { mockPlatformSocket.sendMessage(Request.autostart) }
+    }
+
+    @Test
+    fun whenOldSessionAndAutostartDisabled() {
+        every { mockPlatformSocket.sendMessage(Request.configureRequest) } answers {
+            slot.captured.onMessage(Response.configureSuccessWithNewSessionFalse)
+        }
+
+        subject.connect()
+
+        verify(exactly = 0) { mockPlatformSocket.sendMessage(Request.autostart) }
+    }
+
+    @Test
+    fun whenNewSessionAndAutostartDisabled() {
+        subject.connect()
+
+        verify(exactly = 0) { mockPlatformSocket.sendMessage(Request.autostart) }
+    }
+
+    @Test
+    fun whenNewSessionAndDeploymentConfigNotSet() {
+        every { mockDeploymentConfig.get() } returns null
+
+        subject.connect()
+
+        verify(exactly = 0) { mockPlatformSocket.sendMessage(Request.autostart) }
+    }
+
+    @Test
+    fun whenEventPresenceJoinReceived() {
+        val givenPresenceJoinEvent = """{"eventType":"Presence","presence":{"type":"Join"}}"""
+        val expectedEvent = PresenceEvent(eventType = StructuredMessageEvent.Type.Presence, PresenceEvent.Presence("Join"))
+
+        subject.connect()
+        slot.captured.onMessage(Response.structuredMessageWithEvents(events = givenPresenceJoinEvent))
+
+        verify {
+            mockEventHandler.onEvent(eq(expectedEvent))
+        }
+    }
+
     private fun configuration(): Configuration = Configuration(
         deploymentId = "deploymentId",
         domain = "inindca.com",
@@ -764,6 +849,8 @@ class MessagingClientImplTest {
 private object Response {
     const val configureSuccess =
         """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":true,"newSession":true}}"""
+    const val configureSuccessWithNewSessionFalse =
+        """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":true,"newSession":false}}"""
     const val configureFail =
         """{"type":"response","class":"string","code":400,"body":"Deployment not found"}"""
     const val defaultStructuredEvents =

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -7,4 +7,6 @@ internal object Request {
         """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
     const val echoRequest =
         """{"token":"00000000-0000-0000-0000-000000000000","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
+    const val autostart =
+        """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],"type":"Event"}}"""
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -13,6 +13,7 @@ import com.genesys.cloud.messenger.transport.network.SocketCloseCode
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.receive.AttachmentDeletedResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.GenerateUrlError
 import com.genesys.cloud.messenger.transport.shyrka.receive.HealthCheckEvent
@@ -37,6 +38,7 @@ import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
+import kotlin.reflect.KProperty0
 
 internal class MessagingClientImpl(
     private val api: WebMessagingApi,
@@ -52,6 +54,7 @@ internal class MessagingClientImpl(
     private val eventHandler: EventHandler = EventHandlerImpl(log.withTag(LogTag.EVENT_HANDLER)),
     private val userTypingProvider: UserTypingProvider = UserTypingProvider(log.withTag(LogTag.TYPING_INDICATOR_PROVIDER)),
     private val healthCheckProvider: HealthCheckProvider = HealthCheckProvider(log.withTag(LogTag.HEALTH_CHECK_PROVIDER)),
+    private val deploymentConfig: KProperty0<DeploymentConfig?>,
 ) : MessagingClient {
 
     override val currentState: State

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
@@ -32,10 +32,16 @@ class MessengerTransport(
      * Creates an instance of [MessagingClient] based on the provided configuration.
      */
     fun createMessagingClient(): MessagingClient {
-        if (deploymentConfig == null) {
-            CoroutineScope(Dispatchers.Main + SupervisorJob()).launch { fetchDeploymentConfig() }
-        }
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
+        if (deploymentConfig == null) {
+            CoroutineScope(Dispatchers.Main + SupervisorJob()).launch {
+                try {
+                    fetchDeploymentConfig()
+                } catch (t: Throwable) {
+                    log.w { "Failed to fetch deployment config: $t" }
+                }
+            }
+        }
         val api = WebMessagingApi(configuration)
         val webSocket = PlatformSocket(
             log.withTag(LogTag.WEBSOCKET),

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransport.kt
@@ -10,13 +10,21 @@ import com.genesys.cloud.messenger.transport.util.DefaultTokenStore
 import com.genesys.cloud.messenger.transport.util.TokenStore
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 
 private const val TOKEN_STORE_KEY = "com.genesys.cloud.messenger"
 
 /**
  * The entry point to the services provided by the transport SDK.
  */
-class MessengerTransport(private val configuration: Configuration, private val tokenStore: TokenStore) {
+class MessengerTransport(
+    private val configuration: Configuration,
+    private val tokenStore: TokenStore,
+) {
+    private var deploymentConfig: DeploymentConfig? = null
 
     constructor(configuration: Configuration) : this(configuration, DefaultTokenStore(TOKEN_STORE_KEY))
 
@@ -24,9 +32,16 @@ class MessengerTransport(private val configuration: Configuration, private val t
      * Creates an instance of [MessagingClient] based on the provided configuration.
      */
     fun createMessagingClient(): MessagingClient {
+        if (deploymentConfig == null) {
+            CoroutineScope(Dispatchers.Main + SupervisorJob()).launch { fetchDeploymentConfig() }
+        }
         val log = Log(configuration.logging, LogTag.MESSAGING_CLIENT)
         val api = WebMessagingApi(configuration)
-        val webSocket = PlatformSocket(log.withTag(LogTag.WEBSOCKET), configuration.webSocketUrl, DEFAULT_PING_INTERVAL_IN_SECONDS)
+        val webSocket = PlatformSocket(
+            log.withTag(LogTag.WEBSOCKET),
+            configuration.webSocketUrl,
+            DEFAULT_PING_INTERVAL_IN_SECONDS,
+        )
         val token = tokenStore.token
         val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
         val attachmentHandler = AttachmentHandlerImpl(
@@ -47,7 +62,8 @@ class MessengerTransport(private val configuration: Configuration, private val t
             reconnectionHandler = ReconnectionHandlerImpl(
                 configuration.reconnectionTimeoutInSeconds,
                 log.withTag(LogTag.RECONNECTION_HANDLER),
-            )
+            ),
+            deploymentConfig = this::deploymentConfig,
         )
     }
 
@@ -58,6 +74,11 @@ class MessengerTransport(private val configuration: Configuration, private val t
      */
     @Throws(Exception::class)
     suspend fun fetchDeploymentConfig(): DeploymentConfig {
-        return DeploymentConfigUseCase(configuration.logging, configuration.deploymentConfigUrl.toString()).fetch()
+        return DeploymentConfigUseCase(
+            configuration.logging,
+            configuration.deploymentConfigUrl.toString(),
+        ).fetch().also {
+            deploymentConfig = it
+        }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -32,4 +32,9 @@ sealed class Event {
         val message: String?,
         val correctiveAction: CorrectiveAction,
     ) : Event()
+
+    /**
+     * This event indicates that the conversation was successfully autostarted.
+     */
+    object ConversationAutostart : Event()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.core.events
 import com.genesys.cloud.messenger.transport.core.toCorrectiveAction
 import com.genesys.cloud.messenger.transport.shyrka.receive.ErrorEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.HealthCheckEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.util.logs.Log
@@ -36,5 +37,6 @@ private fun StructuredMessageEvent.toTransportEvent(): Event {
             )
         }
         is HealthCheckEvent -> Event.HealthChecked
+        is PresenceEvent -> Event.ConversationAutostart
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -40,7 +40,11 @@ data class Conversations(
     val messagingEndpoint: String,
     val showAgentTypingIndicator: Boolean = false,
     val showUserTypingIndicator: Boolean = false,
-)
+    val autoStart: AutoStart = AutoStart(),
+) {
+    @Serializable
+    data class AutoStart(val enabled: Boolean = false)
+}
 
 @Serializable
 data class Styles(val primaryColor: String)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -20,6 +20,7 @@ internal sealed class StructuredMessageEvent {
         Typing,
         Error,
         HealthChecked,
+        Presence,
     }
 }
 
@@ -45,11 +46,21 @@ internal data class HealthCheckEvent(
     override val eventType: Type = Type.HealthChecked,
 ) : StructuredMessageEvent()
 
+@Serializable
+internal data class PresenceEvent(
+    override val eventType: Type,
+    val presence: Presence,
+) : StructuredMessageEvent() {
+    @Serializable
+    internal data class Presence(val type: String)
+}
+
 internal object StructuredMessageEventSerializer :
     JsonContentPolymorphicSerializer<StructuredMessageEvent>(StructuredMessageEvent::class) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out StructuredMessageEvent> {
         return when (element.jsonObject["eventType"]?.jsonPrimitive?.content) {
             Type.Typing.name -> TypingEvent.serializer()
+            Type.Presence.name -> PresenceEvent.serializer()
             else -> throw SerializationException("Unknown EventType: key 'eventType' not found or does not matches any known event type.")
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/AutoStartRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/AutoStartRequest.kt
@@ -1,0 +1,23 @@
+package com.genesys.cloud.messenger.transport.shyrka.send
+
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class AutoStartRequest(
+    override val token: String,
+) : WebMessagingRequest {
+    @Required
+    override val action: String = RequestAction.ON_MESSAGE.value
+    @Required
+    val message: EventMessage = EventMessage(
+        listOf(
+            PresenceEvent(
+                eventType = StructuredMessageEvent.Type.Presence,
+                presence = PresenceEvent.Presence(type = "Join"),
+            )
+        )
+    )
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -1,0 +1,34 @@
+package com.genesys.cloud.messenger.transport.shyrka.receive
+
+fun fakeDeploymentConfig() = DeploymentConfig(
+    id = "id",
+    version = "1",
+    languages = listOf("en-us", "zh-cn"),
+    defaultLanguage = "en-us",
+    apiEndpoint = "api_endpoint",
+    messenger = fakeMessenger,
+    journeyEvents = JourneyEvents(enabled = false),
+    status = DeploymentConfig.Status.Active,
+)
+
+private val fakeMessenger = Messenger(
+    enabled = true,
+    apps = Apps(
+        conversations = Conversations(
+            messagingEndpoint = "messaging_endpoint",
+            showAgentTypingIndicator = true,
+            showUserTypingIndicator = true,
+            autoStart = Conversations.AutoStart()
+        )
+    ),
+    styles = Styles(primaryColor = "red"),
+    launcherButton = LauncherButton(visibility = "On"),
+    fileUpload = FileUpload(
+        listOf(
+            Mode(
+                fileTypes = listOf("png"),
+                maxFileSizeKB = 100,
+            ),
+        )
+    )
+)

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -1,26 +1,23 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
-fun fakeDeploymentConfig() = DeploymentConfig(
+fun createDeploymentConfigForTesting(
+    messenger: Messenger = createMessengerVOForTesting()
+) = DeploymentConfig(
     id = "id",
     version = "1",
     languages = listOf("en-us", "zh-cn"),
     defaultLanguage = "en-us",
     apiEndpoint = "api_endpoint",
-    messenger = fakeMessenger,
+    messenger = messenger,
     journeyEvents = JourneyEvents(enabled = false),
     status = DeploymentConfig.Status.Active,
 )
 
-private val fakeMessenger = Messenger(
+fun createMessengerVOForTesting(
+    apps: Apps = Apps(createConversationsVOForTesting())
+) = Messenger(
     enabled = true,
-    apps = Apps(
-        conversations = Conversations(
-            messagingEndpoint = "messaging_endpoint",
-            showAgentTypingIndicator = true,
-            showUserTypingIndicator = true,
-            autoStart = Conversations.AutoStart()
-        )
-    ),
+    apps = apps,
     styles = Styles(primaryColor = "red"),
     launcherButton = LauncherButton(visibility = "On"),
     fileUpload = FileUpload(
@@ -31,4 +28,11 @@ private val fakeMessenger = Messenger(
             ),
         )
     )
+)
+
+fun createConversationsVOForTesting(
+    autoStart: Conversations.AutoStart = Conversations.AutoStart()
+): Conversations = Conversations(
+    messagingEndpoint = "messaging_endpoint",
+    autoStart = autoStart,
 )


### PR DESCRIPTION
- Add support to automatically start conversation. 
- Austostart request will be sent immediately after receiving Configure response with `newSession = true` AND`DeploymentConfig.autostart=true`.
- Upon autostart Messenger Transport will dispatch `Event.ConversationAutostart` to let UI know.
- DeploymentConfig are now cached in MessengerTransport and its getter is exposed to MessagingClient. 
- If at the moment of MessagingClient creation DeploymentConfig are null MessengerTransport will execute the fetchDeploymentConfig.
- Provide unit tests to cover newly added functionality. 