### PR TITLE
MTSDK-111 Update OnMessageRequest structure.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -46,7 +46,6 @@ internal class MessageStoreTest {
             assertEquals(expectedOnMessageRequest.token, token)
             assertEquals(expectedOnMessageRequest.message, message)
             assertNull(time)
-            assertNull(channel)
         }
 
         assertEquals(expectedMessage, subject.getConversation()[0])
@@ -324,15 +323,15 @@ internal class MessageStoreTest {
             givenToken,
             message = TextMessage(
                 "test message",
-                metadata = mapOf("customMessageId" to expectedMessage.id)
+                metadata = mapOf("customMessageId" to expectedMessage.id),
+                channel = Channel(Channel.Metadata(mapOf("A" to "B"))),
             ),
-            channel = Channel(Channel.Metadata(mapOf("A" to "B")))
         )
 
         subject.prepareMessage("test message", mapOf("A" to "B")).run {
             assertEquals(expectedOnMessageRequest.token, token)
             assertEquals(expectedOnMessageRequest.message, message)
-            assertEquals(expectedOnMessageRequest.channel, channel)
+            assertEquals(expectedOnMessageRequest.message.channel, message.channel)
             assertNull(time)
         }
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -516,13 +516,15 @@ class MessagingClientImplTest {
     @Test
     fun whenSendMessageWithCustomAttributes() {
         val expectedMessage =
-            """{"token":"00000000-0000-0000-0000-000000000000","message":{"text":"Hello world","type":"Text"},"channel":{"metadata":{"customAttributes":{"A":"B"}}},"action":"onMessage"}"""
+            """{"token":"00000000-0000-0000-0000-000000000000","message":{"text":"Hello world","channel":{"metadata":{"customAttributes":{"A":"B"}}},"type":"Text"},"action":"onMessage"}"""
         val expectedText = "Hello world"
         val expectedCustomAttributes = mapOf("A" to "B")
         every { mockMessageStore.prepareMessage(any(), any()) } returns OnMessageRequest(
             token = "00000000-0000-0000-0000-000000000000",
-            message = TextMessage("Hello world"),
-            channel = Channel(Metadata(expectedCustomAttributes)),
+            message = TextMessage(
+                text = "Hello world",
+                channel = Channel(Metadata(expectedCustomAttributes)),
+            ),
         )
         subject.connect()
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -40,9 +40,9 @@ internal class MessageStore(
             message = TextMessage(
                 text,
                 metadata = mapOf("customMessageId" to messageToSend.id),
-                content = messageToSend.getUploadedAttachments()
-            ),
-            channel = channel,
+                content = messageToSend.getUploadedAttachments(),
+                channel = channel,
+            )
         )
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
@@ -8,7 +8,6 @@ internal class OnMessageRequest(
     override val token: String,
     val message: TextMessage,
     val time: String? = null,
-    val channel: Channel? = null,
 ) : WebMessagingRequest {
     @Required override val action: String = RequestAction.ON_MESSAGE.value
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
@@ -8,7 +8,9 @@ import kotlinx.serialization.Serializable
 internal data class TextMessage(
     val text: String,
     val metadata: Map<String, String>? = null,
-    val content: List<Message.Content> = emptyList()
+    val content: List<Message.Content> = emptyList(),
+    val channel: Channel? = null,
 ) : BaseMessageProtocol {
-    @Required override val type = BaseMessageProtocol.Type.Text
+    @Required
+    override val type = BaseMessageProtocol.Type.Text
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -18,6 +18,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.TooManyRequestsError
 import com.genesys.cloud.messenger.transport.shyrka.receive.UploadFailureEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
+import com.genesys.cloud.messenger.transport.shyrka.send.Channel
 import com.genesys.cloud.messenger.transport.shyrka.send.ConfigureSessionRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.EchoRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.HealthCheckID
@@ -71,23 +72,25 @@ class SerializationTest {
         assertThat(encodedString, "encoded OnMessageRequest")
             .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","type":"Text"},"action":"onMessage"}""")
 
-        val messageWithAttachmentRequest = OnMessageRequest(
+        val messageWithAttachmentAndCustomAttributesRequest = OnMessageRequest(
             token = "<token>",
             message = TextMessage(
                 text = "Hello world", metadata = mapOf("id" to "aaa-bbb-ccc"),
                 content = listOf(
                     Message.Content(
                         contentType = Message.Content.Type.Attachment,
-                        attachment = Attachment("abcd-1234")
+                        attachment = Attachment("abcd-1234"),
                     )
-                )
+                ),
+                channel = Channel(Channel.Metadata(mapOf("A" to "B"))),
             ),
         )
 
-        encodedString = WebMessagingJson.json.encodeToString(messageWithAttachmentRequest)
+        encodedString =
+            WebMessagingJson.json.encodeToString(messageWithAttachmentAndCustomAttributesRequest)
 
-        assertThat(encodedString, "encoded OnMessageRequest with attachment")
-            .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"content":[{"contentType":"Attachment","attachment":{"id":"abcd-1234"}}],"type":"Text"},"action":"onMessage"}""")
+        assertThat(encodedString, "encoded OnMessageRequest with attachment and custom attributes")
+            .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"content":[{"contentType":"Attachment","attachment":{"id":"abcd-1234"}}],"channel":{"metadata":{"customAttributes":{"A":"B"}}},"type":"Text"},"action":"onMessage"}""")
     }
 
     @Test


### PR DESCRIPTION
According to API changes made on Shyrka, `channel` from OnMessageRequest should be nested inside `message`.

- Nest `channel` inside `TextMessage` according to Shyrka api changes.