### PR TITLE
MTSDK-109 Refactor IndicateTyping

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProviderTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProviderTest.kt
@@ -14,8 +14,15 @@ class UserTypingProviderTest {
     private val mockTimestampFunction: () -> Long = spyk<() -> Long>().also {
         every { it.invoke() } answers { Platform().epochMillis() }
     }
+    private val mockShowUserTypingIndicatorFunction: () -> Boolean = spyk<() -> Boolean>().also {
+        every { it.invoke() } returns true
+    }
 
-    private val subject = UserTypingProvider(mockk(relaxed = true), mockTimestampFunction)
+    private val subject = UserTypingProvider(
+        log = mockk(relaxed = true),
+        showUserTypingEnabled = mockShowUserTypingIndicatorFunction,
+        getCurrentTimestamp = mockTimestampFunction,
+    )
 
     @Test
     fun whenEncode() {
@@ -60,5 +67,14 @@ class UserTypingProviderTest {
 
         assertThat(firstResult).isEqualTo(expected)
         assertThat(secondResult).isEqualTo(expected)
+    }
+
+    @Test
+    fun whenEncodeAndShowUserTypingIsDisabled() {
+        every { mockShowUserTypingIndicatorFunction.invoke() } returns false
+
+        val result = subject.encodeRequest("00000000-0000-0000-0000-000000000000")
+
+        assertThat(result).isNull()
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -49,14 +49,18 @@ internal class MessagingClientImpl(
     private val log: Log,
     private val jwtHandler: JwtHandler,
     private val token: String,
+    private val deploymentConfig: KProperty0<DeploymentConfig?>,
     private val attachmentHandler: AttachmentHandler,
     private val messageStore: MessageStore,
     private val reconnectionHandler: ReconnectionHandler,
     private val stateMachine: StateMachine = StateMachineImpl(log.withTag(LogTag.STATE_MACHINE)),
     private val eventHandler: EventHandler = EventHandlerImpl(log.withTag(LogTag.EVENT_HANDLER)),
-    private val userTypingProvider: UserTypingProvider = UserTypingProvider(log.withTag(LogTag.TYPING_INDICATOR_PROVIDER)),
     private val healthCheckProvider: HealthCheckProvider = HealthCheckProvider(log.withTag(LogTag.HEALTH_CHECK_PROVIDER)),
-    private val deploymentConfig: KProperty0<DeploymentConfig?>,
+    private val userTypingProvider: UserTypingProvider =
+        UserTypingProvider(
+            log.withTag(LogTag.TYPING_INDICATOR_PROVIDER),
+            { deploymentConfig.isShowUserTypingEnabled() },
+        ),
 ) : MessagingClient {
 
     override val currentState: State
@@ -386,3 +390,6 @@ internal class MessagingClientImpl(
 
 private fun KProperty0<DeploymentConfig?>.isAutostartEnabled(): Boolean =
     this.get()?.messenger?.apps?.conversations?.autoStart?.enabled == true
+
+private fun KProperty0<DeploymentConfig?>.isShowUserTypingEnabled(): Boolean =
+    this.get()?.messenger?.apps?.conversations?.showUserTypingIndicator == true

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/UserTypingProvider.kt
@@ -8,19 +8,28 @@ import kotlinx.serialization.encodeToString
 
 private const val TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND = 5000L
 
-internal class UserTypingProvider(val log: Log, val getCurrentTimestamp: () -> Long = { Platform().epochMillis() }) {
+internal class UserTypingProvider(
+    private val log: Log,
+    private val showUserTypingEnabled: () -> Boolean,
+    private val getCurrentTimestamp: () -> Long = { Platform().epochMillis() },
+) {
     private var lastSentUserTypingTimestamp = 0L
 
     @Throws(Exception::class)
     fun encodeRequest(token: String): String? {
-        val currentTimestamp = getCurrentTimestamp()
-        val delta = currentTimestamp - lastSentUserTypingTimestamp
-        return if (delta > TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND) {
-            lastSentUserTypingTimestamp = currentTimestamp
-            val request = UserTypingRequest(token = token)
-            WebMessagingJson.json.encodeToString(request)
+        return if (showUserTypingEnabled()) {
+            val currentTimestamp = getCurrentTimestamp()
+            val delta = currentTimestamp - lastSentUserTypingTimestamp
+            if (delta > TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND) {
+                lastSentUserTypingTimestamp = currentTimestamp
+                val request = UserTypingRequest(token = token)
+                WebMessagingJson.json.encodeToString(request)
+            } else {
+                log.w { "Typing event can be sent only once every $TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND milliseconds." }
+                null
+            }
         } else {
-            log.w { "Typing event can be sent only once every $TYPING_INDICATOR_COOL_DOWN_IN_MILLISECOND milliseconds." }
+            log.w { "typing indicator is disabled." }
             null
         }
     }


### PR DESCRIPTION
- Rely on `deploymentConfig.showUserTypingIndicator` when decide about sending UserTyping request.
- Add/Update unit tests.