### PR TITLE
MTSDK-245 Implement refreshAttachmentUrl api

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -14,6 +14,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.AllowedMedia
 import com.genesys.cloud.messenger.transport.shyrka.receive.FileType
 import com.genesys.cloud.messenger.transport.shyrka.receive.Inbound
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
@@ -21,6 +22,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
 import com.genesys.cloud.messenger.transport.shyrka.receive.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.fromIsoToEpochMilliseconds
 import com.genesys.cloud.messenger.transport.util.extensions.getUploadedAttachments
+import com.genesys.cloud.messenger.transport.util.extensions.isRefreshUrl
 import com.genesys.cloud.messenger.transport.util.extensions.mapOriginatingEntity
 import com.genesys.cloud.messenger.transport.util.extensions.toFileAttachmentProfile
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
@@ -380,5 +382,61 @@ internal class MessageExtensionTest {
         val result = givenSessionResponse.toFileAttachmentProfile()
 
         assertThat(result).isEqualTo(expectedFileAttachmentProfile)
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are empty and fileSize is null`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = emptyMap(),
+            url = "https://downloadUrl.com",
+            fileSize = null,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are NOT empty and fileSize is null`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = mapOf("A" to "B"),
+            url = "https://downloadUrl.com",
+            fileSize = null,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are NOT empty and fileSize has value`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = mapOf("A" to "B"),
+            url = "https://downloadUrl.com",
+            fileSize = 1,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when PresignedUrlResponse isRefreshUrl() and headers are empty and fileSize has value`() {
+        val givenPresignedUrlResponse = PresignedUrlResponse(
+            attachmentId = "99999999-9999-9999-9999-999999999999",
+            headers = emptyMap(),
+            url = "https://downloadUrl.com",
+            fileSize = 1,
+        )
+
+        val result = givenPresignedUrlResponse.isRefreshUrl()
+
+        assertThat(result).isTrue()
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -18,4 +18,6 @@ internal object Request {
         """{"token":"$token","closeAllConnections":true,"action":"closeSession"}"""
     const val clearConversation =
         """{"token":"$token","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Clear"}}],"type":"Event"}}"""
+    const val refreshAttachmentUrl =
+        """{"token":"$token","attachmentId":"88888888-8888-8888-8888-888888888888","action":"getAttachment"}"""
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
@@ -59,6 +59,17 @@ internal object Response {
         },"events": [$events]}}"""
     }
 
+    fun presignedUrlResponse(
+        attachmentId: String = "88888888-8888-8888-8888-888888888888",
+        headers: String = "",
+        url: String = "https://downloadUrl.com",
+        fileSize: Int = 1,
+        fileName: String = "test_asset.png",
+        fileType: String = "image/jpeg",
+    ): String {
+        return """{"type":"response","class":"PresignedUrlResponse","code":200,"body":{"attachmentId":"$attachmentId","headers":{$headers},"url":"$url","fileName":"$fileName","fileSize":$fileSize,"fileType":"$fileType"}}"""
+    }
+
     internal object AllowedMedia {
         const val empty = ""
         const val emptyBlockedExtensions = ""

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Attachment.kt
@@ -46,6 +46,13 @@ data class Attachment(
         data class Uploaded(val downloadUrl: String) : State()
 
         /**
+         * Attachment url was successfully refreshed.
+         *
+         * @param downloadUrl is a refreshed url pointing to uploaded attachment.
+         */
+        data class Refreshed(val downloadUrl: String) : State()
+
+        /**
          * Message that holds this attachment was sent, but there were no confirmation of delivery or failure yet.
          */
         object Sending : State()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -33,5 +33,7 @@ internal interface AttachmentHandler {
 
     fun onMessageError(code: ErrorCode, message: String?)
 
+    fun onAttachmentRefreshed(presignedUrlResponse: PresignedUrlResponse)
+
     fun clearAll()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -196,6 +196,16 @@ interface MessagingClient {
     fun detach(attachmentId: String)
 
     /**
+     * Refresh the downloadUrl.
+     *
+     * @param attachmentId the ID of the attachment to refresh.
+     *
+     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     */
+    @Throws(IllegalStateException::class)
+    fun refreshAttachmentUrl(attachmentId: String)
+
+    /**
      * Get message history for a conversation.
      *
      * @throws Exception

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -196,7 +196,10 @@ interface MessagingClient {
     fun detach(attachmentId: String)
 
     /**
-     * Refresh the downloadUrl.
+     * Refreshes the downloadUrl for a given attachment.
+     * The `downloadUrl` of an attachment typically expires after 10 minutes.
+     * If this URL is consumed after the expiration period, it will result in an error.
+     * To mitigate this, the `refreshAttachmentUrl` function can be used to obtain a new valid `downloadUrl` for the specified attachment.
      *
      * @param attachmentId the ID of the attachment to refresh.
      *

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -5,6 +5,7 @@ import com.genesys.cloud.messenger.transport.core.FileAttachmentProfile
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.Message.Direction
 import com.genesys.cloud.messenger.transport.core.events.toTransportEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.SessionResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
@@ -69,10 +70,10 @@ internal fun String?.mapOriginatingEntity(isInbound: () -> Boolean): Message.Par
 private fun List<StructuredMessage.Content.AttachmentContent>.toAttachments(): Map<String, Attachment> {
     return this.associate {
         it.run {
-            this.attachment.id to Attachment(
-                id = this.attachment.id,
-                fileName = this.attachment.filename,
-                state = Attachment.State.Sent(this.attachment.url),
+            attachment.id to Attachment(
+                id = attachment.id,
+                fileName = attachment.filename,
+                state = Attachment.State.Sent(attachment.url),
             )
         }
     }
@@ -87,4 +88,8 @@ internal fun SessionResponse.toFileAttachmentProfile(): FileAttachmentProfile {
         maxFileSizeKB = allowedMedia?.inbound?.maxFileSizeKB,
         hasWildCard = hasWildcard
     )
+}
+
+internal fun PresignedUrlResponse.isRefreshUrl(): Boolean {
+    return headers.isEmpty() && fileSize != null
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/AttachmentUploadEngine.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/AttachmentUploadEngine.kt
@@ -1,0 +1,40 @@
+package com.genesys.cloud.messenger.transport.network.test_engines
+
+import com.genesys.cloud.messenger.transport.respondNotFound
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondBadRequest
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+
+internal const val UPLOAD_FILE_PATH = "http://uploadurl.com"
+internal const val UPLOAD_FILE_SIZE = 100L
+internal val validHeaders = mapOf("Header" to "Valid")
+internal val invalidHeaders = mapOf("Header" to "Invalid")
+
+internal fun HttpClientConfig<MockEngineConfig>.uploadFileEngine() {
+    engine {
+        addHandler { request ->
+            when (request.url.toString()) {
+                UPLOAD_FILE_PATH -> {
+                    if (request.method == HttpMethod.Put && request.body.contentLength == UPLOAD_FILE_SIZE && request.headers["Header"].equals("Valid")) {
+                        // Simulate a successful upload
+                        respond(
+                            status = HttpStatusCode.OK,
+                            headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            content = ""
+                        )
+                    } else {
+                        respondBadRequest()
+                    }
+                }
+                else -> {
+                    respondNotFound()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
NOTE: MTSDK-245 was checked out from MTSDK-238 (the validate filesize) therefore I am merging it back. 
In perfect case when MTSDK-238 will be merged into main feature branch (MTSDK-137) I will rebase/update current branch and change its target to main feature branch. 

PS. Sorry for confusion.

- Implement refresh downloadUrl flow.
- Add new `refreshAttachmentUrl()` api to MessagingClient.kt
- Add new Attachment.State.Refreshed. Attachment will transition to this state upon successful refresh of downloadUrl and UI will be notified.
- Refactor `WebMessagingApi.uploadFile()` to align with structure of other REST api requests.
- Add/Update unit tests.
- Add KDoc for `refreshAttachmentUrl` and `Attachment.State.Refreshed`.