### PR TITLE
MTSDK-129 Events in history.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -7,9 +7,12 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses.isoTestTimestamp
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.fromIsoToEpochMilliseconds
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
@@ -36,6 +39,7 @@ internal class MessageExtensionTest {
             type = "Text",
             text = "customer msg 7",
             timeStamp = null,
+            events = listOf(Event.ConversationAutostart),
         )
 
         val result = TestWebMessagingApiResponses.testMessageEntityList.toMessageList()
@@ -62,7 +66,13 @@ internal class MessageExtensionTest {
                 )
             ),
             direction = "Inbound",
-            metadata = mapOf("customMessageId" to "test custom id")
+            metadata = mapOf("customMessageId" to "test custom id"),
+            events = listOf(
+                PresenceEvent(
+                    eventType = StructuredMessageEvent.Type.Presence,
+                    presence = PresenceEvent.Presence("Join")
+                )
+            )
         )
         val expectedMessage =
             Message(
@@ -78,7 +88,8 @@ internal class MessageExtensionTest {
                         fileName = "test.png",
                         state = Attachment.State.Sent("http://test.com")
                     )
-                )
+                ),
+                events = listOf<Event>(Event.ConversationAutostart)
             )
 
         assertThat(givenStructuredMessage.toMessage()).isEqualTo(expectedMessage)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.core
 
+import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.util.Platform
 import kotlinx.serialization.Serializable
 
@@ -13,6 +14,7 @@ import kotlinx.serialization.Serializable
  *  @property text the text payload of the message.
  *  @property timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
  *  @property attachments a map of [Attachment] files to the message. Empty by default.
+ *  @property events a list of events related to this message. Empty by default.
  */
 @Serializable
 data class Message(
@@ -23,6 +25,7 @@ data class Message(
     val text: String? = null,
     val timeStamp: Long? = null,
     val attachments: Map<String, Attachment> = emptyMap(),
+    val events: List<Event> = emptyList(),
 ) {
     /**
      * Direction of the message.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -6,6 +6,7 @@ import com.genesys.cloud.messenger.transport.core.ErrorCode
 /**
  * Base class for Transport events.
  */
+@kotlinx.serialization.Serializable
 sealed class Event {
     /**
      *  This event indicates that the agent has begun typing a message.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -25,7 +25,7 @@ internal class EventHandlerImpl(
     }
 }
 
-private fun StructuredMessageEvent.toTransportEvent(): Event {
+internal fun StructuredMessageEvent.toTransportEvent(): Event {
     return when (this) {
         is TypingEvent -> {
             Event.AgentTyping(typing.duration ?: FALLBACK_TYPING_INDICATOR_DURATION)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.util.extensions
 import com.genesys.cloud.messenger.transport.core.Attachment
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
+import com.genesys.cloud.messenger.transport.core.events.toTransportEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.soywiz.klock.DateTime
@@ -21,7 +22,8 @@ internal fun StructuredMessage.toMessage(): Message {
         type = this.type.name,
         text = this.text,
         timeStamp = this.channel?.time.fromIsoToEpochMilliseconds(),
-        attachments = this.content.toAttachments()
+        attachments = this.content.toAttachments(),
+        events = events.map { it.toTransportEvent() },
     )
 }
 

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
@@ -9,14 +9,16 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.LauncherButton
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.Messenger
 import com.genesys.cloud.messenger.transport.shyrka.receive.Mode
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.Styles
 
 object TestWebMessagingApiResponses {
 
     internal const val isoTestTimestamp = "2014-04-30T21:09:51.411Z"
     internal const val messageEntityResponseWith2Messages =
-        """{"entities":[{"id":"5befde6373a23f32f20b59b4e1cba0e6","channel":{"time":"$isoTestTimestamp"},"type":"Text","text":"\uD83E\uDD2A","content":[],"direction":"Outbound"},{"id":"46e7001c24abed05e9bcd1a006eb54b7","channel":{"time":null},"type":"Text","metadata":{"customMessageId":"1234567890"},"text":"customer msg 7","content":[],"direction":"Inbound"}],"pageSize":25,"pageNumber":1, "total": 2, "pageCount": 1}"""
+        """{"entities":[{"id":"5befde6373a23f32f20b59b4e1cba0e6","channel":{"time":"$isoTestTimestamp"},"type":"Text","text":"\uD83E\uDD2A","content":[],"direction":"Outbound"},{"id":"46e7001c24abed05e9bcd1a006eb54b7","channel":{"time":null},"type":"Text","events":[{"eventType":"Presence","presence":{"type":"Join"}}],"metadata":{"customMessageId":"1234567890"},"text":"customer msg 7","content":[],"direction":"Inbound"}],"pageSize":25,"pageNumber":1, "total": 2, "pageCount": 1}"""
 
     internal const val messageEntityListResponseWithoutMessages =
         """{"entities":[],"pageSize":0,"pageNumber":1, "total": 0, "pageCount": 0}"""
@@ -77,6 +79,12 @@ object TestWebMessagingApiResponses {
                 time = null,
                 text = "customer msg 7",
                 customMessageId = "1234567890",
+                events = listOf(
+                    PresenceEvent(
+                        eventType = StructuredMessageEvent.Type.Presence,
+                        presence = PresenceEvent.Presence("Join")
+                    )
+                )
             )
         )
 
@@ -86,6 +94,7 @@ object TestWebMessagingApiResponses {
         text: String,
         isInbound: Boolean = true,
         customMessageId: String? = null,
+        events: List<StructuredMessageEvent> = emptyList(),
     ): StructuredMessage {
         return StructuredMessage(
             id = id,
@@ -94,7 +103,8 @@ object TestWebMessagingApiResponses {
             text = text,
             content = emptyList(),
             direction = if (isInbound) "Inbound" else "Outbound",
-            metadata = if (customMessageId != null) mapOf("customMessageId" to customMessageId) else emptyMap()
+            metadata = if (customMessageId != null) mapOf("customMessageId" to customMessageId) else emptyMap(),
+            events = events,
         )
     }
 }


### PR DESCRIPTION
Some events like `Presence`, `Quick Reply` and more can be included in history transcript along with conventional text messages. This pr is to ensure the history response contains those events.

- Allow adding event information to the history.
- Update KDoc to include events documentation.
- Update unit tests.