### PR TITLE
MTSDK-196 iOS-17(beta) exception handling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.21")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
         classpath("com.android.tools.build:gradle:7.3.1")
         classpath("org.jmailen.gradle:kotlinter-gradle:3.4.0")
         classpath("com.vanniktech:gradle-android-junit-jacoco-plugin:0.16.0")

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -4,7 +4,7 @@ object Deps {
     private const val junitVersion = "4.13.2"
     private const val kermitVersion = "1.1.2"
     private const val kotlinxSerializationJsonVersion = "1.3.2"
-    private const val ktorVersion = "2.2.2"
+    private const val ktorVersion = "2.3.3"
     private const val mockWebServerVersion = "4.9.0"
     private const val mockkVersion = "1.13.3"
     private const val okhttpVersion = "4.10.0"


### PR DESCRIPTION
Apple have a bug in iOS 17 (beta) where some network requests result in crash on simulator devices:
https://youtrack.jetbrains.com/issue/KT-59124/kmm-production-sample-iOS-app-crashes-after-start-on-iOS17-Beta

There is a workaround implemented in ktor 2.3.3 that helps to avoid a hard-crush. 

P.S. also it seems like apple have resolved this issue on their end as well. 

- Upgrade ktor version to 2.3.3