### PR TITLE
MTSDK-255 Remove warning log print when readonly + connected

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -561,11 +561,6 @@ internal class MessagingClientImpl(
                                 if (!connected && isStartingANewSession) {
                                     cleanUp()
                                     configureSession(startNew = true)
-                                } else {
-                                    // Normally should not happen.
-                                    log.w {
-                                        "Unexpected SessionResponse configuration: connected: $connected, readOnly: $readOnly, isStartingANewSession: $isStartingANewSession"
-                                    }
                                 }
                             } else {
                                 isStartingANewSession = false


### PR DESCRIPTION
- Log was added by mistake. It is actually a common scenario where SessionResponse has Readonly=true and connected=true.