### PR TITLE
MTSDK-213 Handle SessionClearedEvent

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImplTest.kt
@@ -1457,6 +1457,20 @@ class MessagingClientImplTest {
         }
     }
 
+    @Test
+    fun whenSessionClearedEventReceived() {
+        val expectedEvent = Event.ConversationCleared
+
+        subject.connect()
+        slot.captured.onMessage(Response.sessionClearedEvent)
+
+        verifySequence {
+            connectSequence()
+            mockEventHandler.onEvent(eq(expectedEvent))
+        }
+    }
+
+
     private fun configuration(): Configuration = Configuration(
         deploymentId = "deploymentId",
         domain = "inindca.com",
@@ -1619,6 +1633,8 @@ private object Response {
         """{"type":"message","class":"LogoutEvent","code":200,"body":{}}"""
     const val unauthorized =
         """{"type": "response","class": "string","code": 401,"body": "User is unauthorized"}"""
+    const val sessionClearedEvent =
+        """{"type":"message","class":"SessionClearedEvent","code":200,"body":{}}"""
 
     fun structuredMessageWithEvents(
         events: String = defaultStructuredEvents,

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerTest.kt
@@ -8,6 +8,7 @@ import com.genesys.cloud.messenger.transport.core.events.Event.AgentTyping
 import com.genesys.cloud.messenger.transport.core.events.Event.Authorized
 import com.genesys.cloud.messenger.transport.core.events.Event.ConnectionClosed
 import com.genesys.cloud.messenger.transport.core.events.Event.ConversationAutostart
+import com.genesys.cloud.messenger.transport.core.events.Event.ConversationCleared
 import com.genesys.cloud.messenger.transport.core.events.Event.ConversationDisconnect
 import com.genesys.cloud.messenger.transport.core.events.Event.Error
 import com.genesys.cloud.messenger.transport.core.events.Event.HealthChecked
@@ -41,6 +42,7 @@ class EventHandlerTest {
             ConnectionClosed,
             Authorized,
             Logout,
+            ConversationCleared,
         )
 
         events.forEach {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -25,6 +25,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.JwtResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.LogoutEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.SessionClearedEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionExpiredEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
@@ -558,6 +559,7 @@ internal class MessagingClientImpl(
                         eventHandler.onEvent(Event.Logout)
                         disconnect()
                     }
+                    is SessionClearedEvent -> eventHandler.onEvent(Event.ConversationCleared)
                     else -> {
                         log.i { "Unhandled message received from Shyrka: $decoded " }
                     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -59,4 +59,9 @@ sealed class Event {
      * Sent when user has been logged out from authenticated session.
      */
     object Logout : Event()
+
+    /**
+     * Sent when conversation was successfully cleared.
+     */
+    object ConversationCleared : Event()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/WebMessagingJson.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/WebMessagingJson.kt
@@ -8,6 +8,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.LogoutEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageClassName
 import com.genesys.cloud.messenger.transport.shyrka.receive.PreIdentifiedWebMessagingMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.SessionClearedEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionExpiredEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
@@ -62,6 +63,8 @@ internal object WebMessagingJson {
                 json.decodeFromString<WebMessagingMessage<ConnectionClosedEvent>>(string)
             MessageClassName.LOGOUT_EVENT.value ->
                 json.decodeFromString<WebMessagingMessage<LogoutEvent>>(string)
+            MessageClassName.SESSION_CLEARED_EVENT.value ->
+                json.decodeFromString<WebMessagingMessage<SessionClearedEvent>>(string)
             else -> throw IllegalArgumentException()
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/MessageClassName.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/MessageClassName.kt
@@ -14,4 +14,5 @@ internal enum class MessageClassName(val value: String) {
     TOO_MANY_REQUESTS_ERROR_MESSAGE("TooManyRequestsErrorMessage"),
     CONNECTION_CLOSED_EVENT("ConnectionClosedEvent"),
     LOGOUT_EVENT("LogoutEvent"),
+    SESSION_CLEARED_EVENT("SessionClearedEvent"),
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionClearedEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionClearedEvent.kt
@@ -1,0 +1,6 @@
+package com.genesys.cloud.messenger.transport.shyrka.receive
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal class SessionClearedEvent

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -13,6 +13,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.JwtResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.LogoutEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.MessageType
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
+import com.genesys.cloud.messenger.transport.shyrka.receive.SessionClearedEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionExpiredEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
@@ -460,5 +461,15 @@ class SerializationTest {
         val result = WebMessagingJson.decodeFromString(givenStructuredMessage)
 
         assertThat(result).isEqualTo(expectedStructuredMessage)
+    }
+
+    @Test
+    fun whenSessionClearedEventThenDecodes() {
+        val json = """{"type":"message","class":"SessionClearedEvent","code":200,"body":{}}"""
+
+        val message = decode(json)
+
+        assertThat(message.body, "WebMessagingMessage body").isNotNull()
+            .hasClass(SessionClearedEvent::class)
     }
 }


### PR DESCRIPTION
- Listen to SessionClearedEvent from Shyrka and dispatch Event.ConversationCleared once received.
- Add new Event.ConversationCleared to let UI know that conversation was successfully cleared.
- Add/Update unit tests to reflect changes and additions.