### PR TITLE
MTSDK-264 Custom Attributes not sent with the next message when first…

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
@@ -138,6 +138,13 @@ class CustomAttributesStoreTest {
     }
 
     @Test
+    fun `when onMessageError`() {
+        subject.onMessageError()
+
+        assertThat(subject.state).isPending()
+    }
+
+    @Test
     fun `when add customAttributes and then onSessionClosed`() {
         val givenCustomAttributes = mapOf("A" to "B")
         val expectedCustomAttributes = mapOf("A" to "B")

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCCustomAttributesTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCCustomAttributesTests.kt
@@ -14,6 +14,7 @@ import com.genesys.cloud.messenger.transport.shyrka.send.TextMessage
 import com.genesys.cloud.messenger.transport.util.Request
 import com.genesys.cloud.messenger.transport.util.Response
 import io.mockk.every
+import io.mockk.verify
 import io.mockk.verifySequence
 import org.junit.Test
 
@@ -61,6 +62,10 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
             mockCustomAttributesStore.onError()
             mockMessageStore.onMessageError(expectedErrorCode, expectedErrorMessage)
             mockAttachmentHandler.onMessageError(expectedErrorCode, expectedErrorMessage)
+        }
+
+        verify(exactly = 0) {
+            mockCustomAttributesStore.onMessageError()
         }
     }
 
@@ -121,6 +126,9 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
             )
             mockMessageStore.onMessageError(ErrorCode.CustomAttributeSizeTooLarge, expectedCustomAttributesErrorMessage)
             mockAttachmentHandler.onMessageError(ErrorCode.CustomAttributeSizeTooLarge, expectedCustomAttributesErrorMessage)
+        }
+        verify(exactly = 0) {
+            mockCustomAttributesStore.onMessageError()
         }
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCMessageTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCMessageTests.kt
@@ -69,7 +69,9 @@ class MCMessageTests : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence()
+            mockCustomAttributesStore.onMessageError()
             mockMessageStore.onMessageError(ErrorCode.MessageTooLong, "message too long")
+            mockAttachmentHandler.onMessageError(ErrorCode.MessageTooLong, "message too long")
         }
         verify(exactly = 0) {
             mockCustomAttributesStore.onError()
@@ -84,6 +86,7 @@ class MCMessageTests : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence()
+            mockCustomAttributesStore.onMessageError()
             mockMessageStore.onMessageError(
                 ErrorCode.RequestRateTooHigh,
                 "Message rate too high for this session. Retry after 3 seconds."
@@ -119,6 +122,7 @@ class MCMessageTests : BaseMessagingClientTest() {
         }
         verify(exactly = 0) {
             mockEventHandler.onEvent(any())
+            mockCustomAttributesStore.onMessageError()
         }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
@@ -37,6 +37,11 @@ internal class CustomAttributesStoreImpl(private val log: Log) : CustomAttribute
         state = State.ERROR
     }
 
+    internal fun onMessageError() {
+        log.i { "onMessageError()" }
+        state = State.PENDING
+    }
+
     internal fun onSessionClosed() {
         log.i { "onSessionClosed()" }
         state = State.PENDING

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -362,6 +362,8 @@ internal class MessagingClientImpl(
                             )
                         )
                     }
+                } else {
+                    internalCustomAttributesStore.onMessageError()
                 }
                 messageStore.onMessageError(code, message)
                 attachmentHandler.onMessageError(code, message)


### PR DESCRIPTION
- When onMessageError is caused by message itself, transition CustomAttributes.State to Pending so that CA can be sent with a next message request.
- Add/Update unit test to reflect changes.