### PR TITLE
MTSDK-220 MessengerTransport module and class name clashes on iOS

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -16,7 +16,7 @@ import com.genesys.cloud.messenger.transport.core.MessageEvent
 import com.genesys.cloud.messenger.transport.core.MessageEvent.AttachmentUpdated
 import com.genesys.cloud.messenger.transport.core.MessagingClient
 import com.genesys.cloud.messenger.transport.core.MessagingClient.State
-import com.genesys.cloud.messenger.transport.core.MessengerTransport
+import com.genesys.cloud.messenger.transport.core.MessengerTransportSDK
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.util.DefaultVault
 import io.ktor.http.URLBuilder
@@ -34,7 +34,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
 
     private val TAG = TestBedViewModel::class.simpleName
 
-    private lateinit var messengerTransport: MessengerTransport
+    private lateinit var messengerTransport: MessengerTransportSDK
     private lateinit var client: MessagingClient
     private lateinit var attachment: ByteArray
     private val attachedIds = mutableListOf<String>()
@@ -74,7 +74,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         context: Context,
         onOktaSignIn: (url: String) -> Unit,
     ) {
-        println("Messenger Transport sdkVersion: ${MessengerTransport.sdkVersion}")
+        println("Messenger Transport sdkVersion: ${MessengerTransportSDK.sdkVersion}")
         this.onOktaSingIn = onOktaSignIn
         val mmsdkConfiguration = Configuration(
             deploymentId = deploymentId.ifEmpty { BuildConfig.DEPLOYMENT_ID },
@@ -83,9 +83,9 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
         )
 
         DefaultVault.context = context
-        messengerTransport = MessengerTransport(mmsdkConfiguration)
+        messengerTransport = MessengerTransportSDK(mmsdkConfiguration)
         client = messengerTransport.createMessagingClient()
-        client.customAttributesStore.add(mapOf("sdkVersion" to "Transport SDK: ${MessengerTransport.sdkVersion}"))
+        client.customAttributesStore.add(mapOf("sdkVersion" to "Transport SDK: ${MessengerTransportSDK.sdkVersion}"))
         with(client) {
             stateChangedListener = {
                 runBlocking {

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -13,7 +13,7 @@ import Combine
 final class MessengerInteractor {
 
     let configuration: Configuration
-    let messengerTransport: MessengerTransport
+    let messengerTransport: MessengerTransportSDK
     let messagingClient: MessagingClient
     let tokenVault: DefaultVault
     
@@ -22,7 +22,7 @@ final class MessengerInteractor {
     let eventSubject = PassthroughSubject<Event, Never>()
         
     init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
-        print("Messenger Transport sdkVersion: \(MessengerTransport.companion.sdkVersion)")
+        print("Messenger Transport sdkVersion: \(MessengerTransportSDK.companion.sdkVersion)")
         
         self.configuration = Configuration(deploymentId: deployment.deploymentId,
                                            domain: deployment.domain,
@@ -30,7 +30,7 @@ final class MessengerInteractor {
                                            reconnectionTimeoutInSeconds: reconnectTimeout,
                                            autoRefreshTokenWhenExpired: true)
         self.tokenVault = DefaultVault(keys: Vault.Keys(vaultKey: "com.genesys.cloud.messenger", tokenKey: "token", authRefreshTokenKey: "auth_refresh_token"))
-        self.messengerTransport = MessengerTransport(configuration: self.configuration, vault: self.tokenVault)
+        self.messengerTransport = MessengerTransportSDK(configuration: self.configuration, vault: self.tokenVault)
         self.messagingClient = self.messengerTransport.createMessagingClient()
         
         messagingClient.stateChangedListener = { [weak self] stateChange in

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
@@ -45,7 +45,7 @@ data class Configuration(
             .apply {
                 path("v1")
                 parameters.append("deploymentId", deploymentId)
-                parameters.append("application", "TransportSDK-${MessengerTransport.sdkVersion}")
+                parameters.append("application", "TransportSDK-${MessengerTransportSDK.sdkVersion}")
             }
             .build()
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
@@ -20,8 +20,7 @@ import kotlinx.coroutines.launch
 /**
  * The entry point to the services provided by the transport SDK.
  */
-@Deprecated("Use MessengerTransportSDK instead.")
-class MessengerTransport(
+class MessengerTransportSDK(
     private val configuration: Configuration,
     @Deprecated("Use Vault instead.") private val tokenStore: TokenStore?,
     private val vault: Vault,
@@ -83,6 +82,8 @@ class MessengerTransport(
             log.withTag(LogTag.ATTACHMENT_HANDLER),
             messageStore.updateAttachmentStateWith,
         )
+
+
         return MessagingClientImpl(
             api = api,
             log = log,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
@@ -83,7 +83,6 @@ class MessengerTransportSDK(
             messageStore.updateAttachmentStateWith,
         )
 
-
         return MessagingClientImpl(
             api = api,
             log = log,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/TokenStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/TokenStore.kt
@@ -3,7 +3,7 @@ package com.genesys.cloud.messenger.transport.util
 /**
  * A store for the session token. Users of the library can use the [DefaultTokenStore]
  * implementation for simplicity or create a custom token store by making a concrete implementation
- * of this class and passing it in to the [MessengerTransport] constructor.
+ * of this class and passing it in to the [MessengerTransportSDK] constructor.
  */
 @Deprecated("Use [Vault] instead.")
 abstract class TokenStore {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
@@ -6,7 +6,7 @@ import com.genesys.cloud.messenger.transport.auth.NO_REFRESH_TOKEN
  * Abstract class representing a vault that stores and retrieves sensitive data using a provided set of keys.
  * Users of the library can use the [DefaultVault]
  * implementation for simplicity or create a custom vault by making a concrete implementation
- * of this class and passing it in to the [MessengerTransport] constructor.
+ * of this class and passing it in to the [MessengerTransportSDK] constructor.
  *
  * @param keys The set of keys used to access stored data in the vault.
  */

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/RegionConfigurationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/RegionConfigurationTest.kt
@@ -3,7 +3,7 @@ package com.genesys.cloud.messenger.transport
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.genesys.cloud.messenger.transport.core.Configuration
-import com.genesys.cloud.messenger.transport.core.MessengerTransport
+import com.genesys.cloud.messenger.transport.core.MessengerTransportSDK
 import io.ktor.http.Url
 import kotlin.test.Test
 
@@ -17,7 +17,7 @@ class RegionConfigurationTest {
         )
 
         val actual = configuration.webSocketUrl
-        val expected = Url("wss://webmessaging.mypurecloud.com/v1?deploymentId=foo&application=TransportSDK-${MessengerTransport.sdkVersion}")
+        val expected = Url("wss://webmessaging.mypurecloud.com/v1?deploymentId=foo&application=TransportSDK-${MessengerTransportSDK.sdkVersion}")
 
         assertThat(actual, "WebSocket URL").isEqualTo(expected)
     }


### PR DESCRIPTION
- Add `MessengerTransportSDK` as main entry point.
- Deprecate `MessengerTransport`.
- Update code to use `MessengerTransportSDK` instead of deprecated `MessengerTransport`.
- Update unit test to use `MessengerTransportSDK`.