### PR TITLE
MTSDK-132 Instrumentation tests fail to build.

### DIFF
--- a/androidComposePrototype/build.gradle
+++ b/androidComposePrototype/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     // Integration with activities
     implementation "androidx.activity:activity-compose:$activity_compose_version"
 
-    testImplementation 'junit:junit:4.+'
+    testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "com.jaredrummler:android-device-names:2.0.0"

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -6,7 +6,7 @@ object Deps {
     private const val kotlinxSerializationJsonVersion = "1.3.2"
     private const val ktorVersion = "1.6.8"
     private const val mockWebServerVersion = "4.9.0"
-    private const val mockkVersion = "1.12.2"
+    private const val mockkVersion = "1.13.3"
     private const val okhttpVersion = "4.10.0"
     private const val klockVersion = "2.4.13"
 


### PR DESCRIPTION
- Bump mockk version (issue: https://github.com/mockk/mockk/issues/828)
- Explicitly specify junit version in androidComposePrototype to avoid conflicts with transport.