### PR TITLE
MTSDK-253 Expose SCP data as API

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
@@ -5,8 +5,13 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 internal object Response {
-    fun configureSuccess(connected: Boolean = true, readOnly: Boolean = false): String =
-        """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":$connected,"newSession":true,"readOnly":$readOnly}}"""
+    fun configureSuccess(
+        connected: Boolean = true,
+        readOnly: Boolean = false,
+        allowedMedia: String = AllowedMedia.empty,
+        blockedExtensions: String = AllowedMedia.emptyBlockedExtensions,
+    ): String =
+        """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":$connected,"newSession":true,"readOnly":$readOnly$allowedMedia$blockedExtensions}}"""
     const val configureSuccessWithNewSessionFalse =
         """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":true,"newSession":false}}"""
     const val webSocketRequestFailed =
@@ -52,5 +57,15 @@ internal object Response {
         return """{"type": "message","class": "StructuredMessage","code": 200,"body": {"direction": "${direction.name}","id": "0000000-0000-0000-0000-0000000000","channel": {"time": "2022-03-09T13:35:31.104Z","messageId": "0000000-0000-0000-0000-0000000000"},"type": "Event","metadata": ${
         Json.encodeToString(metadata)
         },"events": [$events]}}"""
+    }
+
+    internal object AllowedMedia {
+        const val empty = ""
+        const val emptyBlockedExtensions = ""
+        const val listOfBlockedExtensions = ""","blockedExtensions":[".ade",".adp"]"""
+        const val noInbound = ""","allowedMedia":{}"""
+        const val emptyInbound = ""","allowedMedia":{"inbound":{}}"""
+        const val listOfFileTypesWithMaxSize = ""","allowedMedia":{"inbound":{"fileTypes":[{"type":"video/mpg"},{"type":"video/3gpp"}],"maxFileSizeKB":10240}}"""
+        const val listOfFileTypesWithWildcardAndMaxSize = ""","allowedMedia":{"inbound":{"fileTypes":[{"type":"*/*"},{"type":"video/3gpp"}],"maxFileSizeKB":10240}}"""
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/FileAttachmentProfile.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/FileAttachmentProfile.kt
@@ -1,0 +1,16 @@
+package com.genesys.cloud.messenger.transport.core
+
+/**
+ * Represents a configuration for supported content profiles in the Admin Console.
+ *
+ * @property allowedFileTypes the list of file types allowed for upload.
+ * @property blockedFileTypes the list of file types that are NOT allowed for upload.
+ * @property maxFileSizeKB the maximum allowed file size in kilobytes.
+ * @property hasWildCard indicates if a wildcard is present in [allowedFileTypes]
+ */
+data class FileAttachmentProfile(
+    val allowedFileTypes: List<String> = emptyList(),
+    val blockedFileTypes: List<String> = emptyList(),
+    val maxFileSizeKB: Long? = null,
+    val hasWildCard: Boolean = false,
+)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -110,6 +110,8 @@ interface MessagingClient {
      *
      * If an attempt is made to upload a file with an extension that is not included in the `allowedFileTypes` list,
      * it will result in an `IllegalArgumentException` when using the [attach] function.
+     *
+     * NOTE: `fileAttachmentProfile` should be accessible (not null) once `MessagingClient` has transitioned to `State.Configured`.
      */
     val fileAttachmentProfile: FileAttachmentProfile?
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -103,6 +103,17 @@ interface MessagingClient {
     val conversation: List<Message>
 
     /**
+     * Represents the configuration for supported content profiles in the Admin Console.
+     *
+     * This property contains information about the allowed and blocked file extensions, maximum file size,
+     * and whether a wildcard is present in the allowed file types list.
+     *
+     * If an attempt is made to upload a file with an extension that is not included in the `allowedFileTypes` list,
+     * it will result in an `IllegalArgumentException` when using the [attach] function.
+     */
+    val fileAttachmentProfile: FileAttachmentProfile?
+
+    /**
      * Open and Configure a secure WebSocket connection to the Web Messaging service with the url and
      * deploymentId configured on this MessagingClient instance.
      *

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -44,6 +44,7 @@ import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomer
 import com.genesys.cloud.messenger.transport.shyrka.send.JourneyCustomerSession
 import com.genesys.cloud.messenger.transport.util.Platform
 import com.genesys.cloud.messenger.transport.util.Vault
+import com.genesys.cloud.messenger.transport.util.extensions.toFileAttachmentProfile
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
 import com.genesys.cloud.messenger.transport.util.extensions.toMessageList
 import com.genesys.cloud.messenger.transport.util.logs.Log
@@ -84,6 +85,7 @@ internal class MessagingClientImpl(
     private var connectAuthenticated = false
     private var isStartingANewSession = false
     private var reconfigureAttempts = 0
+    private var _fileAttachmentProfile: FileAttachmentProfile? = null
 
     override val currentState: State
         get() {
@@ -113,6 +115,9 @@ internal class MessagingClientImpl(
 
     override val conversation: List<Message>
         get() = messageStore.getConversation()
+
+    override val fileAttachmentProfile: FileAttachmentProfile?
+        get() = _fileAttachmentProfile
 
     @Throws(IllegalStateException::class)
     override fun connect() {
@@ -510,6 +515,7 @@ internal class MessagingClientImpl(
                     }
                     is SessionResponse -> {
                         decoded.body.run {
+                            _fileAttachmentProfile = this.toFileAttachmentProfile()
                             reconnectionHandler.clear()
                             if (readOnly) {
                                 stateMachine.onReadOnly()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
@@ -13,13 +13,13 @@ internal data class SessionResponse(
 
 @Serializable
 internal data class AllowedMedia(
-    val inbound: Inbound,
+    val inbound: Inbound? = null,
 )
 
 @Serializable
 internal data class Inbound(
-    val fileTypes: List<FileType>,
-    val maxFileSizeKB: Long,
+    val fileTypes: List<FileType> = emptyList(),
+    val maxFileSizeKB: Long? = null,
 )
 
 @Serializable

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
@@ -1,0 +1,3 @@
+package com.genesys.cloud.messenger.transport.util
+
+internal const val WILD_CARD = "*/*"

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -1,11 +1,14 @@
 package com.genesys.cloud.messenger.transport.util.extensions
 
 import com.genesys.cloud.messenger.transport.core.Attachment
+import com.genesys.cloud.messenger.transport.core.FileAttachmentProfile
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
 import com.genesys.cloud.messenger.transport.core.events.toTransportEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
+import com.genesys.cloud.messenger.transport.util.WILD_CARD
 import com.soywiz.klock.DateTime
 
 internal fun List<StructuredMessage>.toMessageList(): List<Message> {
@@ -73,4 +76,15 @@ private fun List<StructuredMessage.Content.AttachmentContent>.toAttachments(): M
             )
         }
     }
+}
+
+internal fun SessionResponse.toFileAttachmentProfile(): FileAttachmentProfile {
+    val allowedFileTypes = allowedMedia?.inbound?.fileTypes?.map { it.type }?.toMutableList() ?: mutableListOf()
+    val hasWildcard = allowedFileTypes.remove(WILD_CARD)
+    return FileAttachmentProfile(
+        allowedFileTypes = allowedFileTypes,
+        blockedFileTypes = blockedExtensions,
+        maxFileSizeKB = allowedMedia?.inbound?.maxFileSizeKB,
+        hasWildCard = hasWildcard
+    )
 }


### PR DESCRIPTION
- Add FileAttachmentProfile.kt to represent the SCP data in more convenient way.
- Add nullable fileAttachmentProfile field to MessagingClient.kt API.
- Map AllowedMedia to FileAttachmentProfile.kt when received in SessionResponse.
- Add new Const file to hold commonly used constants.
- Add KDoc for public api
- Add unit tests to cover possible parsing/mapping scenarios.