### PR TITLE
MTSDK-237 Parse new fields from DeploymentConfig

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -69,7 +69,10 @@ data class Styles(val primaryColor: String)
 data class LauncherButton(val visibility: String)
 
 @Serializable
-data class FileUpload(val modes: List<Mode>)
+data class FileUpload(
+    val enableAttachments: Boolean = false,
+    val modes: List<Mode>
+)
 
 @Serializable
 data class Mode(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -71,12 +71,12 @@ data class LauncherButton(val visibility: String)
 @Serializable
 data class FileUpload(
     val enableAttachments: Boolean = false,
-    val modes: List<Mode>
+    val modes: List<Mode> = emptyList(),
 )
 
 @Serializable
 data class Mode(
-    val fileTypes: List<String>,
+    val fileTypes: List<String> = emptyList(),
     val maxFileSizeKB: Long,
 )
 

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -22,7 +22,7 @@ fun createMessengerVOForTesting(
     styles = Styles(primaryColor = "red"),
     launcherButton = LauncherButton(visibility = "On"),
     fileUpload = FileUpload(
-        listOf(
+        modes = listOf(
             Mode(
                 fileTypes = listOf("png"),
                 maxFileSizeKB = 100,


### PR DESCRIPTION
- Add parsing of `enableAttachments` field in DeploymentConfig with fallback to `false` if not available or failed to parse.