### PR TITLE
remove iOS 13 checks: transport min version is 13

### DIFF
--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -3,30 +3,21 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    var window: UIWindow? // necessary for iOS versions < 13.0, prior to SceneDelegate
     let deployment = try! Deployment()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-        guard #available(iOS 13.0, *) else {
-            self.window = UIWindow(frame: UIScreen.main.bounds)
-            window?.rootViewController = ContentViewController(deployment: deployment)
-            window?.makeKeyAndVisible()
-            return true
-        }
-        return true
+        true
     }
 
     // MARK: UISceneSession Lifecycle
 
-    @available(iOS 13.0, *)
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+        UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
 
-    @available(iOS 13.0, *)
     func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.

--- a/iosApp/iosApp/SceneDelegate.swift
+++ b/iosApp/iosApp/SceneDelegate.swift
@@ -1,7 +1,5 @@
 import UIKit
-import SwiftUI
 
-@available(iOS 13.0, *)
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?


### PR DESCRIPTION
The min supported version of the iOS Messenger Transport xcframework is 13.0, so the checks in the iosApp testbed app for earlier iOS versions can be dropped.