### PR TITLE
Remove unapropriate log warning.

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -385,11 +385,6 @@ internal class MessagingClientImpl(
                                 if (!connected && isStartingANewSession) {
                                     cleanUp()
                                     configureSession(startNew = true)
-                                } else {
-                                    // Normally should not happen.
-                                    log.w {
-                                        "Unexpected SessionResponse configuration: connected: $connected, readOnly: $readOnly, isStartingANewSession: $isStartingANewSession"
-                                    }
                                 }
                             } else {
                                 isStartingANewSession = false


### PR DESCRIPTION
- Remove an unapropriate log warning. Having a SessionResponse `connected=true` and `readOnly=true` is completely legitimate scenario where user starts an old session that was closed by Agent and is able to connect to this session. NOTE that there are no effect on actual code behaviour, it is just a log warning that was printed where it should not.