### PR TITLE
MTSDK-187 duplicated symbols when transport used in intermediary framework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 // CocoaPods requires the podspec to have a `version`.
-val buildVersion = "2.3.1"
+val buildVersion = "2.3.2"
 val snapshot = System.getenv("SNAPSHOT_BUILD") ?: ""
 version = "${buildVersion}${snapshot}"
 group = "cloud.genesys"

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -1,7 +1,7 @@
 platform :ios, '13.0'
+use_frameworks!
 
 target 'iosApp' do
-  use_frameworks!
   pod 'transport', :path => '../transport'
 
   target 'iosAppTests' do

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - transport (2.3.1)
+  - transport (2.3.2)
 
 DEPENDENCIES:
   - transport (from `../transport`)
@@ -9,8 +9,8 @@ EXTERNAL SOURCES:
     :path: "../transport"
 
 SPEC CHECKSUMS:
-  transport: f86d3bfdd48460d950f81ecb4db2e375df9d1ba0
+  transport: 2bfb1fe7be748decaaddf0e2f9e87e5a72a9576d
 
-PODFILE CHECKSUM: c3105f0698090ba6d9702820eb0f13f123776417
+PODFILE CHECKSUM: 10743e43aeaf72bb49673a0e57360c028906ace5
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,12 +14,12 @@
 		7555FF8B242A565B00829871 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7555FF89242A565B00829871 /* LaunchScreen.storyboard */; };
 		7555FF96242A565B00829871 /* iosAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF95242A565B00829871 /* iosAppTests.swift */; };
 		7555FFA1242A565B00829871 /* iosAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FFA0242A565B00829871 /* iosAppUITests.swift */; };
+		8744E72642A64695748E911C /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83E5C5259A079A8109FD4D26 /* Pods_iosApp.framework */; };
 		8C3B252A2926EAC500599F72 /* PropertiesResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C3B25292926EAC500599F72 /* PropertiesResource.swift */; };
 		8C4A6A1A273C3CD8008B8150 /* deployment.properties in Resources */ = {isa = PBXBuildFile; fileRef = 8C4A6A19273C3CD8008B8150 /* deployment.properties */; };
 		8C4A6A23273C696C008B8150 /* Deployment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C4A6A22273C696C008B8150 /* Deployment.swift */; };
 		8CF6294F27074EB400AE0CA8 /* TestbedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF6294E27074EB400AE0CA8 /* TestbedViewController.swift */; };
 		8CF62953270754C000AE0CA8 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF80242A565900829871 /* SceneDelegate.swift */; };
-		943EC8CC4FD75C346A3D9489 /* Pods_iosAppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CB900D5580757176254F1A3C /* Pods_iosAppTests.framework */; };
 		BA5B8CD428CA2FEC007C8160 /* MessengerInteractorTester.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */; };
 		BA88FE14284953CA009AA1F8 /* MessengerInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */; };
 		BA88FE16284A54E7009AA1F8 /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = BA88FE15284A54E6009AA1F8 /* config.json */; };
@@ -30,7 +30,7 @@
 		BA88FE28284A5501009AA1F8 /* Conversations.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE20284A5501009AA1F8 /* Conversations.swift */; };
 		BA88FE29284A5501009AA1F8 /* PresenceApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE21284A5501009AA1F8 /* PresenceApi.swift */; };
 		BA88FE2B284A57E2009AA1F8 /* WaitHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA88FE2A284A57E2009AA1F8 /* WaitHandler.swift */; };
-		E919DAB897632FE181838B4E /* Pods_iosApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C8D263996FA013F554AE7AE /* Pods_iosApp.framework */; };
+		C22601993935C25A95085E03 /* Pods_iosAppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D8A56A951E09FAE20CAAEA /* Pods_iosAppTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,10 +67,10 @@
 		7555FF9C242A565B00829871 /* iosAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FFA0242A565B00829871 /* iosAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iosAppUITests.swift; sourceTree = "<group>"; };
 		7555FFA2242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		83E5C5259A079A8109FD4D26 /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C3B25292926EAC500599F72 /* PropertiesResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesResource.swift; sourceTree = "<group>"; };
 		8C4A6A19273C3CD8008B8150 /* deployment.properties */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = deployment.properties; path = ../../deployment.properties; sourceTree = "<group>"; };
 		8C4A6A22273C696C008B8150 /* Deployment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Deployment.swift; sourceTree = "<group>"; };
-		8C8D263996FA013F554AE7AE /* Pods_iosApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8CF6294E27074EB400AE0CA8 /* TestbedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestbedViewController.swift; sourceTree = "<group>"; };
 		BA5B8CD328CA2FEC007C8160 /* MessengerInteractorTester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractorTester.swift; sourceTree = "<group>"; };
 		BA88FE13284953CA009AA1F8 /* MessengerInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessengerInteractor.swift; sourceTree = "<group>"; };
@@ -84,7 +84,7 @@
 		BA88FE2A284A57E2009AA1F8 /* WaitHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitHandler.swift; sourceTree = "<group>"; };
 		BC5D7F2B53B6DBC6BEB75144 /* Pods-iosAppTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosAppTests.debug.xcconfig"; path = "Target Support Files/Pods-iosAppTests/Pods-iosAppTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BDCCB9F2071142B5F5507788 /* Pods-iosApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iosApp.release.xcconfig"; path = "Target Support Files/Pods-iosApp/Pods-iosApp.release.xcconfig"; sourceTree = "<group>"; };
-		CB900D5580757176254F1A3C /* Pods_iosAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0D8A56A951E09FAE20CAAEA /* Pods_iosAppTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_iosAppTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,7 +92,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E919DAB897632FE181838B4E /* Pods_iosApp.framework in Frameworks */,
+				8744E72642A64695748E911C /* Pods_iosApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,7 +100,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				943EC8CC4FD75C346A3D9489 /* Pods_iosAppTests.framework in Frameworks */,
+				C22601993935C25A95085E03 /* Pods_iosAppTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -220,8 +220,8 @@
 		E908B9E7C8AA38BA63E55CF7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				8C8D263996FA013F554AE7AE /* Pods_iosApp.framework */,
-				CB900D5580757176254F1A3C /* Pods_iosAppTests.framework */,
+				83E5C5259A079A8109FD4D26 /* Pods_iosApp.framework */,
+				D0D8A56A951E09FAE20CAAEA /* Pods_iosAppTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -237,6 +237,7 @@
 				7555FF77242A565900829871 /* Sources */,
 				7555FF78242A565900829871 /* Frameworks */,
 				7555FF79242A565900829871 /* Resources */,
+				DC097616B7FF9217867AA1BF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -399,6 +400,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DC097616B7FF9217867AA1BF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-iosApp/Pods-iosApp-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/transport/GenesysCloudMessengerTransport.podspec
+++ b/transport/GenesysCloudMessengerTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                   = 'GenesysCloudMessengerTransport'
-  s.version                = '2.2.0'
+  s.version                = '2.3.2'
   s.summary                = 'Genesys Cloud Messenger Transport SDK'
 
   s.description            = <<-DESC
@@ -33,7 +33,7 @@ SOFTWARE.
                                LICENSE
                              }
   s.author                 = 'Genesys Cloud Services, Inc.'
-  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.2.0/MessengerTransport.xcframework.zip' }
+  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.3.2/MessengerTransport.xcframework.zip' }
 
   s.ios.deployment_target  = '13.0'
 

--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -89,7 +89,7 @@ kotlin {
             baseName = iosFrameworkName
             // To specify a custom Objective-C prefix/name for the Kotlin framework, use the `-module-name` compiler option or matching Gradle DSL statement.
             freeCompilerArgs += listOf("-module-name", "GCM")
-            isStatic = true
+            isStatic = false
         }
     }
 
@@ -192,7 +192,7 @@ tasks {
                 .replace(oldValue = "<VERSION>", newValue = version.toString())
                 .replace(
                     oldValue = "<SOURCE_HTTP_URL>",
-                    newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/${version}/MessengerTransport.xcframework.zip"
+                    newValue = "https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v${version}/MessengerTransport.xcframework.zip"
                 )
             file(podspecFileName, PathValidation.NONE).writeText(content)
             println("CocoaPods podspec for Pod $iosCocoaPodName written to: ${this.project.projectDir}/$podspecFileName")

--- a/transport/transport.podspec
+++ b/transport/transport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'transport'
-    spec.version                  = '2.3.1'
+    spec.version                  = '2.3.2'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http=> ''}
     spec.authors                  = 'Genesys Cloud Services, Inc.'


### PR DESCRIPTION
Patches an issue introduced in v2.3.0 where the CocoapodsExtension was configured to be static. This caused duplicated symbols when transport was named as a dependency in an intermediary framework and also depended on by an enclosing app using both transport and the intermediary frameworks.

* configure CocoapodsExtension to `isStatic = false`
* bump version to 2.3.2