### PR TITLE
MTSDK-266 Convert NSData to KotlinByteArray

### DIFF
--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -507,12 +507,7 @@ extension TestbedViewController: UIDocumentPickerDelegate {
         DispatchQueue.global().async {
             do {
                 let fileData = try Data(contentsOf: pickedURL, options: .mappedIfSafe)
-
-                let kotlinByteArray = KotlinByteArray(size: Int32(fileData.count))
-                for (index, byte) in fileData.enumerated() {
-                    kotlinByteArray.set(index: Int32(index), value: Int8(bitPattern: byte))
-                }
-
+                let kotlinByteArray = TransportUtil().nsDataToKotlinByteArray(data: fileData)
                 DispatchQueue.main.async {
                     do {
                         try self.messenger.attachImage(kotlinByteArray: kotlinByteArray, fileName: fileName)

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/TransportUtil.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/TransportUtil.kt
@@ -1,0 +1,24 @@
+package com.genesys.cloud.messenger.transport.util
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.posix.memcpy
+
+class TransportUtil {
+
+    /**
+     * Utility function that helps with conversion of NSData to KotlinByteArray.
+     *
+     * @param data the NSData to convert.
+     *
+     * @return the resulting KotlinByteArray.
+     */
+    fun nsDataToKotlinByteArray(data: NSData): ByteArray {
+        return ByteArray(data.length.toInt()).apply {
+            usePinned {
+                memcpy(it.addressOf(0), data.bytes, data.length)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add TransportUtil.kt to ios source set. This object will hold helpful utility functions to mitigate kotlin-swift interoperability and ease on integration with TransportSDK.
- Add nsDataToKotlinByteArray function that helps with conversion of NSData to KotlinByteArray.
- Update iOS testbed app to use new utility function.

@GolanSG , NOTE: I have tested NSData to KotlinByteArray with 20 mb file and on average it takes about - `0.025` second which I consider as sufficient. 