### PR TITLE
Feature/mtsdk 131 ios testbed refactoring

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -20,8 +20,8 @@
 		8C4A6A23273C696C008B8150 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A6A22273C696C008B8150 /* Deployment.swift */; };
 		8CF6294F27074EB400AE0CA8 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */; };
 		8CF62953270754C000AE0CA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF80242A565900829871 /* SceneDelegate.swift */; };
-		BA5B8CD428CA2FEC007C8160 /* TestContentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */; };
-		BA88FE14284953CA009AA1F8 /* MessengerHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE13284953CA009AA1F8 /* MessengerHandler.swift */; };
+		BA5B8CD428CA2FEC007C8160 /* MessengerInteractorTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */; };
+		BA88FE14284953CA009AA1F8 /* MessengerInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */; };
 		BA88FE16284A54E7009AA1F8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = BA88FE15284A54E6009AA1F8 /* config.json */; };
 		BA88FE22284A5501009AA1F8 /* TestConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE18284A5501009AA1F8 /* TestConfig.swift */; };
 		BA88FE24284A5501009AA1F8 /* testPng.png in Resources */ = {isa = PBXBuildFile; fileRef = BA88FE1B284A5501009AA1F8 /* testPng.png */; };
@@ -72,8 +72,8 @@
 		8C4A6A19273C3CD8008B8150 /* deployment.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = deployment.properties; path = ../../deployment.properties; sourceTree = "<group>"; };
 		8C4A6A22273C696C008B8150 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
 		8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
-		BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestContentController.swift; sourceTree = "<group>"; };
-		BA88FE13284953CA009AA1F8 /* MessengerHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerHandler.swift; sourceTree = "<group>"; };
+		BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractorTester.swift; sourceTree = "<group>"; };
+		BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractor.swift; sourceTree = "<group>"; };
 		BA88FE15284A54E6009AA1F8 /* config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config.json; sourceTree = "<group>"; };
 		BA88FE18284A5501009AA1F8 /* TestConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestConfig.swift; sourceTree = "<group>"; };
 		BA88FE1B284A5501009AA1F8 /* testPng.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = testPng.png; sourceTree = "<group>"; };
@@ -165,7 +165,7 @@
 				8C4A6A19273C3CD8008B8150 /* deployment.properties */,
 				7555FF7E242A565900829871 /* AppDelegate.swift */,
 				8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */,
-				BA88FE13284953CA009AA1F8 /* MessengerHandler.swift */,
+				BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */,
 				8C4A6A22273C696C008B8150 /* Deployment.swift */,
 				8C3B25292926EAC500599F72 /* PropertiesResource.swift */,
 				6ADDAC5226A09D23004D2C9B /* NSData+ByteArray.swift */,
@@ -214,7 +214,7 @@
 				BA88FE1C284A5501009AA1F8 /* ConversationInfo.swift */,
 				BA88FE1D284A5501009AA1F8 /* extensions.swift */,
 				BA88FE2A284A57E2009AA1F8 /* WaitHandler.swift */,
-				BA5B8CD328CA2FEC007C8160 /* TestContentController.swift */,
+				BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -421,7 +421,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
-				BA88FE14284953CA009AA1F8 /* MessengerHandler.swift in Sources */,
+				BA88FE14284953CA009AA1F8 /* MessengerInteractor.swift in Sources */,
 				8C3B252A2926EAC500599F72 /* PropertiesResource.swift in Sources */,
 				8CF6294F27074EB400AE0CA8 /* ContentViewController.swift in Sources */,
 				6ADDAC5326A09D23004D2C9B /* NSData+ByteArray.swift in Sources */,
@@ -442,7 +442,7 @@
 				7555FF96242A565B00829871 /* iosAppTests.swift in Sources */,
 				BA88FE22284A5501009AA1F8 /* TestConfig.swift in Sources */,
 				BA88FE2B284A57E2009AA1F8 /* WaitHandler.swift in Sources */,
-				BA5B8CD428CA2FEC007C8160 /* TestContentController.swift in Sources */,
+				BA5B8CD428CA2FEC007C8160 /* MessengerInteractorTester.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -18,7 +18,7 @@
 		8C3B252A2926EAC500599F72 /* PropertiesResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3B25292926EAC500599F72 /* PropertiesResource.swift */; };
 		8C4A6A1A273C3CD8008B8150 /* deployment.properties in Resources */ = {isa = PBXBuildFile; fileRef = 8C4A6A19273C3CD8008B8150 /* deployment.properties */; };
 		8C4A6A23273C696C008B8150 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A6A22273C696C008B8150 /* Deployment.swift */; };
-		8CF6294F27074EB400AE0CA8 /* ContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */; };
+		8CF6294F27074EB400AE0CA8 /* TestbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6294E27074EB400AE0CA8 /* TestbedViewController.swift */; };
 		8CF62953270754C000AE0CA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF80242A565900829871 /* SceneDelegate.swift */; };
 		BA5B8CD428CA2FEC007C8160 /* MessengerInteractorTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */; };
 		BA88FE14284953CA009AA1F8 /* MessengerInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */; };
@@ -71,7 +71,7 @@
 		8C3B25292926EAC500599F72 /* PropertiesResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesResource.swift; sourceTree = "<group>"; };
 		8C4A6A19273C3CD8008B8150 /* deployment.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = deployment.properties; path = ../../deployment.properties; sourceTree = "<group>"; };
 		8C4A6A22273C696C008B8150 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
-		8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewController.swift; sourceTree = "<group>"; };
+		8CF6294E27074EB400AE0CA8 /* TestbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestbedViewController.swift; sourceTree = "<group>"; };
 		BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractorTester.swift; sourceTree = "<group>"; };
 		BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractor.swift; sourceTree = "<group>"; };
 		BA88FE15284A54E6009AA1F8 /* config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config.json; sourceTree = "<group>"; };
@@ -164,7 +164,7 @@
 				7555FF8C242A565B00829871 /* Info.plist */,
 				8C4A6A19273C3CD8008B8150 /* deployment.properties */,
 				7555FF7E242A565900829871 /* AppDelegate.swift */,
-				8CF6294E27074EB400AE0CA8 /* ContentViewController.swift */,
+				8CF6294E27074EB400AE0CA8 /* TestbedViewController.swift */,
 				BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */,
 				8C4A6A22273C696C008B8150 /* Deployment.swift */,
 				8C3B25292926EAC500599F72 /* PropertiesResource.swift */,
@@ -423,7 +423,7 @@
 				7555FF7F242A565900829871 /* AppDelegate.swift in Sources */,
 				BA88FE14284953CA009AA1F8 /* MessengerInteractor.swift in Sources */,
 				8C3B252A2926EAC500599F72 /* PropertiesResource.swift in Sources */,
-				8CF6294F27074EB400AE0CA8 /* ContentViewController.swift in Sources */,
+				8CF6294F27074EB400AE0CA8 /* TestbedViewController.swift in Sources */,
 				6ADDAC5326A09D23004D2C9B /* NSData+ByteArray.swift in Sources */,
 				8C4A6A23273C696C008B8150 /* Deployment.swift in Sources */,
 				8CF62953270754C000AE0CA8 /* SceneDelegate.swift in Sources */,

--- a/iosApp/iosApp/AppDelegate.swift
+++ b/iosApp/iosApp/AppDelegate.swift
@@ -4,6 +4,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     let deployment = try! Deployment()
+    lazy private(set) var messenger = MessengerInteractor(deployment: deployment)
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/iosApp/iosApp/ContentViewController.swift
+++ b/iosApp/iosApp/ContentViewController.swift
@@ -8,83 +8,20 @@
 
 import UIKit
 import MessengerTransport
+import Combine
 
 class ContentViewController: UIViewController {
 
-    let messenger: MessengerHandler
+    private let messenger: MessengerInteractor
     private var attachImageName = ""
     private let attachmentName = "image"
     private var byteArray: [UInt8]? = nil
-    var customAttributes: [String: String] = [:]
-
-    init(deployment: Deployment) {
-        self.messenger = MessengerHandler(deployment: deployment)
-        
+    private var customAttributes: [String: String] = [:]
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(messenger: MessengerInteractor) {
+        self.messenger = messenger
         super.init(nibName: nil, bundle: nil)
-        
-        // set up MessengerHandler callbacks
-        
-        messenger.onStateChange = { [weak self] stateChange in
-            let newState = stateChange.newState
-            var stateMessage = "\(newState)"
-            switch newState {
-            case is MessagingClientState.Connecting:
-                stateMessage = "Connecting"
-            case is MessagingClientState.Connected:
-                stateMessage = "Connected"
-            case let configured as MessagingClientState.Configured:
-                stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState is MessagingClientState.Reconnecting)"
-            case let closing as MessagingClientState.Closing:
-                stateMessage = "Closing, code=\(closing.code) reason=\(closing.reason)"
-            case let closed as MessagingClientState.Closed:
-                stateMessage = "Closed, code=\(closed.code) reason=\(closed.reason)"
-            case let error as MessagingClientState.Error:
-                stateMessage = "Error, code=\(error.code) message=\(error.message?.description ?? "nil")"
-            case is MessagingClientState.Reconnecting:
-                stateMessage = "Reconnecting"
-            default:
-                break
-            }
-            self?.status.text = "Messenger Status: " + stateMessage
-            self?.info.text = "State changed from \(stateChange.oldState) to \(newState)"
-        }
-        
-        messenger.onMessageEvent = { [weak self] message in
-            var displayMessage = "Unexpected message event: \(message)"
-            switch message {
-            case let messageInserted as MessageEvent.MessageInserted:
-                displayMessage = "Message Inserted: \(messageInserted.message.description)"
-            case let messageUpdated as MessageEvent.MessageUpdated:
-                displayMessage = "Message Updated: \(messageUpdated.message.description)"
-            case let attachmentUpdated as MessageEvent.AttachmentUpdated:
-                displayMessage = "Attachment Updated: \(attachmentUpdated.attachment.description)"
-            case let history as MessageEvent.HistoryFetched:
-                displayMessage = "History Fetched: startOfConversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)> "
-                print(displayMessage)
-            default:
-                break
-            }
-            self?.info.text = displayMessage
-        }
-        
-        messenger.onEvent = { [weak self] event in
-            var displayEvent = "Unexpected event: \(event)"
-            switch event {
-            case let typing as Event.AgentTyping:
-                displayEvent = "Event received: \(typing.description)"
-            case let error as Event.Error:
-                displayEvent = "Event received: \(error.description)"
-            case let healthChecked as Event.HealthChecked:
-                displayEvent = "Event received: \(healthChecked.description)"
-            case let conversationAutostart as Event.ConversationAutostart:
-                displayEvent = "Event received: \(conversationAutostart.description)"
-            case let connectionClosed as Event.ConnectionClosed:
-                displayEvent = "Event received: \(connectionClosed.description)"
-            default:
-                break
-            }
-            self?.info.text = displayEvent
-        }
     }
 
     required init?(coder: NSCoder) {
@@ -189,12 +126,85 @@ class ContentViewController: UIViewController {
         configureAutoLayout()
         
         observeKeyboard()
+        
+        // Subscribe to MessengerInteractor Subjects
+        messenger.stateChangeSubject
+            .sink(receiveValue: updateWithStateChange)
+            .store(in: &cancellables)
+        messenger.messageEventSubject
+            .sink(receiveValue: updateWithMessageEvent)
+            .store(in: &cancellables)
+        messenger.eventSubject
+            .sink(receiveValue: updateWithEvent)
+            .store(in: &cancellables)
     }
     
     private func configureAutoLayout() {
         content.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
         content.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
         content.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+    }
+    
+    private func updateWithStateChange(_ stateChange: StateChange) {
+        let newState = stateChange.newState
+        var stateMessage = "\(newState)"
+        switch newState {
+        case is MessagingClientState.Connecting:
+            stateMessage = "Connecting"
+        case is MessagingClientState.Connected:
+            stateMessage = "Connected"
+        case let configured as MessagingClientState.Configured:
+            stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState is MessagingClientState.Reconnecting)"
+        case let closing as MessagingClientState.Closing:
+            stateMessage = "Closing, code=\(closing.code) reason=\(closing.reason)"
+        case let closed as MessagingClientState.Closed:
+            stateMessage = "Closed, code=\(closed.code) reason=\(closed.reason)"
+        case let error as MessagingClientState.Error:
+            stateMessage = "Error, code=\(error.code) message=\(error.message?.description ?? "nil")"
+        case is MessagingClientState.Reconnecting:
+            stateMessage = "Reconnecting"
+        default:
+            break
+        }
+        status.text = "Messenger Status: " + stateMessage
+        info.text = "State changed from \(stateChange.oldState) to \(newState)"
+    }
+    
+    private func updateWithMessageEvent(_ message: MessageEvent) {
+        var displayMessage = "Unexpected message event: \(message)"
+        switch message {
+        case let messageInserted as MessageEvent.MessageInserted:
+            displayMessage = "Message Inserted: \(messageInserted.message.description)"
+        case let messageUpdated as MessageEvent.MessageUpdated:
+            displayMessage = "Message Updated: \(messageUpdated.message.description)"
+        case let attachmentUpdated as MessageEvent.AttachmentUpdated:
+            displayMessage = "Attachment Updated: \(attachmentUpdated.attachment.description)"
+        case let history as MessageEvent.HistoryFetched:
+            displayMessage = "History Fetched: startOfConversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)> "
+            print(displayMessage)
+        default:
+            break
+        }
+        info.text = displayMessage
+    }
+    
+    private func updateWithEvent(_ event: Event) {
+        var displayEvent = "Unexpected event: \(event)"
+        switch event {
+        case let typing as Event.AgentTyping:
+            displayEvent = "Event received: \(typing.description)"
+        case let error as Event.Error:
+            displayEvent = "Event received: \(error.description)"
+        case let healthChecked as Event.HealthChecked:
+            displayEvent = "Event received: \(healthChecked.description)"
+        case let conversationAutostart as Event.ConversationAutostart:
+            displayEvent = "Event received: \(conversationAutostart.description)"
+        case let connectionClosed as Event.ConnectionClosed:
+            displayEvent = "Event received: \(connectionClosed.description)"
+        default:
+            break
+        }
+        info.text = displayEvent
     }
         
     private func observeKeyboard() {

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -10,7 +10,7 @@ import Foundation
 import MessengerTransport
 import Combine
 
-class MessengerInteractor {
+final class MessengerInteractor {
 
     let configuration: Configuration
     let messengerTransport: MessengerTransport

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -1,5 +1,5 @@
 //
-//  MessengerHandler.swift
+//  MessengerInteractor.swift
 //  iosApp
 //
 //  Created by Morehouse, Matthew on 6/2/22.
@@ -8,45 +8,43 @@
 
 import Foundation
 import MessengerTransport
-import UIKit
+import Combine
 
-class MessengerHandler {
+class MessengerInteractor {
 
-    private let deployment: Deployment
-    private let config: Configuration
+    let configuration: Configuration
     let messengerTransport: MessengerTransport
-    let client: MessagingClient
+    let messagingClient: MessagingClient
     
-    public var onStateChange: ((StateChange) -> Void)?
-    public var onMessageEvent: ((MessageEvent) -> Void)?
-    public var onEvent: ((Event) -> Void)?
-    
+    let stateChangeSubject = PassthroughSubject<StateChange, Never>()
+    let messageEventSubject = PassthroughSubject<MessageEvent, Never>()
+    let eventSubject = PassthroughSubject<Event, Never>()
+        
     init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
-        self.deployment = deployment
-        self.config = Configuration(deploymentId: deployment.deploymentId,
+        self.configuration = Configuration(deploymentId: deployment.deploymentId,
                                     domain: deployment.domain,
                                     logging: true,
                                     reconnectionTimeoutInSeconds: reconnectTimeout)
-        self.messengerTransport = MessengerTransport(configuration: self.config)
-        self.client = self.messengerTransport.createMessagingClient()
+        self.messengerTransport = MessengerTransport(configuration: self.configuration)
+        self.messagingClient = self.messengerTransport.createMessagingClient()
         
-        client.stateChangedListener = { [weak self] stateChange in
+        messagingClient.stateChangedListener = { [weak self] stateChange in
             print("State Change: \(stateChange)")
-            self?.onStateChange?(stateChange)
+            self?.stateChangeSubject.send(stateChange)
         }
-        client.messageListener = { [weak self] message in
+        messagingClient.messageListener = { [weak self] message in
             print("Message Event: \(message)")
-            self?.onMessageEvent?(message)
+            self?.messageEventSubject.send(message)
         }
-        client.eventListener = { [weak self] event in
+        messagingClient.eventListener = { [weak self] event in
             print("Event: \(event)")
-            self?.onEvent?(event)
+            self?.eventSubject.send(event)
         }
     }
 
     func connect() throws {
         do {
-            try client.connect()
+            try messagingClient.connect()
         } catch {
             print("connect() failed. \(error.localizedDescription)")
             throw error
@@ -55,7 +53,7 @@ class MessengerHandler {
 
     func disconnect() throws {
         do {
-            try client.disconnect()
+            try messagingClient.disconnect()
         } catch {
             print("disconnect() failed. \(error.localizedDescription)")
             throw error
@@ -64,7 +62,7 @@ class MessengerHandler {
 
     func sendMessage(text: String, customAttributes: [String: String] = [:]) throws {
         do {
-            try client.sendMessage(text: text.trimmingCharacters(in: .whitespaces), customAttributes: customAttributes)
+            try messagingClient.sendMessage(text: text.trimmingCharacters(in: .whitespaces), customAttributes: customAttributes)
         } catch {
             print("sendMessage(text:) failed. \(error.localizedDescription)")
             throw error
@@ -72,14 +70,14 @@ class MessengerHandler {
     }
 
     func fetchNextPage(completion: ((Error?) -> Void)? = nil) {
-        client.fetchNextPage() { _, error in
+        messagingClient.fetchNextPage() { _, error in
             completion?(error)
         }
     }
 
     func sendHealthCheck() throws {
         do {
-            try client.sendHealthCheck()
+            try messagingClient.sendHealthCheck()
         } catch {
             print("sendHealthCheck() failed. \(error.localizedDescription)")
             throw error
@@ -88,7 +86,7 @@ class MessengerHandler {
 
     func attachImage(kotlinByteArray: KotlinByteArray) throws {
         do {
-            try client.attach(byteArray: kotlinByteArray, fileName: "image.png", uploadProgress: { progress in
+            try messagingClient.attach(byteArray: kotlinByteArray, fileName: "image.png", uploadProgress: { progress in
                 print("Attachment upload progress: \(progress)")
             })
         } catch {
@@ -99,7 +97,7 @@ class MessengerHandler {
 
     func detachImage(attachId: String) throws {
         do {
-            try client.detach(attachmentId: attachId)
+            try messagingClient.detach(attachmentId: attachId)
         } catch {
             print("detachImage(attachId:) failed. \(error.localizedDescription)")
             throw error
@@ -111,12 +109,12 @@ class MessengerHandler {
     }
 
     func clearConversation() {
-        client.invalidateConversationCache()
+        messagingClient.invalidateConversationCache()
     }
 
     func indicateTyping() throws {
         do {
-            try client.indicateTyping()
+            try messagingClient.indicateTyping()
         } catch {
             print("indicateTyping() failed. \(error.localizedDescription)")
             throw error

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -22,9 +22,9 @@ final class MessengerInteractor {
         
     init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
         self.configuration = Configuration(deploymentId: deployment.deploymentId,
-                                    domain: deployment.domain,
-                                    logging: true,
-                                    reconnectionTimeoutInSeconds: reconnectTimeout)
+                                           domain: deployment.domain,
+                                           logging: true,
+                                           reconnectionTimeoutInSeconds: reconnectTimeout)
         self.messengerTransport = MessengerTransport(configuration: self.configuration)
         self.messagingClient = self.messengerTransport.createMessagingClient()
         

--- a/iosApp/iosApp/SceneDelegate.swift
+++ b/iosApp/iosApp/SceneDelegate.swift
@@ -12,7 +12,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = ContentViewController(deployment: appDelegate().deployment)
+            window.rootViewController = ContentViewController(messenger: appDelegate().messenger)
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/iosApp/iosApp/SceneDelegate.swift
+++ b/iosApp/iosApp/SceneDelegate.swift
@@ -12,7 +12,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {
             let window = UIWindow(windowScene: windowScene)
-            window.rootViewController = ContentViewController(messenger: appDelegate().messenger)
+            window.rootViewController = TestbedViewController(messenger: appDelegate().messenger)
             self.window = window
             window.makeKeyAndVisible()
         }

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ContentViewController.swift
+//  TestbedViewController.swift
 //  iosApp
 //
 //  Created by Chris Rumpf on 10/1/21.
@@ -10,7 +10,7 @@ import UIKit
 import MessengerTransport
 import Combine
 
-class ContentViewController: UIViewController {
+class TestbedViewController: UIViewController {
 
     private let messenger: MessengerInteractor
     private var attachImageName = ""
@@ -270,7 +270,7 @@ class ContentViewController: UIViewController {
 }
 
 // MARK: UITextFieldDelegate
-extension ContentViewController : UITextFieldDelegate {
+extension TestbedViewController : UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         guard let message = textField.text else {
             textField.resignFirstResponder()

--- a/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
+++ b/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
@@ -1,5 +1,5 @@
 //
-//  TestContentController.swift
+//  MessengerInteractorTester.swift
 //  iosAppTests
 //
 //  Created by Morehouse, Matthew on 9/8/22.
@@ -10,7 +10,7 @@ import XCTest
 import MessengerTransport
 @testable import iosApp
 
-class TestContentController: MessengerHandler {
+class MessengerInteractorTester: MessengerInteractor {
 
     var testExpectation: XCTestExpectation?
     var errorExpectation: XCTestExpectation?
@@ -21,7 +21,7 @@ class TestContentController: MessengerHandler {
     override init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
         super.init(deployment: deployment, reconnectTimeout: reconnectTimeout)
 
-        client.stateChangedListener = { [weak self] stateChange in
+        messagingClient.stateChangedListener = { [weak self] stateChange in
             print("State Event. New state: \(stateChange.newState), old state: \(stateChange.oldState)")
             let newState = stateChange.newState
             switch newState {
@@ -35,10 +35,9 @@ class TestContentController: MessengerHandler {
             default:
                 break
             }
-            self?.onStateChange?(stateChange)
         }
 
-        client.messageListener = { [weak self] message in
+        messagingClient.messageListener = { [weak self] message in
             switch message {
             case let messageInserted as MessageEvent.MessageInserted:
                 print("Message Inserted: <\(messageInserted.message.description)>")
@@ -60,10 +59,9 @@ class TestContentController: MessengerHandler {
             default:
                 print("Unexpected messageListener event: \(message)")
             }
-            self?.onMessageEvent?(message)
         }
 
-        client.eventListener = { [weak self] event in
+        messagingClient.eventListener = { [weak self] event in
             switch event {
             case let typing as Event.AgentTyping:
                 print("Agent is typing: \(typing)")

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -11,7 +11,7 @@ import MessengerTransport
 
 class iosAppTests: XCTestCase {
 
-    var contentController: TestContentController?
+    var contentController: MessengerInteractorTester?
 
     override class func setUp() {
         super.setUp()
@@ -24,7 +24,7 @@ class iosAppTests: XCTestCase {
         if contentController == nil {
             do {
                 let deployment = try Deployment()
-                contentController = TestContentController(deployment: deployment)
+                contentController = MessengerInteractorTester(deployment: deployment)
             } catch {
                 XCTFail("Failed to initialize Content Controller: \(error.localizedDescription)")
             }
@@ -117,9 +117,9 @@ class iosAppTests: XCTestCase {
         // Create 4 new content controllers. We'll use these to trigger a connection closed event.
         // Right now, there's a max number of 3 open sesssions that use the same token.
         // We'll open 4 and confirm that an error occurs in the fourth attempt on the oldest client.
-        var controllers = [TestContentController]()
+        var controllers = [MessengerInteractorTester]()
         for _ in 1...4 {
-            controllers.append(TestContentController(deployment: deployment))
+            controllers.append(MessengerInteractorTester(deployment: deployment))
         }
         controllers[0].connectionClosed = XCTestExpectation(description: "Wait for the ConnectionClosedEvent")
         for controller in controllers {
@@ -220,14 +220,14 @@ class iosAppTests: XCTestCase {
     
     func testAccessDenied() {
         let deployment = try! Deployment()
-        let testController = TestContentController(deployment: Deployment(deploymentId: "InvalidDeploymentId", domain: deployment.domain))
+        let testController = MessengerInteractorTester(deployment: Deployment(deploymentId: "InvalidDeploymentId", domain: deployment.domain))
                  
         testController.startMessengerConnectionWithErrorExpectation(XCTestExpectation(description: "Expecting access denied."))
         
-        if let state = testController.client.currentState as? MessagingClientState.Error {
+        if let state = testController.messagingClient.currentState as? MessagingClientState.Error {
             XCTAssertTrue(state.code is ErrorCode.WebsocketAccessDenied)
         } else {
-            XCTFail("Expected Error state, but instead state is: \(testController.client.currentState)")
+            XCTFail("Expected Error state, but instead state is: \(testController.messagingClient.currentState)")
         }
     }
 

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -11,7 +11,7 @@ import MessengerTransport
 
 class iosAppTests: XCTestCase {
 
-    var contentController: MessengerInteractorTester?
+    var messengerTester: MessengerInteractorTester?
 
     override class func setUp() {
         super.setUp()
@@ -21,12 +21,12 @@ class iosAppTests: XCTestCase {
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
-        if contentController == nil {
+        if messengerTester == nil {
             do {
                 let deployment = try Deployment()
-                contentController = MessengerInteractorTester(deployment: deployment)
+                messengerTester = MessengerInteractorTester(deployment: deployment)
             } catch {
-                XCTFail("Failed to initialize Content Controller: \(error.localizedDescription)")
+                XCTFail("Failed to initialize MessengerInteractorTester: \(error.localizedDescription)")
             }
         }
     }
@@ -38,13 +38,13 @@ class iosAppTests: XCTestCase {
     func testAttachments() {
         // Setup the session. Send a message to start the conversation.
         // Setup the session. Send a message.
-        guard let contentController = contentController else {
-            XCTFail("Failed to setup the content controller.")
+        guard let messengerTester = messengerTester else {
+            XCTFail("Failed to setup the Messenger tester.")
             return
         }
 
-        contentController.startMessengerConnection()
-        contentController.sendText(text: "Testing from E2E test.")
+        messengerTester.startMessengerConnection()
+        messengerTester.sendText(text: "Testing from E2E test.")
 
         // Use the public API to answer the new Messenger conversation.
         // Send a message from that agent and make sure we receive it.
@@ -65,17 +65,17 @@ class iosAppTests: XCTestCase {
         for (index, element) in intArray.enumerated() {
             kotlinByteArray.set(index: Int32(index), value: element)
         }
-        contentController.attemptImageAttach(kotlinByteArray: kotlinByteArray)
-        contentController.sendUploadedImage()
+        messengerTester.attemptImageAttach(kotlinByteArray: kotlinByteArray)
+        messengerTester.sendUploadedImage()
 
         // Disconnect the conversation for the agent and disconnect the session.
         ApiHelper.shared.sendConnectOrDisconnect(conversationInfo: conversationInfo, connecting: false, wrapup: true)
-        contentController.disconnectMessenger()
+        messengerTester.disconnectMessenger()
     }
 
     // Test will always fail if the deployment configuration doesn't have AutoStart enabled. See Deployment Configuration options in Admin.
     func testAutoStart() {
-        guard let deploymentConfig = contentController?.pullDeploymentConfig() else {
+        guard let deploymentConfig = messengerTester?.pullDeploymentConfig() else {
             XCTFail("Failed to pull the deployment configuration.")
             return
         }
@@ -84,13 +84,13 @@ class iosAppTests: XCTestCase {
         // Save a new token.
         DefaultTokenStore(storeKey: "com.genesys.cloud.messenger").store(token: UUID().uuidString)
 
-        guard let contentController = contentController else {
-            XCTFail("Failed to setup the content controller.")
+        guard let messengerTester = messengerTester else {
+            XCTFail("Failed to setup the Messenger tester.")
             return
         }
 
         // Should be able to answer the conversation immediately after starting the connection if AutoStart is enabled.
-        contentController.startMessengerConnection()
+        messengerTester.startMessengerConnection()
         guard let conversationInfo = ApiHelper.shared.answerNewConversation() else {
             XCTFail("The message we sent may not have connected to an agent.")
             return
@@ -98,7 +98,7 @@ class iosAppTests: XCTestCase {
 
         // Disconnect the conversation for the agent and disconnect the session.
         ApiHelper.shared.sendConnectOrDisconnect(conversationInfo: conversationInfo, connecting: false, wrapup: true)
-        contentController.disconnectMessenger()
+        messengerTester.disconnectMessenger()
     }
 
     func testConnectionClosed() {
@@ -114,43 +114,43 @@ class iosAppTests: XCTestCase {
             return
         }
 
-        // Create 4 new content controllers. We'll use these to trigger a connection closed event.
+        // Create 4 new MessengerInteractorTesters. We'll use these to trigger a connection closed event.
         // Right now, there's a max number of 3 open sesssions that use the same token.
         // We'll open 4 and confirm that an error occurs in the fourth attempt on the oldest client.
-        var controllers = [MessengerInteractorTester]()
+        var testers = [MessengerInteractorTester]()
         for _ in 1...4 {
-            controllers.append(MessengerInteractorTester(deployment: deployment))
+            testers.append(MessengerInteractorTester(deployment: deployment))
         }
-        controllers[0].connectionClosed = XCTestExpectation(description: "Wait for the ConnectionClosedEvent")
-        for controller in controllers {
-            controller.startMessengerConnection()
+        testers[0].connectionClosed = XCTestExpectation(description: "Wait for the ConnectionClosedEvent")
+        for tester in testers {
+            tester.startMessengerConnection()
             delay(3)
         }
-        let result = XCTWaiter().wait(for: [controllers[0].connectionClosed!], timeout: 30)
+        let result = XCTWaiter().wait(for: [testers[0].connectionClosed!], timeout: 30)
         XCTAssertEqual(result, .completed, "Did not receive a Connection Closed event.")
 
         // Cleanup. Also verifies that all of the other clients are still connected due to an error being thrown if we disconnect while not being connected.
-        for x in 1...3 {
-            controllers[x].disconnectMessenger()
+        for tester in testers[1..<testers.count] {
+            tester.disconnectMessenger()
         }
     }
 
     func testMessageAttributes() {
         // Setup the session. Send a message.
-        guard let contentController = contentController else {
-            XCTFail("Failed to setup the content controller.")
+        guard let messengerTester = messengerTester else {
+            XCTFail("Failed to setup the Messenger tester.")
             return
         }
 
-        contentController.startMessengerConnection()
-        contentController.sendTextWithAttribute(text: "Testing with a specific name.", attributes: ["name": "Jane Doe"])
+        messengerTester.startMessengerConnection()
+        messengerTester.sendTextWithAttribute(text: "Testing with a specific name.", attributes: ["name": "Jane Doe"])
         guard let conversationInfo = ApiHelper.shared.answerNewConversation() else {
             XCTFail("The message we sent may not have connected to an agent.")
             return
         }
 
         // Send a message with a new name via custom attributes.
-        contentController.sendTextWithAttribute(text: "Testing with a new name!", attributes: ["name": "John Doe"])
+        messengerTester.sendTextWithAttribute(text: "Testing with a new name!", attributes: ["name": "John Doe"])
 
         // Cleanup.
         ApiHelper.shared.sendConnectOrDisconnect(conversationInfo: conversationInfo, connecting: false, wrapup: true)
@@ -158,13 +158,13 @@ class iosAppTests: XCTestCase {
 
     func testSendAndReceiveMessage() {
         // Setup the session. Send a message.
-        guard let contentController = contentController else {
-            XCTFail("Failed to setup the content controller.")
+        guard let messengerTester = messengerTester else {
+            XCTFail("Failed to setup the Messenger tester.")
             return
         }
 
-        contentController.startMessengerConnection()
-        contentController.sendText(text: "Testing from E2E test.")
+        messengerTester.startMessengerConnection()
+        messengerTester.sendText(text: "Testing from E2E test.")
 
         // Use the public API to answer the new Messenger conversation.
         // Send a message from that agent and make sure we receive it.
@@ -173,26 +173,26 @@ class iosAppTests: XCTestCase {
             return
         }
         let receivedMessageText = "Test message sent via API request!"
-        contentController.testExpectation = XCTestExpectation(description: "Wait for message to be received from the UI agent.")
+        messengerTester.testExpectation = XCTestExpectation(description: "Wait for message to be received from the UI agent.")
         ApiHelper.shared.sendOutboundSmsMessage(conversationId: conversationInfo.conversationId, communicationId: conversationInfo.communicationId, message: receivedMessageText)
-        contentController.waitForTestExpectation()
-        contentController.verifyReceivedMessage(expectedMessage: receivedMessageText)
+        messengerTester.waitForTestExpectation()
+        messengerTester.verifyReceivedMessage(expectedMessage: receivedMessageText)
 
         // Disconnect the conversation for the agent and disconnect the session.
         ApiHelper.shared.sendConnectOrDisconnect(conversationInfo: conversationInfo, connecting: false, wrapup: true)
-        contentController.disconnectMessenger()
+        messengerTester.disconnectMessenger()
     }
 
     func testTypingIndicators() {
         // Setup the session. Send a message.
-        guard let contentController = contentController else {
-            XCTFail("Failed to setup the content controller.")
+        guard let messengerTester = messengerTester else {
+            XCTFail("Failed to setup the Messenger tester.")
             return
 
         }
 
-        contentController.startMessengerConnection()
-        contentController.sendText(text: "Testing from E2E test.")
+        messengerTester.startMessengerConnection()
+        messengerTester.sendText(text: "Testing from E2E test.")
 
         // Use the public API to answer the new Messenger conversation.
         // Send a message from that agent and make sure we receive it.
@@ -201,33 +201,29 @@ class iosAppTests: XCTestCase {
             return
         }
 
-        // Send a typing indicator. Ensure that we don't receive an error.
-        do {
-            try contentController.indicateTyping()
-        } catch {
-            XCTFail(error.localizedDescription)
-        }
+        // Send a typing indicator.
+        messengerTester.indicateTyping()
 
         // Receive a typing indicator from the agent.
-        contentController.testExpectation = XCTestExpectation(description: "Wait for a typing indicator from the agent.")
+        messengerTester.testExpectation = XCTestExpectation(description: "Wait for a typing indicator from the agent.")
         ApiHelper.shared.sendTypingIndicator(conversationId: conversationInfo.conversationId, communicationId: conversationInfo.communicationId)
-        contentController.waitForTestExpectation()
+        messengerTester.waitForTestExpectation()
 
         // Disconnect the conversation for the agent and disconnect the session.
         ApiHelper.shared.sendConnectOrDisconnect(conversationInfo: conversationInfo, connecting: false, wrapup: true)
-        contentController.disconnectMessenger()
+        messengerTester.disconnectMessenger()
     }
     
     func testAccessDenied() {
         let deployment = try! Deployment()
-        let testController = MessengerInteractorTester(deployment: Deployment(deploymentId: "InvalidDeploymentId", domain: deployment.domain))
+        let tester = MessengerInteractorTester(deployment: Deployment(deploymentId: "InvalidDeploymentId", domain: deployment.domain))
                  
-        testController.startMessengerConnectionWithErrorExpectation(XCTestExpectation(description: "Expecting access denied."))
+        tester.startMessengerConnectionWithErrorExpectation(XCTestExpectation(description: "Expecting access denied."))
         
-        if let state = testController.messagingClient.currentState as? MessagingClientState.Error {
+        if let state = tester.messenger.messagingClient.currentState as? MessagingClientState.Error {
             XCTAssertTrue(state.code is ErrorCode.WebsocketAccessDenied)
         } else {
-            XCTFail("Expected Error state, but instead state is: \(testController.messagingClient.currentState)")
+            XCTFail("Expected Error state, but instead state is: \(tester.messenger.messagingClient.currentState)")
         }
     }
 


### PR DESCRIPTION
Knocking down some tech debt that has accumulated in the iosApp testbed app:

* refactor some types for better clarity (ContentViewController → TestbedViewController, MessengerHandler → MessengerInteractor, TestContentController → MessengerInteractorTester)
* inject a MessengerInteractor into the TestbedViewController instead of just the Deployment info
* refactor event messaging in the MessengerInteractor to use Combine PassthroughSubjects instead of callbacks via function type properties.
* refactor the MessengerInteractorTester to use composition instead of inheritance