### PR TITLE
Feature/mtsdk 241 implement scp on i os testbed

### DIFF
--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -46,7 +46,11 @@ final class MessengerInteractor {
             self?.eventSubject.send(event)
         }
     }
-    
+
+    func getFileAttachmentProfile() -> FileAttachmentProfile? {
+        return messagingClient.fileAttachmentProfile
+    }
+
     func authorize(authCode: String, redirectUri: String, codeVerifier: String?) {
         messagingClient.authorize(authCode: authCode, redirectUri: redirectUri, codeVerifier: codeVerifier)
     }
@@ -120,7 +124,7 @@ final class MessengerInteractor {
         }
     }
 
-    func attachImage(kotlinByteArray: KotlinByteArray, fileName: String = "image.png") throws {
+    func attachImage(kotlinByteArray: KotlinByteArray, fileName: String) throws {
         do {
             try messagingClient.attach(byteArray: kotlinByteArray, fileName: fileName, uploadProgress: { progress in
                 print("Attachment upload progress: \(progress)")

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -130,6 +130,16 @@ final class MessengerInteractor {
             throw error
         }
     }
+    
+    
+    func refreshAttachmentUrl(attachId: String) throws {
+        do {
+            try messagingClient.refreshAttachmentUrl(attachmentId: attachId)
+        } catch {
+            print("refreshAttachmentUrl(attachId:) failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func detachImage(attachId: String) throws {
         do {

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -133,8 +133,7 @@ final class MessengerInteractor {
             print("attachImage(kotlinByteArray:) failed. \(error.localizedDescription)")
             throw error
         }
-    }
-    
+    }    
     
     func refreshAttachmentUrl(attachId: String) throws {
         do {

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -398,7 +398,7 @@ extension TestbedViewController : UITextFieldDelegate {
                     DispatchQueue.main.async {
                         self.info.text = "<loaded \(String(describing: self.byteArray?.count)) bytes>"
                     }
-                }M
+                }
             case (.attach, _):
                 if(byteArray != nil) {
                     let swiftByteArray : [UInt8] = byteArray!

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -45,6 +45,7 @@ class TestbedViewController: UIViewController {
         case history
         case selectAttachment
         case attach
+        case refreshAttachment
         case detach
         case deployment
         case bye
@@ -60,6 +61,7 @@ class TestbedViewController: UIViewController {
             case .send: return "send <msg>"
             case .detach: return "detach <attachmentId>"
             case .addAttribute: return "addAttribute <key> <value>"
+            case .refreshAttachment: return "refreshAttachment <attachmentId>"
             default: return rawValue
             }
         }
@@ -396,7 +398,7 @@ extension TestbedViewController : UITextFieldDelegate {
                     DispatchQueue.main.async {
                         self.info.text = "<loaded \(String(describing: self.byteArray?.count)) bytes>"
                     }
-                }
+                }M
             case (.attach, _):
                 if(byteArray != nil) {
                     let swiftByteArray : [UInt8] = byteArray!
@@ -409,6 +411,8 @@ extension TestbedViewController : UITextFieldDelegate {
                     
                     try messenger.attachImage(kotlinByteArray: kotlinByteArray)
                 }
+            case (.refreshAttachment, let attachId?):
+                try messenger.refreshAttachmentUrl(attachId: attachId)
             case (.detach, let attachId?):
                 try messenger.detachImage(attachId: attachId)
             case (.deployment, _):

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Chris Rumpf on 10/1/21.
 //  Copyright © 2021 Genesys. All rights reserved.
 //
-
+import MobileCoreServices
 import UIKit
 import MessengerTransport
 import Combine
@@ -13,9 +13,6 @@ import Combine
 class TestbedViewController: UIViewController {
 
     private let messenger: MessengerInteractor
-    private var attachImageName = ""
-    private let attachmentName = "image"
-    private var byteArray: [UInt8]? = nil
     private var customAttributes: [String: String] = [:]
     private var cancellables = Set<AnyCancellable>()
     private var pkceEnabled = false
@@ -43,7 +40,6 @@ class TestbedViewController: UIViewController {
         case newChat
         case send
         case history
-        case selectAttachment
         case attach
         case refreshAttachment
         case detach
@@ -316,6 +312,14 @@ class TestbedViewController: UIViewController {
         }
         return (UserCommand(rawValue: command!), input)
     }
+    
+    func utiForMimeType(mimeType: String) -> String? {
+        if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType as CFString, nil)?.takeRetainedValue() {
+            return uti as String
+        }
+        print("Could not convert mime type to uti: \(mimeType)")
+        return nil
+    }
 
     private func buildOktaAuthorizeUrl() -> URL? {
         guard let plistPath = Bundle.main.path(forResource: "Okta", ofType: "plist"),
@@ -368,7 +372,6 @@ extension TestbedViewController : UITextFieldDelegate {
             return true
         }
 
-        attachImageName = ""
         let userInput = segmentUserInput(message)
         let command = convertToCommand(command: userInput.0,input: userInput.1)
 
@@ -389,28 +392,18 @@ extension TestbedViewController : UITextFieldDelegate {
                 messenger.fetchNextPage()
             case (.healthCheck, _):
                 try messenger.sendHealthCheck()
-            case (.selectAttachment, _):
-                attachImageName = attachmentName
-                DispatchQueue.global().async {
-                    let image = UIImage(named: self.attachmentName)
-                    guard let data = image?.pngData() as NSData? else { return }
-                    self.byteArray = data.toByteArray()
-                    DispatchQueue.main.async {
-                        self.info.text = "<loaded \(String(describing: self.byteArray?.count)) bytes>"
-                    }
-                }
             case (.attach, _):
-                if(byteArray != nil) {
-                    let swiftByteArray : [UInt8] = byteArray!
-                    let intArray : [Int8] = swiftByteArray
-                        .map { Int8(bitPattern: $0) }
-                    let kotlinByteArray: KotlinByteArray = KotlinByteArray.init(size: Int32(swiftByteArray.count))
-                    for (index, element) in intArray.enumerated() {
-                        kotlinByteArray.set(index: Int32(index), value: element)
-                    }
-                    
-                    try messenger.attachImage(kotlinByteArray: kotlinByteArray)
+                guard let fileAttachmentProfile = messenger.getFileAttachmentProfile() else {
+                    self.info.text = "FileAttachmentProfile is not set. Can not launch file picker."
+                    break
                 }
+                
+                if (!fileAttachmentProfile.hasWildCard && fileAttachmentProfile.allowedFileTypes.isEmpty) {
+                    self.info.text = "Allowed file types is empty. Can not launch file picker."
+                    break
+                }
+                
+                showDocumentPicker(fileAttachmentProfile: fileAttachmentProfile)
             case (.refreshAttachment, let attachId?):
                 try messenger.refreshAttachmentUrl(attachId: attachId)
             case (.detach, let attachId?):
@@ -482,4 +475,60 @@ enum AuthState {
     case authorized
     case loggedOut
     case error(errorCode: ErrorCode, message: String?, correctiveAction: CorrectiveAction)
+}
+
+extension TestbedViewController: UIDocumentPickerDelegate {
+    
+    func showDocumentPicker(fileAttachmentProfile: FileAttachmentProfile) {
+        let documentPicker: UIDocumentPickerViewController
+
+        if fileAttachmentProfile.hasWildCard {
+            documentPicker = UIDocumentPickerViewController(documentTypes: ["public.content"], in: .import)
+        } else {
+            var utiArray: [String] = []
+            for fileType in fileAttachmentProfile.allowedFileTypes {
+                if let result = utiForMimeType(mimeType: fileType) {
+                    utiArray.append(result)
+                }
+            }
+
+            documentPicker = UIDocumentPickerViewController(documentTypes: utiArray, in: .import)
+        }
+
+        documentPicker.delegate = self
+        present(documentPicker, animated: true, completion: nil)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard let pickedURL = urls.first else { return }
+
+        let fileName = pickedURL.lastPathComponent
+
+        DispatchQueue.global().async {
+            do {
+                let fileData = try Data(contentsOf: pickedURL, options: .mappedIfSafe)
+
+                let kotlinByteArray = KotlinByteArray(size: Int32(fileData.count))
+                for (index, byte) in fileData.enumerated() {
+                    kotlinByteArray.set(index: Int32(index), value: Int8(bitPattern: byte))
+                }
+
+                DispatchQueue.main.async {
+                    do {
+                        try self.messenger.attachImage(kotlinByteArray: kotlinByteArray, fileName: fileName)
+                    } catch {
+                        self.info.text = "\(error.localizedDescription)"
+                    }
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    self.info.text = "Error converting file URL to ByteArray: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        self.info.text = "File selection canceled. No attachment selected."
+    }
 }


### PR DESCRIPTION
- Implement file picker on iOS Testbed app.
- Implement refreshAttachment url on iOS Testbed.
- Remove `selectAttachment` command as it is redundant now.
