### PR TITLE
Exclude licence from android packaging options as junit has conflicts.

### DIFF
--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -37,6 +37,8 @@ android {
     packagingOptions {
         resources {
             excludes += "META-INF/*.kotlin_module"
+            excludes += "META-INF/LICENSE.md"
+            excludes += "META-INF/LICENSE-notice.md"
         }
     }
 }


### PR DESCRIPTION
- Exclude licence from android packaging options as junit has conflicts.