### PR TITLE
Feature/mtsdk 11 handle read only field from session response

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -225,7 +225,10 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         Log.v(TAG, "onClientStateChanged(oldState = $oldState, newState = $newState)")
         clientState = newState
         val statePayloadMessage = when (newState) {
-            is State.Configured -> "connected: ${newState.connected}, newSession: ${newState.newSession}, wasReconnecting: ${oldState is State.Reconnecting}"
+            is State.Configured -> "connected: ${newState.connected}," +
+                    " newSession: ${newState.newSession}," +
+                    " wasReconnecting: ${oldState is State.Reconnecting}," +
+                    " readOnly: ${newState.readOnly}"
             is State.Closing -> "code: ${newState.code}, reason: ${newState.reason}"
             is State.Closed -> "code: ${newState.code}, reason: ${newState.reason}"
             is State.Error -> "code: ${newState.code}, message: ${newState.message}"

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -154,7 +154,7 @@ class TestbedViewController: UIViewController {
         case is MessagingClientState.Connected:
             stateMessage = "Connected"
         case let configured as MessagingClientState.Configured:
-            stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState is MessagingClientState.Reconnecting)"
+            stateMessage = "Configured, connected=\(configured.connected) newSession=\(configured.newSession) wasReconnecting=\(stateChange.oldState is MessagingClientState.Reconnecting) readOnly=\(configured.readOnly)"
         case let closing as MessagingClientState.Closing:
             stateMessage = "Closing, code=\(closing.code) reason=\(closing.reason)"
         case let closed as MessagingClientState.Closed:

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -154,7 +154,7 @@ class MessagingClientImplTest {
     fun whenConnect() {
         subject.connect()
 
-        assertThat(subject).isConfigured(connected = true, newSession = true)
+        assertThat(subject).isConfigured(connected = true, newSession = true, readOnly = false)
         verifySequence {
             connectSequence()
         }
@@ -859,7 +859,7 @@ class MessagingClientImplTest {
         expectedCloseReason: String = "The user has closed the connection.",
     ) {
         val fromConfiguredToClosing = StateChange(
-            oldState = State.Configured(connected = true, newSession = true),
+            oldState = State.Configured(connected = true, newSession = true, readOnly = false),
             newState = State.Closing(expectedCloseCode, expectedCloseReason)
         )
         val fromClosingToClosed = StateChange(
@@ -896,7 +896,7 @@ class MessagingClientImplTest {
     private val fromConnectedToConfigured =
         StateChange(
             oldState = State.Connected,
-            newState = State.Configured(connected = true, newSession = true)
+            newState = State.Configured(connected = true, newSession = true, readOnly = false)
         )
 
     private fun fromConnectedToError(errorState: State) =
@@ -904,7 +904,7 @@ class MessagingClientImplTest {
 
     private fun fromConfiguredToError(errorState: State) =
         StateChange(
-            oldState = State.Configured(connected = true, newSession = true),
+            oldState = State.Configured(connected = true, newSession = true, readOnly = false),
             newState = errorState,
         )
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineTest.kt
@@ -82,7 +82,7 @@ class StateMachineTest {
 
     @Test
     fun whenOnConnectAndCurrentStateIsConfigured() {
-        subject.onSessionConfigured(connected = true, newSession = true)
+        subject.onSessionConfigured(connected = true, newSession = true, readOnly = false)
 
         assertFailsWith<IllegalStateException> { subject.onConnect() }
     }
@@ -101,16 +101,17 @@ class StateMachineTest {
     @Test
     fun whenOnSessionConfigured() {
         val expectedStateChange =
-            StateChange(State.Idle, State.Configured(connected = true, newSession = true))
+            StateChange(State.Idle, State.Configured(connected = true, newSession = true, readOnly = false))
 
-        subject.onSessionConfigured(connected = true, newSession = true)
+        subject.onSessionConfigured(connected = true, newSession = true, readOnly = false)
 
         assertThat(subject).isConfigured(
             connected = true,
             newSession = true,
+            readOnly = false,
         )
         verify {
-            mockStateListener(State.Configured(connected = true, newSession = true))
+            mockStateListener(State.Configured(connected = true, newSession = true, readOnly = false))
         }
         verify { mockStateChangedListener(expectedStateChange) }
     }
@@ -118,20 +119,22 @@ class StateMachineTest {
     @Test
     fun whenOnSessionConfiguredAfterOnReconnect() {
         val expectedStateChange =
-            StateChange(State.Reconnecting, State.Configured(connected = true, newSession = true))
+            StateChange(State.Reconnecting, State.Configured(connected = true, newSession = true, readOnly = false))
 
         subject.onReconnect()
-        subject.onSessionConfigured(connected = true, newSession = true)
+        subject.onSessionConfigured(connected = true, newSession = true, readOnly = false)
 
         assertThat(subject).isConfigured(
             connected = true,
             newSession = true,
+            readOnly = false,
         )
         verify {
             mockStateListener(
                 State.Configured(
                     connected = true,
                     newSession = true,
+                    readOnly = false,
                 )
             )
         }
@@ -210,16 +213,16 @@ class StateMachineTest {
         assertThat(subject).isConnecting()
         subject.onConnectionOpened()
         assertThat(subject).isConnected()
-        subject.onSessionConfigured(connected = true, newSession = true)
-        assertThat(subject).isConfigured(connected = true, newSession = true)
+        subject.onSessionConfigured(connected = true, newSession = true, readOnly = false)
+        assertThat(subject).isConfigured(connected = true, newSession = true, readOnly = false)
         subject.onReconnect()
         assertThat(subject).isReconnecting()
         subject.onConnect()
         assertThat(subject).isReconnecting()
         subject.onConnectionOpened()
         assertThat(subject).isReconnecting()
-        subject.onSessionConfigured(connected = true, newSession = false)
-        assertThat(subject).isConfigured(connected = true, newSession = false)
+        subject.onSessionConfigured(connected = true, newSession = false, readOnly = false)
+        assertThat(subject).isConfigured(connected = true, newSession = false, readOnly = false)
         subject.onClosing(100, "sss")
         assertThat(subject).isClosing(100, "sss")
         subject.onClosed(100, "sss")
@@ -246,11 +249,13 @@ class StateMachineTest {
     private fun Assert<StateMachine>.isConfigured(
         connected: Boolean,
         newSession: Boolean,
+        readOnly: Boolean,
     ) =
         currentState().isEqualTo(
             State.Configured(
                 connected,
                 newSession,
+                readOnly,
             )
         )
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -37,8 +37,15 @@ interface MessagingClient {
          *
          * @property connected true if session has been configured and connection is established.
          * @property newSession indicates if configured session is new. When configuring an existing session, [newSession] will be false.
+         * @property readOnly represents the session state. When [readOnly] is set to true, the user will not be able to send or receive any new messages,
+         * but they will still be able to fetch and read existing message history.
+         * When [readOnly] is set to false, the user will be able to send and receive messages.
          */
-        data class Configured(val connected: Boolean, val newSession: Boolean) : State()
+        data class Configured(
+            val connected: Boolean,
+            val newSession: Boolean,
+            val readOnly: Boolean,
+        ) : State()
 
         /**
          * Remote peer has indicated that no more incoming messages will be transmitted.
@@ -134,7 +141,7 @@ interface MessagingClient {
     fun attach(
         byteArray: ByteArray,
         fileName: String,
-        uploadProgress: ((Float) -> Unit)? = null
+        uploadProgress: ((Float) -> Unit)? = null,
     ): String
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -332,7 +332,7 @@ internal class MessagingClientImpl(
                     is SessionResponse -> {
                         decoded.body.run {
                             reconnectionHandler.clear()
-                            stateMachine.onSessionConfigured(connected, newSession)
+                            stateMachine.onSessionConfigured(connected, newSession, readOnly)
                             if (newSession && deploymentConfig.isAutostartEnabled()) {
                                 sendAutoStart()
                             }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachine.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachine.kt
@@ -9,7 +9,7 @@ internal interface StateMachine {
     @Throws(IllegalStateException::class)
     fun onConnect()
     fun onReconnect()
-    fun onSessionConfigured(connected: Boolean, newSession: Boolean)
+    fun onSessionConfigured(connected: Boolean, newSession: Boolean, readOnly: Boolean)
     @Throws(IllegalStateException::class)
     fun onClosing(code: Int, reason: String)
     fun onClosed(code: Int, reason: String)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -40,8 +40,9 @@ internal class StateMachineImpl(
     override fun onSessionConfigured(
         connected: Boolean,
         newSession: Boolean,
+        readOnly: Boolean,
     ) {
-        currentState = State.Configured(connected, newSession)
+        currentState = State.Configured(connected, newSession, readOnly)
     }
 
     @Throws(IllegalStateException::class)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -41,9 +41,20 @@ data class Conversations(
     val showAgentTypingIndicator: Boolean = false,
     val showUserTypingIndicator: Boolean = false,
     val autoStart: AutoStart = AutoStart(),
+    val conversationDisconnect: ConversationDisconnect = ConversationDisconnect()
 ) {
     @Serializable
     data class AutoStart(val enabled: Boolean = false)
+
+    @Serializable
+    data class ConversationDisconnect(val enabled: Boolean = false, val type: Type = Type.Send) {
+
+        @Serializable
+        enum class Type {
+            ReadOnly,
+            Send,
+        }
+    }
 }
 
 @Serializable

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
@@ -6,4 +6,5 @@ import kotlinx.serialization.Serializable
 internal data class SessionResponse(
     val connected: Boolean,
     val newSession: Boolean,
+    val readOnly: Boolean = false,
 )

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientAssertk.kt
@@ -17,8 +17,8 @@ fun Assert<MessagingClient>.isConnected() =
 fun Assert<MessagingClient>.isClosing(code: Int, reason: String) =
     currentState().isEqualTo(MessagingClient.State.Closing(code, reason))
 
-fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean) =
-    currentState().isEqualTo(MessagingClient.State.Configured(connected, newSession))
+fun Assert<MessagingClient>.isConfigured(connected: Boolean, newSession: Boolean, readOnly: Boolean) =
+    currentState().isEqualTo(MessagingClient.State.Configured(connected, newSession, readOnly))
 
 fun Assert<MessagingClient>.isError(code: ErrorCode, message: String?) =
     currentState().isEqualTo(MessagingClient.State.Error(code, message))

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
@@ -24,7 +24,7 @@ object TestWebMessagingApiResponses {
         """{"entities":[],"pageSize":0,"pageNumber":1, "total": 0, "pageCount": 0}"""
 
     internal const val deploymentConfigResponse =
-        """{"id":"test_config_id","version":"3","languages":["en-us"],"defaultLanguage":"en-us","apiEndpoint":"https://api.inindca.com","messenger":{"enabled":true,"apps":{"conversations":{"messagingEndpoint":"wss://webmessaging.inindca.com"}},"styles":{"primaryColor":"#ff0000"},"launcherButton":{"visibility":"On"},"fileUpload":{"modes":[{"fileTypes":["image/png","image/jpeg","image/gif"],"maxFileSizeKB":10000}]}},"journeyEvents":{"enabled":true},"status":"Active"}"""
+        """{"id":"test_config_id","version":"3","languages":["en-us"],"defaultLanguage":"en-us","apiEndpoint":"https://api.inindca.com","messenger":{"enabled":true,"apps":{"conversations":{"messagingEndpoint":"wss://webmessaging.inindca.com","conversationDisconnect":{"enabled":true,"type":"ReadOnly"}}},"styles":{"primaryColor":"#ff0000"},"launcherButton":{"visibility":"On"},"fileUpload":{"modes":[{"fileTypes":["image/png","image/jpeg","image/gif"],"maxFileSizeKB":10000}]}},"journeyEvents":{"enabled":true},"status":"Active"}"""
 
     internal val testMessageEntityList =
         MessageEntityList(
@@ -50,7 +50,13 @@ object TestWebMessagingApiResponses {
         apiEndpoint = "https://api.inindca.com",
         messenger = Messenger(
             enabled = true,
-            apps = Apps(conversations = Conversations(messagingEndpoint = "wss://webmessaging.inindca.com")),
+            apps = Apps(conversations = Conversations(
+                messagingEndpoint = "wss://webmessaging.inindca.com",
+                conversationDisconnect = Conversations.ConversationDisconnect(
+                    enabled = true,
+                    type = Conversations.ConversationDisconnect.Type.ReadOnly
+                )
+            )),
             styles = Styles(primaryColor = "#ff0000"),
             launcherButton = LauncherButton(visibility = "On"),
             fileUpload = FileUpload(

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -1,7 +1,7 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
 fun createDeploymentConfigForTesting(
-    messenger: Messenger = createMessengerVOForTesting()
+    messenger: Messenger = createMessengerVOForTesting(),
 ) = DeploymentConfig(
     id = "id",
     version = "1",
@@ -14,7 +14,7 @@ fun createDeploymentConfigForTesting(
 )
 
 fun createMessengerVOForTesting(
-    apps: Apps = Apps(createConversationsVOForTesting())
+    apps: Apps = Apps(createConversationsVOForTesting()),
 ) = Messenger(
     enabled = true,
     apps = apps,
@@ -31,8 +31,10 @@ fun createMessengerVOForTesting(
 )
 
 fun createConversationsVOForTesting(
-    autoStart: Conversations.AutoStart = Conversations.AutoStart()
+    autoStart: Conversations.AutoStart = Conversations.AutoStart(),
+    conversationDisconnect: Conversations.ConversationDisconnect = Conversations.ConversationDisconnect(),
 ): Conversations = Conversations(
     messagingEndpoint = "messaging_endpoint",
     autoStart = autoStart,
+    conversationDisconnect = conversationDisconnect,
 )


### PR DESCRIPTION
As part of Conversation Disconnect feature the `readOnly` field was added to the ConfigureSession response on the Shyrka end. The purpose of this field is to indicate whether configured session allows further communication with an agent (`readOnly=false`) or it is allowed to only fetch conversation history to display to the client (`readOnly=true`). Note, that any attempt to send a message while `readOnly=true` will result in error response from Shyrka saying that communication is not allowed. 

- Parse `readOnly` field from SessionResponse.kt
- Expose to the client the `readOnly` field as part of State.Configure.
- Update Android and iOS Testbed application to include `readOnly` field.
- Update unit tests to include `readOnly` field.
- Provide KDoc that describes the usage of `readOnly` field.