### PR TITLE
MTSDK-256 MessagingClient failed to transition to State.Closed

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -393,6 +393,7 @@ internal class MessagingClientImpl(
     }
 
     private fun handleWebSocketError(errorCode: ErrorCode) {
+        considerForceClose()
         if (stateMachine.isInactive()) return
         invalidateConversationCache()
         when (errorCode) {
@@ -494,6 +495,14 @@ internal class MessagingClientImpl(
         reconnectionHandler.clear()
         reconfigureAttempts = 0
         sendingAutostart = false
+    }
+
+    private fun considerForceClose() {
+        if (stateMachine.isClosing()) {
+            log.i { "Force close web socket." }
+            val closingState = stateMachine.currentState as State.Closing
+            socketListener.onClosed(closingState.code, closingState.reason)
+        }
     }
 
     private fun encodeAnonymousConfigureSessionRequest(startNew: Boolean) =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -80,7 +80,7 @@ internal fun StateMachine.checkIfConfiguredOrReadOnly() =
 internal fun StateMachine.isInactive(): Boolean =
     currentState is State.Idle || currentState is State.Closing || currentState is State.Closed || currentState is State.Error
 
-internal fun StateMachine.isClosed(): Boolean = currentState is State.Closed
+internal fun StateMachine.isClosing(): Boolean = currentState is State.Closing
 
 @Throws(IllegalStateException::class)
 internal fun StateMachine.checkIfCanStartANewChat() =


### PR DESCRIPTION
- Force close websocket when WebsocketError is thrown during closure.
- Add unit test for this use-case.