### PR TITLE
Feature/mtsdk 108 access denied

### DIFF
--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.network
 
+import com.genesys.cloud.messenger.transport.core.ErrorCode
 import com.genesys.cloud.messenger.transport.core.ErrorMessage
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.okHttpLogger
@@ -37,7 +38,10 @@ internal actual class PlatformSocket actual constructor(
             object : okhttp3.WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) = listener.onOpen()
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
-                    listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t))
+                    when (response?.code) {
+                        403 -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t), ErrorCode.WebsocketHandshakeFailure)
+                        else -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t))
+                    }
 
                 override fun onMessage(webSocket: WebSocket, text: String) =
                     listener.onMessage(text)

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -39,7 +39,7 @@ internal actual class PlatformSocket actual constructor(
                 override fun onOpen(webSocket: WebSocket, response: Response) = listener.onOpen()
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
                     when (response?.code) {
-                        403 -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t), ErrorCode.WebsocketAccessDenied)
+                        403 -> listener.onFailure(Throwable(response.message, t), ErrorCode.WebsocketAccessDenied)
                         else -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t))
                     }
 

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -39,7 +39,7 @@ internal actual class PlatformSocket actual constructor(
                 override fun onOpen(webSocket: WebSocket, response: Response) = listener.onOpen()
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) =
                     when (response?.code) {
-                        403 -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t), ErrorCode.WebsocketHandshakeFailure)
+                        403 -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t), ErrorCode.WebsocketAccessDenied)
                         else -> listener.onFailure(Throwable(ErrorMessage.FailedToReconnect, t))
                     }
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCodeTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCodeTest.kt
@@ -26,6 +26,8 @@ internal class ErrorCodeTest {
         assertTrue(ErrorCode.mapFrom(4029) is ErrorCode.RequestRateTooHigh)
         assertTrue(ErrorCode.mapFrom(5000) is ErrorCode.UnexpectedError)
         assertTrue(ErrorCode.mapFrom(1001) is ErrorCode.WebsocketError)
+        assertTrue(ErrorCode.mapFrom(1002) is ErrorCode.WebsocketAccessDenied)
+        assertTrue(ErrorCode.mapFrom(-1009) is ErrorCode.NetworkDisabled)
         val randomIn300Range = Random.nextInt(300, 400)
         assertEquals(
             ErrorCode.mapFrom(randomIn300Range),

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -21,6 +21,7 @@ sealed class ErrorCode(val code: Int) {
     object RequestRateTooHigh : ErrorCode(4029)
     object UnexpectedError : ErrorCode(5000)
     object WebsocketError : ErrorCode(1001)
+    object WebsocketHandshakeFailure : ErrorCode(1002)
     object NetworkDisabled : ErrorCode(-1009)
     data class RedirectResponseError(val value: Int) : ErrorCode(value)
     data class ClientResponseError(val value: Int) : ErrorCode(value)
@@ -30,6 +31,7 @@ sealed class ErrorCode(val code: Int) {
         fun mapFrom(value: Int): ErrorCode {
             return when (value) {
                 1001 -> WebsocketError
+                1002 -> WebsocketHandshakeFailure
                 4000 -> FeatureUnavailable
                 4001 -> FileTypeInvalid
                 4002 -> FileSizeInvalid
@@ -48,6 +50,7 @@ sealed class ErrorCode(val code: Int) {
                 in 300..399 -> RedirectResponseError(value)
                 in 400..499 -> ClientResponseError(value)
                 in 500..599 -> ServerResponseError(value)
+                -1009 -> NetworkDisabled
                 else -> UnexpectedError
             }
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -21,7 +21,7 @@ sealed class ErrorCode(val code: Int) {
     object RequestRateTooHigh : ErrorCode(4029)
     object UnexpectedError : ErrorCode(5000)
     object WebsocketError : ErrorCode(1001)
-    object WebsocketHandshakeFailure : ErrorCode(1002)
+    object WebsocketAccessDenied : ErrorCode(1002)
     object NetworkDisabled : ErrorCode(-1009)
     data class RedirectResponseError(val value: Int) : ErrorCode(value)
     data class ClientResponseError(val value: Int) : ErrorCode(value)
@@ -31,7 +31,7 @@ sealed class ErrorCode(val code: Int) {
         fun mapFrom(value: Int): ErrorCode {
             return when (value) {
                 1001 -> WebsocketError
-                1002 -> WebsocketHandshakeFailure
+                1002 -> WebsocketAccessDenied
                 4000 -> FeatureUnavailable
                 4001 -> FileTypeInvalid
                 4002 -> FileSizeInvalid
@@ -65,7 +65,9 @@ object ErrorMessage {
 
 sealed class CorrectiveAction(val message: String) {
     object BadRequest : CorrectiveAction("Refer to the error details.")
-    object Forbidden : CorrectiveAction("Turn on the Feature Toggle or fix the configuration.")
+    object Forbidden :
+        CorrectiveAction("Access was refused. Check that your deploymentId, feature toggles, and configuration are correct.")
+
     object NotFound :
         CorrectiveAction("An object referenced in the request was not found, pass an id that exists.")
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -53,8 +53,8 @@ interface MessagingClient {
         /**
          * In case of fatal, unrecoverable errors MessagingClient will transition to this state.
          *
-         * @property code the [ErrorCode.WebsocketError] for websocket errors.
-         * @property message is an optional message.
+         * @property code the [ErrorCode] representing the reason for the failure.
+         * @property message an optional message describing the error.
          */
         data class Error(val code: ErrorCode, val message: String?) : State()
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -257,6 +257,14 @@ internal class MessagingClientImpl(
                     reconnectionHandler.clear()
                 }
             }
+            is ErrorCode.WebsocketHandshakeFailure -> {
+                stateMachine.onError(
+                    errorCode,
+                    "Server handshake failed. Please check your deploymentId."
+                )
+                attachmentHandler.clearAll()
+                reconnectionHandler.clear()
+            }
             is ErrorCode.NetworkDisabled -> {
                 stateMachine.onError(errorCode, ErrorMessage.InternetConnectionIsOffline)
                 attachmentHandler.clearAll()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -257,11 +257,8 @@ internal class MessagingClientImpl(
                     reconnectionHandler.clear()
                 }
             }
-            is ErrorCode.WebsocketHandshakeFailure -> {
-                stateMachine.onError(
-                    errorCode,
-                    "Server handshake failed. Please check your deploymentId."
-                )
+            is ErrorCode.WebsocketAccessDenied -> {
+                stateMachine.onError(errorCode, CorrectiveAction.Forbidden.message)
                 attachmentHandler.clearAll()
                 reconnectionHandler.clear()
             }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -198,7 +198,7 @@ private fun NSError.toTransportErrorCode(): ErrorCode =
         NSURLErrorNotConnectedToInternet -> ErrorCode.NetworkDisabled
         NSURLErrorBadServerResponse -> {
             if (this.userInfo.containsKey("_NSURLErrorWebSocketHandshakeFailureReasonKey")) {
-                ErrorCode.WebsocketHandshakeFailure
+                ErrorCode.WebsocketAccessDenied
             } else {
                 ErrorCode.WebsocketError
             }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -13,6 +13,8 @@ import platform.Foundation.NSOperationQueue
 import platform.Foundation.NSPOSIXErrorDomain
 import platform.Foundation.NSTimer
 import platform.Foundation.NSURL
+import platform.Foundation.NSURLErrorBadServerResponse
+import platform.Foundation.NSURLErrorNotConnectedToInternet
 import platform.Foundation.NSURLSession
 import platform.Foundation.NSURLSessionConfiguration
 import platform.Foundation.NSURLSessionWebSocketCloseCode
@@ -100,7 +102,7 @@ internal actual class PlatformSocket actual constructor(
         webSocket?.receiveMessageWithCompletionHandler { message, nsError ->
             when {
                 nsError != null -> {
-                    log.e { "receiveMessageWithCompletionHandler: error: ${nsError.localizedDescription}" }
+                    log.e { "receiveMessageWithCompletionHandler error [${nsError.code}] ${nsError.localizedDescription}" }
                     handleError(
                         nsError, "Receive handler error"
                     )
@@ -177,22 +179,32 @@ internal actual class PlatformSocket actual constructor(
     }
 
     private fun handleError(error: NSError, context: String? = null) {
-        log.e { "${context ?: "NSError"}. [${error.code}] ${error.localizedDescription}" }
+        log.e { "handleError (${context ?: "no context"}) [${error.code}] $error" }
         if (active) {
             deactivateAndCancelWebSocket(
                 SocketCloseCode.GOING_AWAY.value,
                 "Closing due to error code ${error.code}"
             )
             listener?.onFailure(
-                Throwable(error.localizedDescription),
-                error.code.toTransportErrorCode()
+                Throwable("[${error.code}] ${error.localizedDescription}"),
+                error.toTransportErrorCode()
             )
         }
     }
 }
 
-private fun Long.toTransportErrorCode(): ErrorCode =
-    if (this.toInt() == ErrorCode.NetworkDisabled.code) ErrorCode.NetworkDisabled else ErrorCode.WebsocketError
+private fun NSError.toTransportErrorCode(): ErrorCode =
+    when (this.code) {
+        NSURLErrorNotConnectedToInternet -> ErrorCode.NetworkDisabled
+        NSURLErrorBadServerResponse -> {
+            if (this.userInfo.containsKey("_NSURLErrorWebSocketHandshakeFailureReasonKey")) {
+                ErrorCode.WebsocketHandshakeFailure
+            } else {
+                ErrorCode.WebsocketError
+            }
+        }
+        else -> ErrorCode.WebsocketError
+    }
 
 internal fun NSTimer?.isScheduled(): Boolean {
     return this?.valid ?: false


### PR DESCRIPTION
With this PR I'm trying to commonize how the Android and iOS websockets deal with a the failure to open a connection if they supply an invalid deploymentId. Sadly, they don't respond the same way if the service forbids access.

On Android, okhttp returns a `403` error with a message "User is not authorized to access this resource with an explicit deny".

On iOS, the Apple websocket returns a error code `-1011` (`NSURLErrorBadServerResponse`) and I discovered a key in the associated `userInfo` dictionary called `_NSURLErrorWebSocketHandshakeFailureReasonKey` which I further used to constrain things.

Now, in these situations the PlatformSocket actuals will fail with a new `ErrorCode.WebsocketAccessDenied` error which the `MessagingClientImpl` can handle similarly to `ErrorCode.NetworkDisabled` and not trigger the reconnection logic and go straight to an error state.