### PR TITLE
Feature/mtsdk 209 support conversation clear on iOS testbed app

### DIFF
--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -143,8 +143,8 @@ final class MessengerInteractor {
     func fetchDeployment(completion: @escaping (DeploymentConfig?, Error?) -> Void) {
         messengerTransport.fetchDeploymentConfig(completionHandler: completion)
     }
-
-    func clearConversation() {
+    
+    func invalidateConversationCache() {
         messagingClient.invalidateConversationCache()
     }
 
@@ -153,6 +153,15 @@ final class MessengerInteractor {
             try messagingClient.indicateTyping()
         } catch {
             print("indicateTyping() failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
+    
+    func clearConversation() throws {
+        do {
+            try messagingClient.clearConversation()
+        } catch {
+            print("clearConversation() failed. \(error.localizedDescription)")
             throw error
         }
     }

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -445,7 +445,6 @@ extension TestbedViewController : UITextFieldDelegate {
                         let plistData = FileManager.default.contents(atPath: plistPath),
                         let plistDictionary = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any],
                         let signInRedirectURI = plistDictionary["signInRedirectURI"] as? String,
-                      
                         let codeVerifier: String? = pkceEnabled ? plistDictionary["codeVerifier"] as? String : nil
                 else {
                     authState = AuthState.error(errorCode: ErrorCode.AuthFailed.shared, message: "Unable to read Okta.plist or missing required key", correctiveAction: CorrectiveAction.ReAuthenticate.shared)

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -49,10 +49,11 @@ class TestbedViewController: UIViewController {
         case deployment
         case bye
         case healthCheck
-        case clearConversation
+        case invalidateConversationCache
         case addAttribute
         case typing
         case authorize
+        case clearConversation
 
         var helpDescription: String {
             switch self {
@@ -418,8 +419,8 @@ extension TestbedViewController : UITextFieldDelegate {
                     }
                     self.info.text = "<\(deploymentConfig?.description() ?? "Unknown deployment config")>"
                 }
-            case (.clearConversation, _):
-                messenger.clearConversation()
+            case (.invalidateConversationCache, _):
+                messenger.invalidateConversationCache()
             case(.addAttribute, let msg?):
                 let segments = segmentUserInput(msg)
                 if let key = segments.0, !key.isEmpty {
@@ -444,6 +445,7 @@ extension TestbedViewController : UITextFieldDelegate {
                         let plistData = FileManager.default.contents(atPath: plistPath),
                         let plistDictionary = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any],
                         let signInRedirectURI = plistDictionary["signInRedirectURI"] as? String,
+                      
                         let codeVerifier: String? = pkceEnabled ? plistDictionary["codeVerifier"] as? String : nil
                 else {
                     authState = AuthState.error(errorCode: ErrorCode.AuthFailed.shared, message: "Unable to read Okta.plist or missing required key", correctiveAction: CorrectiveAction.ReAuthenticate.shared)
@@ -452,6 +454,8 @@ extension TestbedViewController : UITextFieldDelegate {
                 }
                 
                 messenger.authorize(authCode: self.authCode ?? "", redirectUri: signInRedirectURI, codeVerifier: codeVerifier)
+            case (.clearConversation, _):
+                try messenger.clearConversation()
             default:
                 self.info.text = "Invalid command"
             }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -232,4 +232,20 @@ interface MessagingClient {
      */
     @Throws(IllegalStateException::class)
     fun logoutFromAuthenticatedSession()
+
+    /**
+     * Permanently clears the existing conversation history with an agent from all devices that share the same session.
+     * This action is allowed in both [State.Configured] and [State.ReadOnly].
+     *
+     * After successful clearance, [Event.ConversationCleared] will be dispatched to allow
+     * the application to update the UI and clear necessary cache.
+     *
+     * In case of failure, [Event.Error] will be dispatched with a description of the failure cause.
+     *
+     * Note: Calling this API will result in the WebSocket connection being closed and new session will be created upon [connect].
+     *
+     * @throws IllegalStateException if the current state of the MessagingClient is not compatible with the requested action.
+     */
+    @Throws(IllegalStateException::class)
+    fun clearConversation()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -254,6 +254,11 @@ internal class MessagingClientImpl(
         authHandler.logout()
     }
 
+    @Throws(IllegalStateException::class)
+    override fun clearConversation() {
+        log.w { "clearConversation() Api is not implemented yet." }
+    }
+
     override fun invalidateConversationCache() {
         log.i { "Clear conversation history." }
         messageStore.invalidateConversationCache()


### PR DESCRIPTION
- Add clearConversation() API to MessagingClient.kt
- Repurpose clearConversation command to perform clearConversation API, instead of doing the invalidateConversationCache.
- Add invalidateConversationCache command that will perform a call to client.invalidateConversationCache() API.
- Implement a temporary placeholder for clearConversation() API in MessagingClientImpl.kt