### PR TITLE
MTSDK-166 Fix Inbound message sent from WebMessenger.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -155,10 +155,17 @@ internal class MessageStoreTest {
 
     @Test
     fun whenUpdateInboundWithIdThatDoesNotPresentInConversation() {
-        subject.update(message = Message("some id"))
+        val givenMessage =
+            Message(id = "randomId", state = Message.State.Sent, text = "test message")
 
-        assertTrue { subject.getConversation().isEmpty() }
-        verify { mockMessageListener wasNot Called }
+        subject.update(message = givenMessage)
+
+        verify { mockMessageListener(capture(messageSlot)) }
+        assertTrue { subject.getConversation().size == 1 }
+        assertEquals(
+            givenMessage,
+            (messageSlot.captured as MessageEvent.MessageInserted).message
+        )
     }
 
     @Test

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -53,6 +53,9 @@ internal class MessageStore(
                 activeConversation.find { it.id == message.id }?.let {
                     activeConversation[it.getIndex()] = message
                     messageListener?.invoke(MessageEvent.MessageUpdated(message))
+                } ?: run {
+                    activeConversation.add(message)
+                    messageListener?.invoke(MessageEvent.MessageInserted(message))
                 }
             }
             Direction.Outbound -> {


### PR DESCRIPTION
At the moment Messages sent by the user from WebMessenger are filtered out in Transport. 
This pr is to fix this issue and improve sync between WebMessenger and MobileTransport.

- Notify UI with event MessageInserted when Transport get an Inbound message sent from web messenger.
- Fix incorrect unit test.