### PR TITLE
MTSDK-242 Validate blocked extensions.

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -79,7 +79,9 @@ object ErrorMessage {
     const val AutoRefreshTokenDisabled = "AutoRefreshTokenWhenExpired is disabled in Configuration."
     const val NoRefreshToken = "No refreshAuthToken. Authentication is required."
     const val FailedToClearConversation = "Failed to clear conversation."
+    const val FileSizeIsToSmall = "Attachment size cannot be less than 1 byte"
     fun fileSizeIsTooBig(maxFileSize: Long?) = "Reduce the attachment size to $maxFileSize KB or less."
+    fun fileTypeIsProhibited(fileName: String) = "File type  $fileName is prohibited for upload."
 }
 
 sealed class CorrectiveAction(val message: String) {


### PR DESCRIPTION
- Add blocked extension validation on the file name
- Slightly refactor `AttachmentHandlerImpl.validate()` function to improve readability.
- Add a couple of extension function to help with file name and size validation.
- Validate that attachment size is not 0 and provide a meaningful error message if so.
- Add/Update unit tests.