### PR TITLE
Feature/mtsdk 158 android test conversation disconnect

### DIFF
--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/BasePage.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/BasePage.kt
@@ -11,7 +11,7 @@ import androidx.test.uiautomator.Until
 
 open class BasePage(val activity: Activity) {
 
-    val waitTime = 30.toLong()
+    val waitTime = 40.toLong()
 
     // Initialize activity
     init {

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/MessengerPage.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/MessengerPage.kt
@@ -19,6 +19,7 @@ class MessengerPage(activity: Activity) : BasePage(activity) {
     private val autostartEventText = "Event\$ConversationAutostart"
     private val disconnectEventText = "Event\$ConversationDisconnect"
     private val newChatText = "newChat"
+    private val readOnlyText = "ReadOnly"
 
     // Wait until android compose prototype begins
     fun verifyPageIsVisible(waitTime: Long = 20) {
@@ -110,11 +111,19 @@ class MessengerPage(activity: Activity) : BasePage(activity) {
         if (!(response.contains(messageResultText2, ignoreCase = true))) AssertionError("Response does not contain MessageUpdated")
     }
 
-    // Verify response for the history command
-    fun checkHistoryFullResponse() {
+    // Verify response contains events for autostart and conversationDisconnect
+    fun checkHistoryForAutoStartAndDisconnectEventsResponse() {
         val response = getFullResponse()
         if (!(response.contains(autostartEventText, ignoreCase = true))) AssertionError("Response does not contain Autostart event")
-        if (!(response.contains(disconnectEventText, ignoreCase = true))) AssertionError("Response does not contain Disconnect event")
+        if (!(response.contains(disconnectEventText, ignoreCase = true))) AssertionError("Response does not contain conversationDisconnect event")
+    }
+
+    // Verify response does not contain readOnly or an event for conversationDisconnect
+    fun checkHistoryDoesNotContainDisconnectEventOrReadOnlyResponse() {
+        val response = getFullResponse()
+        if (response.contains(disconnectEventText, ignoreCase = true)) AssertionError("Response does contain conversationDisconnect event but should not")
+        val clientResponse = getClientResponse()
+        if (clientResponse == readOnlyText) AssertionError("Client response is in ReadOnly but should not be.")
     }
 
     fun pullAttachmentId(response: String): String {

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/MessengerPage.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/MessengerPage.kt
@@ -16,6 +16,9 @@ class MessengerPage(activity: Activity) : BasePage(activity) {
     private val messageResultText2 = "Message\$State\$Sent"
     private val commandClass = "android.widget.EditText"
     private val responseClass = "android.widget.ScrollView"
+    private val autostartEventText = "Event\$ConversationAutostart"
+    private val disconnectEventText = "Event\$ConversationDisconnect"
+    private val newChatText = "newChat"
 
     // Wait until android compose prototype begins
     fun verifyPageIsVisible(waitTime: Long = 20) {
@@ -63,7 +66,21 @@ class MessengerPage(activity: Activity) : BasePage(activity) {
     fun waitForConfigured() {
         Awaitility.await().atMost(waitTime, SECONDS)
             .until {
-                getClientResponse().contains("Configured", ignoreCase = true)
+                (getClientResponse().contains("Configured", ignoreCase = true) || (getClientResponse().contains("ReadOnly", ignoreCase = true)))
+            }
+        if (getClientResponse().contains("ReadOnly", ignoreCase = true)) {
+            enterCommand(newChatText)
+            Awaitility.await().atMost(waitTime, SECONDS)
+                .until {
+                    getClientResponse().contains("Configured", ignoreCase = true)
+                }
+        }
+    }
+
+    fun waitForReadOnly() {
+        Awaitility.await().atMost(waitTime, SECONDS)
+            .until {
+                getClientResponse().contains("ReadOnly", ignoreCase = true)
             }
     }
 
@@ -96,7 +113,8 @@ class MessengerPage(activity: Activity) : BasePage(activity) {
     // Verify response for the history command
     fun checkHistoryFullResponse() {
         val response = getFullResponse()
-        if (!(response.contains("HistoryFetched", ignoreCase = true))) AssertionError("Response does not contain \"pageSize\": 1")
+        if (!(response.contains(autostartEventText, ignoreCase = true))) AssertionError("Response does not contain Autostart event")
+        if (!(response.contains(disconnectEventText, ignoreCase = true))) AssertionError("Response does not contain Disconnect event")
     }
 
     fun pullAttachmentId(response: String): String {

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/OpeningPage.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/page/OpeningPage.kt
@@ -5,10 +5,13 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.genesys.cloud.messenger.uitest.support.testConfig
+import java.lang.Thread.sleep
 
 class OpeningPage(activity: Activity) : BasePage(activity) {
 
     val title = "Deployment ID"
+    val regionDefault = "inindca.com"
+    val prodRegion = ""
 
     // Wait until android compose prototype begins
     fun verifyPageIsVisible(waitTime: Long = 20) {
@@ -23,11 +26,27 @@ class OpeningPage(activity: Activity) : BasePage(activity) {
     }
 
     // Enter the deployment ID contained in the assets>testConfig.json file
-    fun enterDeploymentID() {
+    fun enterDeploymentID(deploymentId: String) {
         val mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         val deploymentIdField = mDevice.findObject(UiSelector().text(title))
         deploymentIdField.click()
         deploymentIdField.clearTextField()
-        deploymentIdField.legacySetText(testConfig.deploymentId)
+        deploymentIdField.legacySetText(deploymentId)
+        sleep(2000)
+        val regionField = mDevice.findObject(UiSelector().className("android.widget.Button").index(1))
+        regionField.click()
+        sleep(2000)
+        val listOfSrollView = mDevice.findObject(UiSelector().className("android.widget.ScrollView"))
+        if (testConfig.domain == regionDefault) {
+            val dcaView = listOfSrollView.getChild(UiSelector().className("android.view.View").index(0))
+            if (dcaView != null) {
+                dcaView.click()
+            }
+        } else {
+            val prodView = listOfSrollView.getChild(UiSelector().className("android.view.View").index(1))
+            if (prodView != null) {
+                prodView.click()
+            }
+        }
     }
 }

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/ApiHelper/API.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/ApiHelper/API.kt
@@ -43,7 +43,7 @@ class API : IdlingResource {
                 }
             } catch (error: FileNotFoundException) {
                 // FileNotFoundException can be received when a 404 is returned by an endpoint.
-                throw Error("An error was received while sending an HTTP Request. The target endpoint was: $error.message \n$responseCode \n$responseMessage")
+                throw Error("An error was received while sending an HTTP Request. The target endpoint was: ${error.message} \n$responseCode \n$responseMessage")
                 setIdle(false)
             }
         }

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/ApiHelper/Conversations.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/ApiHelper/Conversations.kt
@@ -87,6 +87,13 @@ fun API.sendTypingIndicatorFromAgentToUser(conversationInfo: Conversation) {
     publicApiCall("POST", "/api/v2/conversations/messages/${conversationInfo.id}/communications/${conversationInfo.getCommunicationId(participant!!)}/typing", payload = payload)
 }
 
+fun API.sendOutboundMessageFromAgentToUser(conversationInfo: Conversation, message: String) {
+    val agentParticipant = conversationInfo.getParticipantFromPurpose("agent")
+    val communicationId = conversationInfo.getCommunicationId(agentParticipant!!)
+    val payload = "{\"textBody\": \"${message}\"}".toByteArray()
+    publicApiCall("POST", "/api/v2/conversations/messages/${conversationInfo.id}/communications/$communicationId/messages", payload)
+}
+
 fun API.answerNewConversation(): Conversation? {
     changePresence("On Queue", testConfig.agentUserId)
     val conversation = waitForConversation()
@@ -113,7 +120,7 @@ fun API.sendConnectOrDisconnect(conversationInfo: Conversation, connecting: Bool
     // Send requests to connect/disconnect the conversation and send the wrapup code.
     sendStatusToParticipant(conversationInfo.id, agentParticipant!!.id, statusPayload)
     if (connecting) {
-        waitForParticipantToConnect(conversationInfo.id)
+        waitForParticipantToConnectOrDisconnect(conversationInfo.id, "connected")
     } else if (wrapup) {
         sleep(2000)
         print("Sending wrapup code.")
@@ -126,11 +133,11 @@ fun API.getDefaultWrapupCodeId(conversationId: String, participantId: String): J
     return wrapupCodeId
 }
 
-private fun API.waitForParticipantToConnect(conversationId: String) {
+fun API.waitForParticipantToConnectOrDisconnect(conversationId: String, connectionState: String) {
     Awaitility.await().atMost(60, TimeUnit.SECONDS).ignoreExceptions()
         .untilAsserted {
             val listOfMessages = getConversationInfo(conversationId).getParticipantFromPurpose("agent")?.messages?.toList()
-            listOfMessages?.get(0)?.state == "connected"
+            listOfMessages?.get(0)?.state == connectionState
         }
 }
 

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/config.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/support/config.kt
@@ -11,6 +11,10 @@ data class Config(
     val agentEmail: String,
     val agentUserId: String,
     val deploymentId: String,
+    val humanizeDisableDeploymentId: String,
+    val botDeploymentId: String,
+    val agentDisconnectDeploymentId: String,
+    val botName: String,
     val password: String,
     val domain: String,
     val apiBaseAddress: String

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
@@ -9,8 +9,8 @@ import com.genesys.cloud.messenger.uitest.support.ApiHelper.API
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.answerNewConversation
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.disconnectAllConversations
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendConnectOrDisconnect
-import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendTypingIndicatorFromAgentToUser
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendOutboundMessageFromAgentToUser
+import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendTypingIndicatorFromAgentToUser
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.waitForParticipantToConnectOrDisconnect
 import com.genesys.cloud.messenger.uitest.support.testConfig
 import org.junit.FixMethodOrder
@@ -352,12 +352,12 @@ class ComposePrototypeUITest : BaseTests() {
         else {
             Log.i(TAG, "Conversation started successfully.")
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
-            //wait for agent to disconnect
+            // wait for agent to disconnect
             apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
             checkForReadOnly()
             bye()
             sleep(2000)
-            //connect again and check for readOnly
+            // connect again and check for readOnly
             reconnectReadOnly()
             bye()
         }
@@ -376,7 +376,7 @@ class ComposePrototypeUITest : BaseTests() {
             apiHelper.sendOutboundMessageFromAgentToUser(conversationInfo, outboundMessage)
             verifyResponse(outboundMessage)
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
-            //wait for agent to disconnect
+            // wait for agent to disconnect
             apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
             sendMsg(helloText)
             val conversation2Info = apiHelper.answerNewConversation()
@@ -384,14 +384,14 @@ class ComposePrototypeUITest : BaseTests() {
             else {
                 Log.i(TAG, "Conversation started successfully.")
                 if (conversationInfo.id != conversation2Info.id) AssertionError("Reconnecting a conversation may not have matching conversation IDs.")
-                else (Log.i(TAG, "Conversation ids matched as expected." ))
+                else (Log.i(TAG, "Conversation ids matched as expected."))
                 apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
-                //wait for agent to disconnect
+                // wait for agent to disconnect
                 apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
             }
         }
     }
-    
+
     @Test
     fun testHistoryPull() {
         apiHelper.disconnectAllConversations()
@@ -403,19 +403,19 @@ class ComposePrototypeUITest : BaseTests() {
         else {
             Log.i(TAG, "Conversation started successfully.")
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
-            //wait for agent to disconnect
+            // wait for agent to disconnect
             apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
             checkForReadOnly()
-            //enter history and check for ConversationDisconnect and ConversationAutostart events
+            // enter history and check for ConversationDisconnect and ConversationAutostart events
             history()
-            //Just to clear things up, let's start a new chat, wait for configured
+            // Just to clear things up, let's start a new chat, wait for configured
             startNewChat()
             val conversation2Info = apiHelper.answerNewConversation()
             if (conversation2Info == null) AssertionError("Unable to answer conversation.")
             else {
                 Log.i(TAG, "Conversation started successfully.")
                 apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
-                //wait for agent to disconnect
+                // wait for agent to disconnect
                 apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
             }
             bye()

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
@@ -10,6 +10,9 @@ import com.genesys.cloud.messenger.uitest.support.ApiHelper.answerNewConversatio
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.disconnectAllConversations
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendConnectOrDisconnect
 import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendTypingIndicatorFromAgentToUser
+import com.genesys.cloud.messenger.uitest.support.ApiHelper.sendOutboundMessageFromAgentToUser
+import com.genesys.cloud.messenger.uitest.support.ApiHelper.waitForParticipantToConnectOrDisconnect
+import com.genesys.cloud.messenger.uitest.support.testConfig
 import org.junit.FixMethodOrder
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,7 +31,7 @@ class ComposePrototypeUITest : BaseTests() {
     private val sendMsgText = "send"
     private val helloText = "hello"
     private val healthCheckText = "healthCheck"
-    private val historyText = "history 1 1"
+    private val historyText = "history"
     private val attachImageText = "attach"
     private val detachImageText = "detach"
     private val byeText = "bye"
@@ -42,17 +45,30 @@ class ComposePrototypeUITest : BaseTests() {
     private val customAttributeAddedText = "Custom attribute added"
     private val oneThousandText = "Code: 1000"
     private val healthCheckResponse = "HealthChecked"
-    private val historyFetchedText = "HistoryFetched"
     private val longClosedText = "The user has closed the connection"
     private val connectedText = "Connected: true"
+    private val newChatText = "newChat"
     private val typingIndicatorResponse = "AgentTyping"
+    private val outboundMessage = "Right back at you"
     private val autoStartEnabledText = "ConversationAutostart"
+    private var humanNameText = "name=Nellie Hay"
+    private val prodHumanNameText = "name=Beagle Puppy"
+    private var avatarText = "imageUrl=https://dev-inin-directory-service-profile.s3.amazonaws.com"
+    private val prodAvatorText = "imageUrl=https://prod-inin-directory-service-profile.s3.amazonaws.com"
+    private val humanText = "originatingEntity=Human"
+    private val deploymentText = "Deployment"
+    private val humanizeDisabledText = "from=Participant(name=null, imageUrl=null"
+    private val botImageName = "from=Participant(name=Test-Bot-Name, imageUrl=null"
+    private val botEntity = "originatingEntity=Bot"
+    private val yesText = "Yes"
+    private val anotherBotMessage = "Would you like to continue"
+    private val startOfConversationText = "Start of conversation"
     private val TAG = TestBedViewModel::class.simpleName
 
-    fun enterDeploymentInfo() {
+    fun enterDeploymentInfo(deploymentId: String) {
         opening {
             verifyPageIsVisible()
-            enterDeploymentID()
+            enterDeploymentID(deploymentId)
             selectView(testBedViewText)
         }
         messenger {
@@ -65,7 +81,26 @@ class ComposePrototypeUITest : BaseTests() {
         messenger {
             verifyPageIsVisible()
             enterCommand(connectText)
-            waitForProperResponse(connectedText)
+            waitForConfigured()
+        }
+    }
+
+    fun checkForReadOnly() {
+        messenger {
+            waitForReadOnly()
+        }
+    }
+
+    fun reconnectReadOnly() {
+        messenger {
+            enterCommand(connectText)
+            waitForReadOnly()
+        }
+    }
+
+    fun startNewChat() {
+        messenger {
+            enterCommand(newChatText)
             waitForConfigured()
         }
     }
@@ -77,6 +112,14 @@ class ComposePrototypeUITest : BaseTests() {
             enterCommand("$sendMsgText $messageText")
             waitForProperResponse(messageText)
             checkSendMsgFullResponse()
+        }
+    }
+
+    fun sendBotResponseAndCheckReply(messageText: String) {
+        messenger {
+            verifyPageIsVisible()
+            enterCommand("$sendMsgText $messageText")
+            verifyResponse(anotherBotMessage)
         }
     }
 
@@ -94,7 +137,7 @@ class ComposePrototypeUITest : BaseTests() {
         messenger {
             verifyPageIsVisible()
             enterCommand(historyText)
-            waitForProperResponse(historyFetchedText)
+            waitForProperResponse(startOfConversationText)
             checkHistoryFullResponse()
         }
     }
@@ -146,23 +189,30 @@ class ComposePrototypeUITest : BaseTests() {
         }
     }
 
-    fun verifyAutoStartResponse() {
+    fun enterDeploymentCommand(responseLookingFor: String) {
         messenger {
-            waitForProperResponse(autoStartEnabledText)
+            verifyPageIsVisible()
+            enterCommand(deploymentText)
+            waitForProperResponse(responseLookingFor)
+        }
+    }
+
+    fun verifyResponse(response: String) {
+        messenger {
+            waitForProperResponse(response)
         }
     }
 
     @Test
     fun testSendTypingIndicator() {
-        enterDeploymentInfo()
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
         connect()
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo != null) {
             apiHelper.sendTypingIndicatorFromAgentToUser(conversationInfo)
-            messenger {
-                waitForProperResponse(typingIndicatorResponse)
-            }
+            verifyResponse(typingIndicatorResponse)
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
         } else AssertionError("Agent did not answer conversation.")
         apiHelper.disconnectAllConversations()
@@ -171,11 +221,12 @@ class ComposePrototypeUITest : BaseTests() {
     @Test
     // Adjusting the test name to force this test to run first
     fun test1VerifyAutoStart() {
-        enterDeploymentInfo()
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         // Force a new session. AutoStart is enabled and newSession is true
         DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
         connect()
-        verifyAutoStartResponse()
+        verifyResponse(autoStartEnabledText)
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo == null) AssertionError("Unable to answer conversation with autoStart enabled.")
         else {
@@ -187,8 +238,8 @@ class ComposePrototypeUITest : BaseTests() {
 
     @Test
     fun testHealthCheck() {
-        enterDeploymentInfo()
-        DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         connect()
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo == null) AssertionError("Unable to answer conversation with autoStart enabled.")
@@ -201,16 +252,25 @@ class ComposePrototypeUITest : BaseTests() {
     }
 
     @Test
-    fun testSendMessage() {
-        enterDeploymentInfo()
-        DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
+    fun testSendAndReceiveMessage() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         connect()
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo == null) AssertionError("Unable to answer conversation.")
         else {
             Log.i(TAG, "Conversation started successfully.")
-            sleep(3000)
             sendMsg(helloText)
+            sleep(3000)
+            apiHelper.sendOutboundMessageFromAgentToUser(conversationInfo, outboundMessage)
+            verifyResponse(outboundMessage)
+            if (testConfig.domain == "mypurecloud.com") {
+                humanNameText = prodHumanNameText
+                avatarText = prodAvatorText
+            }
+            verifyResponse(humanNameText)
+            verifyResponse(avatarText)
+            verifyResponse(humanText)
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
         }
         bye()
@@ -218,9 +278,10 @@ class ComposePrototypeUITest : BaseTests() {
 
     @Test
     fun testAttachments() {
-        enterDeploymentInfo()
-        DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         connect()
+        sendMsg(helloText)
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo == null) AssertionError("Unable to answer conversation.")
         else {
@@ -235,8 +296,8 @@ class ComposePrototypeUITest : BaseTests() {
 
     @Test
     fun testCustomAttributes() {
-        enterDeploymentInfo()
-        DefaultTokenStore("com.genesys.cloud.messenger").store(UUID.randomUUID().toString())
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
         connect()
         val conversationInfo = apiHelper.answerNewConversation()
         if (conversationInfo == null) AssertionError("Unable to answer conversation.")
@@ -247,5 +308,117 @@ class ComposePrototypeUITest : BaseTests() {
             apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
         }
         bye()
+    }
+
+    @Test
+    fun testUnknownAgent() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.humanizeDisableDeploymentId)
+        connect()
+        sendMsg(helloText)
+        val conversationInfo = apiHelper.answerNewConversation()
+        if (conversationInfo == null) AssertionError("Unable to answer conversation.")
+        else {
+            Log.i(TAG, "Conversation started successfully.")
+            apiHelper.sendOutboundMessageFromAgentToUser(conversationInfo, outboundMessage)
+            verifyResponse(outboundMessage)
+            verifyResponse(humanizeDisabledText)
+            verifyResponse(humanText)
+            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+        }
+        bye()
+    }
+
+    @Test
+    fun testBotAgent() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.botDeploymentId)
+        connect()
+        verifyResponse(botImageName)
+        verifyResponse(botEntity)
+        sleep(3000)
+        sendBotResponseAndCheckReply(yesText)
+        bye()
+    }
+
+    @Test
+    fun testDisconnectAgent_ReadOnly() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.agentDisconnectDeploymentId)
+        connect()
+        sendMsg(helloText)
+        val conversationInfo = apiHelper.answerNewConversation()
+        if (conversationInfo == null) AssertionError("Unable to answer conversation.")
+        else {
+            Log.i(TAG, "Conversation started successfully.")
+            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            //wait for agent to disconnect
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            checkForReadOnly()
+            bye()
+            sleep(2000)
+            //connect again and check for readOnly
+            reconnectReadOnly()
+            bye()
+        }
+    }
+
+    @Test
+    fun testDisconnectAgent_NotReadOnly() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.deploymentId)
+        connect()
+        sendMsg(helloText)
+        val conversationInfo = apiHelper.answerNewConversation()
+        if (conversationInfo == null) AssertionError("Unable to answer conversation.")
+        else {
+            Log.i(TAG, "Conversation started successfully.")
+            apiHelper.sendOutboundMessageFromAgentToUser(conversationInfo, outboundMessage)
+            verifyResponse(outboundMessage)
+            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            //wait for agent to disconnect
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            sendMsg(helloText)
+            val conversation2Info = apiHelper.answerNewConversation()
+            if (conversation2Info == null) AssertionError("Unable to answer conversation.")
+            else {
+                Log.i(TAG, "Conversation started successfully.")
+                if (conversationInfo.id != conversation2Info.id) AssertionError("Reconnecting a conversation may not have matching conversation IDs.")
+                else (Log.i(TAG, "Conversation ids matched as expected." ))
+                apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
+                //wait for agent to disconnect
+                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
+            }
+        }
+    }
+
+    @Test
+    fun testHistoryPull() {
+        apiHelper.disconnectAllConversations()
+        enterDeploymentInfo(testConfig.agentDisconnectDeploymentId)
+        connect()
+        sendMsg(helloText)
+        val conversationInfo = apiHelper.answerNewConversation()
+        if (conversationInfo == null) AssertionError("Unable to answer conversation.")
+        else {
+            Log.i(TAG, "Conversation started successfully.")
+            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            //wait for agent to disconnect
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            checkForReadOnly()
+            //enter history and check for ConversationDisconnect and ConversationAutostart events
+            history()
+            //Just to clear things up, let's start a new chat, wait for configured
+            startNewChat()
+            val conversation2Info = apiHelper.answerNewConversation()
+            if (conversation2Info == null) AssertionError("Unable to answer conversation.")
+            else {
+                Log.i(TAG, "Conversation started successfully.")
+                apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
+                //wait for agent to disconnect
+                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
+            }
+            bye()
+        }
     }
 }

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
@@ -133,12 +133,13 @@ class ComposePrototypeUITest : BaseTests() {
     }
 
     // Send a history command, wait for the response, and verify it is correct
-    fun history() {
+    fun history(withConversationDisconnectEvent: Boolean = true) {
         messenger {
             verifyPageIsVisible()
             enterCommand(historyText)
             waitForProperResponse(startOfConversationText)
-            checkHistoryFullResponse()
+            if (withConversationDisconnectEvent) checkHistoryForAutoStartAndDisconnectEventsResponse()
+            else checkHistoryDoesNotContainDisconnectEventOrReadOnlyResponse()
         }
     }
 
@@ -213,7 +214,7 @@ class ComposePrototypeUITest : BaseTests() {
         if (conversationInfo != null) {
             apiHelper.sendTypingIndicatorFromAgentToUser(conversationInfo)
             verifyResponse(typingIndicatorResponse)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         } else AssertionError("Agent did not answer conversation.")
         apiHelper.disconnectAllConversations()
     }
@@ -231,7 +232,7 @@ class ComposePrototypeUITest : BaseTests() {
         if (conversationInfo == null) AssertionError("Unable to answer conversation with autoStart enabled.")
         else {
             Log.i(TAG, "Conversation started successfully with autoStart enabled.")
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         apiHelper.disconnectAllConversations()
     }
@@ -246,7 +247,7 @@ class ComposePrototypeUITest : BaseTests() {
         else {
             Log.i(TAG, "Conversation started successfully with autoStart enabled.")
             healthcheckTest()
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         bye()
     }
@@ -271,7 +272,7 @@ class ComposePrototypeUITest : BaseTests() {
             verifyResponse(humanNameText)
             verifyResponse(avatarText)
             verifyResponse(humanText)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         bye()
     }
@@ -289,7 +290,7 @@ class ComposePrototypeUITest : BaseTests() {
             attachImage()
             // wait for image to load
             sleep(3000)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         bye()
     }
@@ -305,7 +306,7 @@ class ComposePrototypeUITest : BaseTests() {
             Log.i(TAG, "Conversation started successfully.")
             addCustomAttribute(nameText, newNameText)
             sleep(3000)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         bye()
     }
@@ -324,7 +325,7 @@ class ComposePrototypeUITest : BaseTests() {
             verifyResponse(outboundMessage)
             verifyResponse(humanizeDisabledText)
             verifyResponse(humanText)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
         }
         bye()
     }
@@ -338,6 +339,8 @@ class ComposePrototypeUITest : BaseTests() {
         verifyResponse(botEntity)
         sleep(3000)
         sendBotResponseAndCheckReply(yesText)
+        sleep(2000)
+        history(withConversationDisconnectEvent = false)
         bye()
     }
 
@@ -351,9 +354,10 @@ class ComposePrototypeUITest : BaseTests() {
         if (conversationInfo == null) AssertionError("Unable to answer conversation.")
         else {
             Log.i(TAG, "Conversation started successfully.")
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            // conversationInfo: Conversation, connecting: Boolean, wrapup: Boolean = true
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
             // wait for agent to disconnect
-            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id)
             checkForReadOnly()
             bye()
             sleep(2000)
@@ -375,9 +379,9 @@ class ComposePrototypeUITest : BaseTests() {
             Log.i(TAG, "Conversation started successfully.")
             apiHelper.sendOutboundMessageFromAgentToUser(conversationInfo, outboundMessage)
             verifyResponse(outboundMessage)
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
             // wait for agent to disconnect
-            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id)
             sendMsg(helloText)
             val conversation2Info = apiHelper.answerNewConversation()
             if (conversation2Info == null) AssertionError("Unable to answer conversation.")
@@ -385,9 +389,9 @@ class ComposePrototypeUITest : BaseTests() {
                 Log.i(TAG, "Conversation started successfully.")
                 if (conversationInfo.id != conversation2Info.id) AssertionError("Reconnecting a conversation may not have matching conversation IDs.")
                 else (Log.i(TAG, "Conversation ids matched as expected."))
-                apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
+                apiHelper.sendConnectOrDisconnect(conversation2Info)
                 // wait for agent to disconnect
-                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
+                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id)
             }
         }
     }
@@ -402,9 +406,9 @@ class ComposePrototypeUITest : BaseTests() {
         if (conversationInfo == null) AssertionError("Unable to answer conversation.")
         else {
             Log.i(TAG, "Conversation started successfully.")
-            apiHelper.sendConnectOrDisconnect(conversationInfo, false, true)
+            apiHelper.sendConnectOrDisconnect(conversationInfo)
             // wait for agent to disconnect
-            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id, "disconnected")
+            apiHelper.waitForParticipantToConnectOrDisconnect(conversationInfo.id)
             checkForReadOnly()
             // enter history and check for ConversationDisconnect and ConversationAutostart events
             history()
@@ -414,9 +418,9 @@ class ComposePrototypeUITest : BaseTests() {
             if (conversation2Info == null) AssertionError("Unable to answer conversation.")
             else {
                 Log.i(TAG, "Conversation started successfully.")
-                apiHelper.sendConnectOrDisconnect(conversation2Info, false, true)
+                apiHelper.sendConnectOrDisconnect(conversation2Info)
                 // wait for agent to disconnect
-                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id, "disconnected")
+                apiHelper.waitForParticipantToConnectOrDisconnect(conversation2Info.id)
             }
             bye()
         }

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
@@ -392,6 +392,7 @@ class ComposePrototypeUITest : BaseTests() {
         }
     }
 
+    
     @Test
     fun testHistoryPull() {
         apiHelper.disconnectAllConversations()

--- a/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
+++ b/androidComposePrototype/src/androidTest/java/com/genesys/cloud/messenger/uitest/test/ComposePrototypeUITest.kt
@@ -391,7 +391,6 @@ class ComposePrototypeUITest : BaseTests() {
             }
         }
     }
-
     
     @Test
     fun testHistoryPull() {

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import com.genesys.cloud.messenger.androidcomposeprototype.BuildConfig
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Detached
 import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.core.MessageEvent
@@ -46,16 +45,16 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         private set
     var deploymentId: String by mutableStateOf("")
         private set
-    var region: String by mutableStateOf("inindca")
+    var region: String by mutableStateOf("inindca.com")
         private set
 
-    val regions = listOf("inindca")
+    val regions = listOf("inindca.com", "mypurecloud.com")
     private val customAttributes = mutableMapOf<String, String>()
 
     suspend fun init(context: Context) {
         val mmsdkConfiguration = Configuration(
-            deploymentId = BuildConfig.DEPLOYMENT_ID,
-            domain = BuildConfig.DEPLOYMENT_DOMAIN,
+            deploymentId = deploymentId,
+            domain = region,
             logging = true
         )
         DefaultTokenStore.context = context


### PR DESCRIPTION
Add three new tests for Conversation Disconnect

- testDisconnectAgent_ReadOnly
- testDisconnectAgent_NotReadOnly
- testHistoryPull

Update method for entering Deployment ID
Remove unnecessary calls to DefaultTokenStore
