### PR TITLE
MTSDK-238 Validate file size before upload

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -14,6 +14,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.AllowedMedia
 import com.genesys.cloud.messenger.transport.shyrka.receive.FileType
 import com.genesys.cloud.messenger.transport.shyrka.receive.Inbound
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
@@ -21,6 +22,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
 import com.genesys.cloud.messenger.transport.shyrka.receive.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.fromIsoToEpochMilliseconds
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
+import com.genesys.cloud.messenger.transport.util.extensions.isRefreshUrl
 import com.genesys.cloud.messenger.transport.util.extensions.mapOriginatingEntity
 import com.genesys.cloud.messenger.transport.util.extensions.toFileAttachmentProfile
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
@@ -380,5 +382,61 @@ internal class MessageExtensionTest {
         val result = givenSessionResponse.toFileAttachmentProfile()
 
         assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are empty and fileSize is null`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = emptyMap(),
+            url = "https://downloadUrl.com",
+            fileSize = null,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are NOT empty and fileSize is null`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = mapOf("A" to "B"),
+            url = "https://downloadUrl.com",
+            fileSize = null,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are NOT empty and fileSize has value`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = mapOf("A" to "B"),
+            url = "https://downloadUrl.com",
+            fileSize = 1,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are empty and fileSize has value`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = emptyMap(),
+            url = "https://downloadUrl.com",
+            fileSize = 1,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isTrue()
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -10,7 +10,11 @@ import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses
 import com.genesys.cloud.messenger.transport.network.TestWebMessagingApiResponses.isoTestTimestamp
+import com.genesys.cloud.messenger.transport.shyrka.receive.AllowedMedia
+import com.genesys.cloud.messenger.transport.shyrka.receive.FileType
+import com.genesys.cloud.messenger.transport.shyrka.receive.Inbound
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
@@ -18,6 +22,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.fromIsoToEpochMilliseconds
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
 import com.genesys.cloud.messenger.transport.util.extensions.mapOriginatingEntity
+import com.genesys.cloud.messenger.transport.util.extensions.toFileAttachmentProfile
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
 import com.genesys.cloud.messenger.transport.util.extensions.toMessageList
 import org.junit.Test
@@ -25,7 +30,7 @@ import org.junit.Test
 internal class MessageExtensionTest {
 
     @Test
-    fun whenMessageEntityListToMessageList() {
+    fun `when MessageEntityList toMessageList()`() {
         val expectedMessage1 = Message(
             id = "5befde6373a23f32f20b59b4e1cba0e6",
             direction = Message.Direction.Outbound,
@@ -52,7 +57,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenInboundStructuredMessageToMessage() {
+    fun `when inbound StructuredMessage toMessage()`() {
         val givenStructuredMessage = StructuredMessage(
             id = "id",
             channel = StructuredMessage.Channel(
@@ -111,7 +116,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenGetUploadedAttachmentsWithOneUploadedAndOneDeletedAttachments() {
+    fun `when getUploadedAttachments() with 1 uploaded and 1 deleted attachments`() {
         val givenMessage =
             Message(
                 id = "test custom id",
@@ -143,7 +148,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenGetUploadedAttachmentsWithoutAttachments() {
+    fun `when getUploadedAttachments() but there are no attachments`() {
         val givenMessage =
             Message(
                 id = "test custom id",
@@ -156,7 +161,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenOutboundStructuredMessageToMessageFromParticipantWithUnknownInfo() {
+    fun `when outbound StructuredMessage toMessage() from participant with unknown info`() {
         val givenStructuredMessage = StructuredMessage(
             id = "id",
             type = StructuredMessage.Type.Text,
@@ -177,7 +182,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenFromIsoToEpochMillisecondsOnValidISOString() {
+    fun `when fromIsoToEpochMilliseconds() on valid ISO timestamp String`() {
         val expectedTimestamp = 1398892191411L
 
         val result = isoTestTimestamp.fromIsoToEpochMilliseconds()
@@ -186,21 +191,21 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenFromIsoToEpochMillisecondsOnInvalidString() {
+    fun `when fromIsoToEpochMilliseconds() on invalid timestamp String`() {
         val result = "invalid timestamp format".fromIsoToEpochMilliseconds()
 
         assertThat(result).isNull()
     }
 
     @Test
-    fun whenFromIsoToEpochMillisecondsOnNullString() {
+    fun `when fromIsoToEpochMilliseconds() on a null String`() {
         val result = null.fromIsoToEpochMilliseconds()
 
         assertThat(result).isNull()
     }
 
     @Test
-    fun whenOutboundStructuredMessageCheckedForIsOutbound() {
+    fun `when outbound StructuredMessage checked for isOutbound()`() {
         val givenStructuredMessage = StructuredMessage(
             id = "some_id",
             type = StructuredMessage.Type.Text,
@@ -211,7 +216,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenInboundStructuredMessageCheckedForIsOutbound() {
+    fun `when inbound StructuredMessage checked for isOutbound()`() {
         val givenStructuredMessage = StructuredMessage(
             id = "some_id",
             type = StructuredMessage.Type.Text,
@@ -222,7 +227,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenInboundStructuredMessageCheckedForIsInbound() {
+    fun `when inbound StructuredMessage checked for isInbound()`() {
         val givenStructuredMessage = StructuredMessage(
             id = "some_id",
             type = StructuredMessage.Type.Text,
@@ -233,7 +238,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenOutboundStructuredMessageCheckedForIsInbound() {
+    fun `when outbound StructuredMessage checked for isInbound()`() {
         val givenStructuredMessage = StructuredMessage(
             id = "some_id",
             type = StructuredMessage.Type.Text,
@@ -244,7 +249,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenMapOriginatingEntityHumanWithInboundFalse() {
+    fun `when mapOriginatingEntity() is Human with inbound=false`() {
         val givenIsInbound = false
         val originatingEntity = "Human"
         val expectedOriginatingEntity = Message.Participant.OriginatingEntity.Human
@@ -255,7 +260,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenMapOriginatingEntityBotWithInboundFalse() {
+    fun `when mapOriginatingEntity() is Bot with inbound=false`() {
         val givenIsInbound = false
         val originatingEntity = "Bot"
         val expectedOriginatingEntity = Message.Participant.OriginatingEntity.Bot
@@ -266,7 +271,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenMapOriginatingEntityUnknownWithInboundFalse() {
+    fun `when mapOriginatingEntity() is unknown with inbound=false`() {
         val givenIsInbound = false
         val originatingEntity = "any value"
         val expectedOriginatingEntity = Message.Participant.OriginatingEntity.Unknown
@@ -277,7 +282,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenMapOriginatingEntityNullWithInboundFalse() {
+    fun `when mapOriginatingEntity() is null with inbound=false`() {
         val givenIsInbound = false
         val originatingEntity = null
         val expectedOriginatingEntity = Message.Participant.OriginatingEntity.Unknown
@@ -288,7 +293,7 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun whenMapOriginatingEntityBotWithInboundTrue() {
+    fun `when mapOriginatingEntity() is Bot with inbound=true`() {
         val givenIsInbound = true
         val originatingEntity = "Bot"
         val expectedOriginatingEntity = Message.Participant.OriginatingEntity.Human
@@ -296,5 +301,84 @@ internal class MessageExtensionTest {
         val result = originatingEntity.mapOriginatingEntity { givenIsInbound }
 
         assertThat(result).isEqualTo(expectedOriginatingEntity)
+    }
+
+    @Test
+    fun `when SessionResponse toFileAttachmentProfile() but it has no AllowedMedia and blockedExtensions entries`() {
+        val givenSessionResponse = SessionResponse(connected = true)
+        val expectedFileAttachmentProfile = FileAttachmentProfile()
+
+        val result = givenSessionResponse.toFileAttachmentProfile()
+
+        assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when SessionResponse toFileAttachmentProfile() but AllowedMedia has no inbound and blockedExtensions entries`() {
+        val givenSessionResponse = SessionResponse(connected = true, allowedMedia = AllowedMedia())
+        val expectedFileAttachmentProfile = FileAttachmentProfile()
+
+        val result = givenSessionResponse.toFileAttachmentProfile()
+
+        assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when SessionResponse toFileAttachmentProfile() but AllowedMedia has no filetypes,maxFileSizeKB and blockedExtensions entries`() {
+        val givenSessionResponse =
+            SessionResponse(connected = true, allowedMedia = AllowedMedia(Inbound()))
+        val expectedFileAttachmentProfile = FileAttachmentProfile()
+
+        val result = givenSessionResponse.toFileAttachmentProfile()
+
+        assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when SessionResponse toFileAttachmentProfile() and AllowedMedia has filetypes without wildcard but with maxFileSizeKB and blockedExtensions entries`() {
+        val givenSessionResponse = SessionResponse(
+            connected = true,
+            allowedMedia = AllowedMedia(
+                inbound = Inbound(
+                    fileTypes = listOf(FileType("video/mpg"), FileType("video/3gpp")),
+                    maxFileSizeKB = 10240,
+                )
+            ),
+            blockedExtensions = listOf(".ade", ".adp")
+        )
+        val expectedFileAttachmentProfile = FileAttachmentProfile(
+            allowedFileTypes = listOf("video/mpg", "video/3gpp"),
+            blockedFileTypes = listOf(".ade", ".adp"),
+            maxFileSizeKB = 10240,
+            hasWildCard = false,
+        )
+
+        val result = givenSessionResponse.toFileAttachmentProfile()
+
+        assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when SessionResponse toFileAttachmentProfile() and AllowedMedia has filetypes with wildcard,maxFileSizeKB and blockedExtensions entries`() {
+        val givenSessionResponse = SessionResponse(
+            connected = true,
+            allowedMedia = AllowedMedia(
+                inbound = Inbound(
+                    fileTypes = listOf(FileType("*/*"), FileType("video/3gpp")),
+                    maxFileSizeKB = 10240,
+                ),
+            ),
+            blockedExtensions = listOf(".ade", ".adp")
+        )
+        val expectedFileAttachmentProfile = FileAttachmentProfile(
+            allowedFileTypes = listOf("video/3gpp"),
+            blockedFileTypes = listOf(".ade", ".adp"),
+            maxFileSizeKB = 10240,
+            hasWildCard = true,
+        )
+
+        val result = givenSessionResponse.toFileAttachmentProfile()
+
+        assertThat(result).isEqualTo(expectedFileAttachmentProfile)
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -73,6 +73,8 @@ open class BaseMessagingClientTest {
             token = Request.token,
             attachmentId = "88888888-8888-8888-8888-888888888888"
         )
+        every { fileAttachmentProfile } returns null
+        every { validate(any()) } returns true
     }
     internal val mockPlatformSocket: PlatformSocket = mockk {
         every { openSocket(capture(slot)) } answers {
@@ -167,6 +169,7 @@ open class BaseMessagingClientTest {
             mockAuthHandler.jwt // use jwt for request
         }
         mockPlatformSocket.sendMessage(configureRequest)
+        mockAttachmentHandler.fileAttachmentProfile = any()
         mockReconnectionHandler.clear()
         mockStateChangedListener(fromConnectedToConfigured)
     }
@@ -176,6 +179,7 @@ open class BaseMessagingClientTest {
         mockPlatformSocket.openSocket(any())
         mockStateChangedListener(fromConnectingToConnected)
         mockPlatformSocket.sendMessage(Request.configureRequest())
+        mockAttachmentHandler.fileAttachmentProfile = any()
         mockReconnectionHandler.clear()
         mockStateChangedListener(fromConnectedToReadOnly)
     }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -74,7 +74,6 @@ open class BaseMessagingClientTest {
             attachmentId = "88888888-8888-8888-8888-888888888888"
         )
         every { fileAttachmentProfile } returns null
-        every { validate(any()) } returns true
     }
     internal val mockPlatformSocket: PlatformSocket = mockk {
         every { openSocket(capture(slot)) } answers {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCAttachmentTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCAttachmentTests.kt
@@ -37,7 +37,6 @@ class MCAttachmentTests : BaseMessagingClientTest() {
         assertEquals(expectedAttachmentId, result)
         verifySequence {
             connectSequence()
-            mockAttachmentHandler.validate(any())
             mockAttachmentHandler.prepare(any(), any(), any())
             mockPlatformSocket.sendMessage(expectedMessage)
         }
@@ -237,9 +236,15 @@ class MCAttachmentTests : BaseMessagingClientTest() {
     }
 
     @Test
-    fun `when attach() but validate attachment returns false`() {
+    fun `when attach() but attachmentHandler_prepare() throws exception`() {
         val givenByteArray = ByteArray(1)
-        every { mockAttachmentHandler.validate(givenByteArray) } returns false
+        every {
+            mockAttachmentHandler.prepare(
+                any(),
+                any(),
+                any()
+            )
+        } throws IllegalArgumentException(ErrorMessage.fileSizeIsTooBig(null))
         subject.connect()
 
         assertFailsWith<IllegalArgumentException>(ErrorMessage.fileSizeIsTooBig(null)) {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCConversationDisconnectTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCConversationDisconnectTests.kt
@@ -217,6 +217,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
             connectToReadOnlySequence()
             mockPlatformSocket.sendMessage(Request.closeAllConnections)
             mockStateChangedListener(fromReadOnlyToError(errorState = expectedErrorState))
+            mockAttachmentHandler.clearAll()
             mockReconnectionHandler.clear()
         }
     }
@@ -237,6 +238,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
         verifySequence {
             connectToReadOnlySequence()
             mockPlatformSocket.sendMessage(Request.closeAllConnections)
+            mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             verifyCleanUp()
             mockPlatformSocket.sendMessage(Request.configureRequest(startNew = true))
@@ -259,6 +261,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
         verifySequence {
             connectToReadOnlySequence()
             mockPlatformSocket.sendMessage(Request.closeAllConnections)
+            mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
         }
         verify(exactly = 0) {
@@ -277,6 +280,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
         assertThat(subject.currentState).isReadOnly()
         verifySequence {
             connectSequence()
+            mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockStateChangedListener(fromConfiguredToReadOnly())
         }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCHealthCheckTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCHealthCheckTests.kt
@@ -74,6 +74,7 @@ class MCHealthCheckTests : BaseMessagingClientTest() {
             mockPlatformSocket.openSocket(any())
             mockStateChangedListener(fromConnectingToConnected)
             mockPlatformSocket.sendMessage(Request.configureRequest())
+            mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockStateChangedListener(fromConnectedToConfigured)
             mockPlatformSocket.sendMessage(expectedMessage)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCMessageTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCMessageTests.kt
@@ -64,6 +64,7 @@ class MCMessageTests : BaseMessagingClientTest() {
         verifySequence {
             connectSequence()
             mockMessageStore.onMessageError(ErrorCode.MessageTooLong, "message too long")
+            mockAttachmentHandler.onMessageError(ErrorCode.MessageTooLong, "message too long")
         }
     }
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCustomAttributesTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCustomAttributesTests.kt
@@ -48,6 +48,7 @@ class MCustomAttributesTests : BaseMessagingClientTest() {
         verifySequence {
             connectSequence()
             mockMessageStore.onMessageError(expectedErrorCode, expectedErrorMessage)
+            mockAttachmentHandler.onMessageError(expectedErrorCode, expectedErrorMessage)
         }
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -18,4 +18,6 @@ internal object Request {
         """{"token":"$token","closeAllConnections":true,"action":"closeSession"}"""
     const val clearConversation =
         """{"token":"$token","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Clear"}}],"type":"Event"}}"""
+    const val refreshAttachmentUrl =
+        """{"token":"$token","attachmentId":"88888888-8888-8888-8888-888888888888","action":"getAttachment"}"""
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
@@ -59,6 +59,17 @@ internal object Response {
         },"events": [$events]}}"""
     }
 
+    fun presignedUrlResponse(
+        attachmentId: String = "88888888-8888-8888-8888-888888888888",
+        headers: String = "",
+        url: String = "https://downloadUrl.com",
+        fileSize: Int = 1,
+        fileName: String = "test_asset.png",
+        fileType: String = "image/jpeg",
+    ): String {
+        return """{"type":"response","class":"PresignedUrlResponse","code":200,"body":{"attachmentId":"$attachmentId","headers":{$headers},"url":"$url","fileName":"$fileName","fileSize":$fileSize,"fileType":"$fileType"}}"""
+    }
+
     internal object AllowedMedia {
         const val empty = ""
         const val emptyBlockedExtensions = ""

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -46,6 +46,13 @@ data class Attachment(
         data class Uploaded(val downloadUrl: String) : State()
 
         /**
+         * Attachment url was successfully refreshed.
+         *
+         * @param downloadUrl is a refreshed url pointing to uploaded attachment.
+         */
+        data class Refreshed(val downloadUrl: String) : State()
+
+        /**
          * Message that holds this attachment was sent, but there were no confirmation of delivery or failure yet.
          */
         object Sending : State()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -6,6 +6,7 @@ import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
 
 internal interface AttachmentHandler {
+    var fileAttachmentProfile: FileAttachmentProfile?
 
     fun prepare(
         attachmentId: String,
@@ -17,6 +18,8 @@ internal interface AttachmentHandler {
     fun upload(presignedUrlResponse: PresignedUrlResponse)
 
     fun detach(attachmentId: String): DeleteAttachmentRequest?
+
+    fun validate(byteArray: ByteArray): Boolean
 
     fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -33,5 +33,7 @@ internal interface AttachmentHandler {
 
     fun onMessageError(code: ErrorCode, message: String?)
 
+    fun onAttachmentRefreshed(presignedUrlResponse: PresignedUrlResponse)
+
     fun clearAll()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -8,6 +8,7 @@ import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
 internal interface AttachmentHandler {
     var fileAttachmentProfile: FileAttachmentProfile?
 
+    @Throws(IllegalArgumentException::class)
     fun prepare(
         attachmentId: String,
         byteArray: ByteArray,
@@ -18,8 +19,6 @@ internal interface AttachmentHandler {
     fun upload(presignedUrlResponse: PresignedUrlResponse)
 
     fun detach(attachmentId: String): DeleteAttachmentRequest?
-
-    fun validate(byteArray: ByteArray): Boolean
 
     fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -32,6 +32,8 @@ internal class AttachmentHandlerImpl(
 ) : AttachmentHandler {
     private val uploadDispatcher = CoroutineScope(Dispatchers.Main + SupervisorJob())
 
+    override var fileAttachmentProfile: FileAttachmentProfile? = null
+
     override fun prepare(
         attachmentId: String,
         byteArray: ByteArray,
@@ -104,6 +106,12 @@ internal class AttachmentHandlerImpl(
             }
         }
         return null
+    }
+
+    override fun validate(byteArray: ByteArray): Boolean {
+        return fileAttachmentProfile?.maxFileSizeKB?.let { maxFileSize ->
+            byteArray.toKB() <= maxFileSize
+        } ?: false
     }
 
     override fun onDetached(attachmentId: String) {
@@ -181,3 +189,5 @@ private fun ProcessedAttachment.takeSendingId(): String? =
 
 private fun ProcessedAttachment.takeUploaded(): ProcessedAttachment? =
     this.takeIf { it.attachment.state is Uploaded }
+
+private fun ByteArray.toKB(): Long = size / 1000L

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -79,6 +79,7 @@ object ErrorMessage {
     const val AutoRefreshTokenDisabled = "AutoRefreshTokenWhenExpired is disabled in Configuration."
     const val NoRefreshToken = "No refreshAuthToken. Authentication is required."
     const val FailedToClearConversation = "Failed to clear conversation."
+    fun fileSizeIsTooBig(maxFileSize: Long?) = "Reduce the attachment size to $maxFileSize KB or less."
 }
 
 sealed class CorrectiveAction(val message: String) {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -196,6 +196,19 @@ interface MessagingClient {
     fun detach(attachmentId: String)
 
     /**
+     * Refreshes the downloadUrl for a given attachment.
+     * The `downloadUrl` of an attachment typically expires after 10 minutes.
+     * If this URL is consumed after the expiration period, it will result in an error.
+     * To mitigate this, the `refreshAttachmentUrl` function can be used to obtain a new valid `downloadUrl` for the specified attachment.
+     *
+     * @param attachmentId the ID of the attachment to refresh.
+     *
+     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     */
+    @Throws(IllegalStateException::class)
+    fun refreshAttachmentUrl(attachmentId: String)
+
+    /**
      * Get message history for a conversation.
      *
      * @throws Exception

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -174,9 +174,10 @@ interface MessagingClient {
      * @param uploadProgress optional callback to track attachment upload progress.
      *
      * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     * @throws IllegalArgumentException If provided file size exceeds [FileAttachmentProfile.maxFileSizeKB].
      * @return internally generated attachmentId. Can be used to track upload progress
      */
-    @Throws(IllegalStateException::class)
+    @Throws(IllegalStateException::class, IllegalArgumentException::class)
     fun attach(
         byteArray: ByteArray,
         fileName: String,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -198,9 +198,7 @@ internal class MessagingClientImpl(
         uploadProgress: ((Float) -> Unit)?,
     ): String {
         log.i { "attach(fileName = $fileName)" }
-        if (!attachmentHandler.validate(byteArray)) {
-            throw IllegalArgumentException(ErrorMessage.fileSizeIsTooBig(fileAttachmentProfile?.maxFileSizeKB))
-        }
+
         val request = attachmentHandler.prepare(
             Platform().randomUUID(),
             byteArray,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -5,6 +5,7 @@ import com.genesys.cloud.messenger.transport.core.FileAttachmentProfile
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
 import com.genesys.cloud.messenger.transport.core.events.toTransportEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
@@ -69,10 +70,10 @@ internal fun String?.mapOriginatingEntity(isInbound: () -> Boolean): Message.Par
 private fun List<StructuredMessage.Content.AttachmentContent>.toAttachments(): Map<String, Attachment> {
     return this.associate {
         it.run {
-            this.attachment.id to Attachment(
-                id = this.attachment.id,
-                fileName = this.attachment.filename,
-                state = Attachment.State.Sent(this.attachment.url),
+            attachment.id to Attachment(
+                id = attachment.id,
+                fileName = attachment.filename,
+                state = Attachment.State.Sent(attachment.url),
             )
         }
     }
@@ -87,4 +88,8 @@ internal fun SessionResponse.toFileAttachmentProfile(): FileAttachmentProfile {
         maxFileSizeKB = allowedMedia?.inbound?.maxFileSizeKB,
         hasWildCard = hasWildcard
     )
+}
+
+internal fun PresignedUrlResponse.isRefreshUrl(): Boolean {
+    return headers.isEmpty() && fileSize != null
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/AttachmentUploadEngine.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/AttachmentUploadEngine.kt
@@ -1,0 +1,40 @@
+package com.genesys.cloud.messenger.transport.network.test_engines
+
+import com.genesys.cloud.messenger.transport.respondNotFound
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondBadRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+
+internal const val UPLOAD_FILE_PATH = "http://uploadurl.com"
+internal const val UPLOAD_FILE_SIZE = 100L
+internal val validHeaders = mapOf("Header" to "Valid")
+internal val invalidHeaders = mapOf("Header" to "Invalid")
+
+internal fun HttpClientConfig<MockEngineConfig>.uploadFileEngine() {
+    engine {
+        addHandler { request ->
+            when (request.url.toString()) {
+                UPLOAD_FILE_PATH -> {
+                    if (request.method == HttpMethod.Put && request.body.contentLength == UPLOAD_FILE_SIZE && request.headers["Header"].equals("Valid")) {
+                        // Simulate a successful upload
+                        respond(
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            content = ""
+                        )
+                    } else {
+                        respondBadRequest()
+                    }
+                }
+                else -> {
+                    respondNotFound()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add `validate(ByteArray)` function to AttachmentHandler/Impl to verify that provided ByteArray size match `maxFileSizeKB`
- Move reference to FileAttachmentProfile from MessagingClientImpl.kt to AttachmentHandlerImpl.kt as it makes more sense to have it there.
- Add `throw IllegalArgumentException` to `attach` function and throw it when `attachmentHandler.validate()` returns false.
- Add dedicated ErrorMessage when file size exceed max allowed size.
- Add unit tests to cover newly added functionality.
- Update existing unit tests to accommodate to the changes.
- Update some existing unit test names to use more convenient "back-tick" kotlin feature for naming functions.
- Update KDoc to include the new throw type of attach() function