### PR TITLE
MTSDK-216 Transition To State.ReadOnly before dispatching Event.Conve…

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -56,6 +56,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class MessagingClientImplTest {
     private val configuration = configuration()
@@ -929,8 +930,12 @@ class MessagingClientImplTest {
             )
         )
 
-        verify { mockEventHandler.onEvent(eq(expectedEvent)) }
-        verify { mockStateChangedListener.invoke(fromConfiguredToReadOnly()) }
+        assertTrue(subject.currentState is State.ReadOnly)
+        verifySequence {
+            connectSequence()
+            mockStateChangedListener.invoke(fromConfiguredToReadOnly())
+            mockEventHandler.onEvent(eq(expectedEvent))
+        }
     }
 
     @Test

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -384,12 +384,10 @@ internal class MessagingClientImpl(
             StructuredMessage.Type.Event -> {
                 if (structuredMessage.isOutbound()) {
                     structuredMessage.events.forEach {
-                        if (it.isDisconnectionEvent()) {
-                            eventHandler.onEvent(it.toTransportEvent())
-                            if (structuredMessage.metadata["readOnly"].toBoolean()) stateMachine.onReadOnly()
-                        } else {
-                            eventHandler.onEvent(it.toTransportEvent())
+                        if (it.isDisconnectionEvent() && structuredMessage.metadata["readOnly"].toBoolean()) {
+                            stateMachine.onReadOnly()
                         }
+                        eventHandler.onEvent(it.toTransportEvent())
                     }
                 } else {
                     structuredMessage.events.forEach {


### PR DESCRIPTION
Transition To State.ReadOnly before dispatching Event.ConversationDisconnect

- Reorder sequence of handling Event.ConversationDisconnect. First do state transition and only then dispatch event.
- Update ConversationDisconnect related unit tests to ensure that calls happens in expected sequence.