### PR TITLE
MTSDK-165-Configure New Chat

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
@@ -59,7 +59,7 @@ fun TestBedContent(
             style = typography.h5
         )
         Text(
-            "Commands: connect, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>, typing",
+            "Commands: connect, newChat, send <msg>, history, clearConversation, attach, detach, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>, typing",
             style = typography.caption,
             softWrap = true
         )

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -112,6 +112,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "clearConversation" -> doClearConversation()
             "addAttribute" -> doAddCustomAttributes(input)
             "typing" -> doIndicateTyping()
+            "newChat" -> doStartNewChat()
             else -> {
                 Log.e(TAG, "Invalid command")
                 withContext(Dispatchers.Main) {
@@ -136,6 +137,14 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             client.connect()
         } catch (t: Throwable) {
             handleException(t, "connect")
+        }
+    }
+
+    private suspend fun doStartNewChat() {
+        try {
+            client.startNewChat()
+        } catch (t: Throwable) {
+            handleException(t, "start new chat")
         }
     }
 

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -50,6 +50,15 @@ final class MessengerInteractor {
             throw error
         }
     }
+    
+    func newChat() throws {
+        do {
+            try messagingClient.startNewChat()
+        } catch {
+            print("startNewChat() failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func disconnect() throws {
         do {

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -33,6 +33,7 @@ class TestbedViewController: UIViewController {
      */
     enum UserCommand: String, CaseIterable {
         case connect
+        case newChat
         case send
         case history
         case selectAttachment
@@ -287,6 +288,8 @@ extension TestbedViewController : UITextFieldDelegate {
             switch command {
             case (.connect, _):
                 try messenger.connect()
+            case (.newChat, _):
+                try messenger.newChat()
             case (.bye, _):
                 try messenger.disconnect()
             case (.send, let msg?):

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -1,12 +1,14 @@
 package com.genesys.cloud.messenger.transport.util
 
 internal object Request {
-    const val configureRequest =
-        """{"token":"00000000-0000-0000-0000-000000000000","deploymentId":"deploymentId","journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
+    fun configureRequest(startNew: Boolean = false) =
+        """{"token":"00000000-0000-0000-0000-000000000000","deploymentId":"deploymentId","startNew":$startNew,"journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
     const val userTypingRequest =
         """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
     const val echoRequest =
         """{"token":"00000000-0000-0000-0000-000000000000","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
     const val autostart =
         """{"token":"00000000-0000-0000-0000-000000000000","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],"type":"Event"}}"""
+    const val closeAllConnections =
+        """{"token":"00000000-0000-0000-0000-000000000000","closeAllConnections":true,"action":"closeSession"}"""
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -44,8 +44,12 @@ interface MessagingClient {
         ) : State()
 
         /**
-         * MessagingClient is only allowed to perform read actions while in this state. For example, [fetchNextPage].
-         * An InvalidState exception will be thrown on any attempt to send an action.
+         * MessagingClient will transition to this state, once [Event.ConversationDisconnect] is received AND
+         * messenger is configured to display conversation status and disconnect session OR when SessionResponse indicates that session is `readOnly=true`.
+         * For more information on this state, please visit official [documentation](https://developer.genesys.cloud/commdigital/digital/webmessaging/messenger-transport-mobile-sdk/)
+         * While in this state, it is only allowed to perform read actions. For example, [fetchNextPage].
+         *
+         * An IllegalStateException will be thrown on any attempt to send an action.
          */
         object ReadOnly : State()
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -108,6 +108,16 @@ interface MessagingClient {
     fun connect()
 
     /**
+     * Configure a new chat once the previous one is in State.ReadOnly.
+     * It is important to note that once new chat started,
+     * all information regarding previous conversations will be lost.
+     *
+     * @throws IllegalStateException if MessagingClient not in ReadOnly state.
+     */
+    @Throws(IllegalStateException::class)
+    fun startNewChat()
+
+    /**
      * Send a message to the conversation as plain text.
      *
      * @param text the plain text to send.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -29,7 +29,7 @@ internal class StateMachineImpl(
 
     @Throws(IllegalStateException::class)
     override fun onConnect() {
-        check(currentState.canConnect()) { "MessagingClient state must be Closed, Idle or Error" }
+        check(currentState.canConnect()) { "MessagingClient state must be Closed, Idle or Error, but was: $currentState" }
         currentState = if (currentState.isReconnecting()) State.Reconnecting else State.Connecting
     }
 
@@ -65,15 +65,21 @@ internal class StateMachineImpl(
 
 internal fun StateMachine.isConnected(): Boolean = currentState is State.Connected
 
+internal fun StateMachine.isReadOnly(): Boolean = currentState is State.ReadOnly
+
 @Throws(IllegalStateException::class)
 internal fun StateMachine.checkIfConfigured() =
     check(currentState is State.Configured) { "MessagingClient is not Configured or in ReadOnly state." }
 
 @Throws(IllegalStateException::class)
 internal fun StateMachine.checkIfConfiguredOrReadOnly() =
-    check(currentState is State.Configured || currentState is State.ReadOnly) { "To perform this action MessagingClient must be either Configured or in ReadOnly state. " }
+    check(currentState is State.Configured || isReadOnly()) { "To perform this action MessagingClient must be either Configured or in ReadOnly state. " }
 
 internal fun StateMachine.isClosed(): Boolean = currentState is State.Closed
+
+@Throws(IllegalStateException::class)
+internal fun StateMachine.checkIfCanStartANewChat() =
+    check(isReadOnly()) { "MessagingClient is not in ReadOnly state." }
 
 private fun State.canConnect(): Boolean =
     this is State.Closed || this is State.Idle || this is State.Error || this is State.Reconnecting

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class SessionResponse(
     val connected: Boolean,
-    val newSession: Boolean,
+    val newSession: Boolean = false,
     val readOnly: Boolean = false,
 )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/CloseSessionRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/CloseSessionRequest.kt
@@ -1,0 +1,13 @@
+package com.genesys.cloud.messenger.transport.shyrka.send
+
+import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class CloseSessionRequest(
+    override val token: String,
+    val closeAllConnections: Boolean,
+) : WebMessagingRequest {
+    @Required
+    override val action: String = RequestAction.CLOSE_SESSION.value
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/ConfigureSessionRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/ConfigureSessionRequest.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.Serializable
 internal data class ConfigureSessionRequest(
     override val token: String,
     val deploymentId: String,
+    val startNew: Boolean,
     val journeyContext: JourneyContext? = null,
 ) : WebMessagingRequest {
     @Required override val action: String = RequestAction.CONFIGURE_SESSION.value

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/RequestAction.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/RequestAction.kt
@@ -7,5 +7,6 @@ internal enum class RequestAction(val value: String) {
     ON_ATTACHMENT("onAttachment"),
     GET_ATTACHMENT("getAttachment"),
     DELETE_ATTACHMENT("deleteAttachment"),
-    GET_JWT("getJwt")
+    GET_JWT("getJwt"),
+    CLOSE_SESSION("closeSession"),
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -20,6 +20,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.UploadFailureEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
 import com.genesys.cloud.messenger.transport.shyrka.send.Channel
+import com.genesys.cloud.messenger.transport.shyrka.send.CloseSessionRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.ConfigureSessionRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.EchoRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.HealthCheckID
@@ -44,14 +45,15 @@ class SerializationTest {
         )
         val encodedString = WebMessagingJson.json.encodeToString(
             ConfigureSessionRequest(
-                "<token>",
-                "<deploymentId>",
-                journeyContext,
+                token = "<token>",
+                deploymentId = "<deploymentId>",
+                startNew = false,
+                journeyContext = journeyContext,
             )
         )
 
         assertThat(encodedString, "encoded ConfigureSessionRequest")
-            .isEqualTo("""{"token":"<token>","deploymentId":"<deploymentId>","journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}""")
+            .isEqualTo("""{"token":"<token>","deploymentId":"<deploymentId>","startNew":false,"journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}""")
     }
 
     @Test
@@ -381,5 +383,18 @@ class SerializationTest {
 
         assertThat(message.body, "WebMessagingMessage body").isNotNull()
             .hasClass(ConnectionClosedEvent::class)
+    }
+
+    @Test
+    fun whenCloseSessionRequestThenEncodes() {
+        val encodedString = WebMessagingJson.json.encodeToString(
+            CloseSessionRequest(
+                token = "<token>",
+                closeAllConnections = true,
+            )
+        )
+
+        assertThat(encodedString, "encoded CloseSessionRequest")
+            .isEqualTo("""{"token":"<token>","closeAllConnections":true,"action":"closeSession"}""")
     }
 }


### PR DESCRIPTION
MessagingClient.startNewChat() can be called only when MessagingClientState is State.ReadOnly. This API will close any existing connection for the session that share the same token. As a result of successful closure of all connections Shyrka will dispatch an event SessionResponse with `connected=false`. We are using this flag along with `isStartingANewSession` to indicate intent  to start a new conversation. MessagingClient is doing that by sending a ConfigureSession request with `startNew=true`. 

- Add `startNewChat()` API to MessagingClient.kt. This function will close any existing connection for this session and then configure a new chat. Once new chat configured, information regarding previous conversations will be lost. This function will throw an IllegalStateException if invoked while MessagingClient state is NOT in `State.ReadOnly`
- ConfigureSessionRequest.kt now has additional field: `startNew`. When set to true, Shyrka will configure a fresh new session for this token, making access for a previous session unreachable. When set to false, Shyrka will try to configure existing session. If existing session is not in ReadOnly state and has been expired or this is a first ever session for this token - new session will be generated.
- Add CloseSessionRequest.kt - This request will close all existing connections that share this session (no matter what platform) by sending there a ConnectionClosedEvent.
- Add KDoc for newly added public API.
- Add/Update unit tests
- Update Android and iOS TestBed apps to support newly added API.