### PR TITLE
MTSDK-269 Improve legacy FileAttachment api

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Composables.kt
@@ -61,7 +61,7 @@ fun TestBedContent(
             style = typography.h5
         )
         Text(
-            "Commands: oktaSignIn, oktaSignInWithPKCE, oktaLogout, connect, connectAuthenticated, newChat, send <msg>, history, invalidateConversationCache, attach, attachSavedImage, detach, refreshAttachment<attachmentId>, delete <attachmentId> , deployment, bye, healthCheck, addAttribute <key> <value>, typing, authorize, clearConversation, savedFileName <new file name>",
+            "Commands: oktaSignIn, oktaSignInWithPKCE, oktaLogout, connect, connectAuthenticated, newChat, send <msg>, history, invalidateConversationCache, attach, attachSavedImage, detach, refreshAttachment<attachmentId>, delete <attachmentId>, fileAttachmentProfile, deployment, bye, healthCheck, addAttribute <key> <value>, typing, authorize, clearConversation, savedFileName <new file name>",
             style = typography.caption,
             softWrap = true
         )

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -148,6 +148,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "clearConversation" -> doClearConversation()
             "refreshAttachment" -> doRefreshAttachmentUrl(input)
             "savedFileName" -> doChangeFileName(input)
+            "fileAttachmentProfile" -> doFileAttachmentProfile()
             else -> {
                 Log.e(TAG, "Invalid command")
                 commandWaiting = false
@@ -282,6 +283,9 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             handleException(t, "refreshAttachmentUrl")
         }
     }
+
+    private fun doFileAttachmentProfile() =
+        onSocketMessageReceived("FileAttachmentProfile: ${client.fileAttachmentProfile}")
 
     private fun doChangeFileName(newFileName: String) {
         sendFileName = newFileName

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -43,6 +43,7 @@ class TestbedViewController: UIViewController {
         case attach
         case refreshAttachment
         case detach
+        case fileAttachmentProfile
         case deployment
         case bye
         case healthCheck
@@ -408,6 +409,8 @@ extension TestbedViewController : UITextFieldDelegate {
                 try messenger.refreshAttachmentUrl(attachId: attachId)
             case (.detach, let attachId?):
                 try messenger.detachImage(attachId: attachId)
+            case (.fileAttachmentProfile, _):
+                self.info.text = "FileAttachmentProfile: <\(messenger.getFileAttachmentProfile())>"
             case (.deployment, _):
                 messenger.fetchDeployment { deploymentConfig, error in
                     if let error = error {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImplTest.kt
@@ -402,7 +402,7 @@ internal class AttachmentHandlerImplTest {
     fun `when prepare() but maxFileSizeKB in fileAttachmentProfile is less then provided ByteArray size`() {
         val givenByteArray = ByteArray(2000)
         val expectedExceptionMessage = ErrorMessage.fileSizeIsTooBig(maxFileSize = 1)
-        subject.fileAttachmentProfile = FileAttachmentProfile(maxFileSizeKB = 1)
+        subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 1)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
             subject.prepare(givenAttachmentId, givenByteArray, "image.png")
@@ -411,8 +411,8 @@ internal class AttachmentHandlerImplTest {
 
     @Test
     fun `when prepare() and maxFileSizeKB in fileAttachmentProfile is equal to then provided ByteArray size`() {
-        val givenByteArray = ByteArray(2000)
-        subject.fileAttachmentProfile = FileAttachmentProfile(maxFileSizeKB = 2)
+        val givenByteArray = ByteArray(2000,)
+        subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 2)
         val expectedFileSizeInKB = 2L
         val expectedOnAttachmentRequest = OnAttachmentRequest(
             token = givenToken,
@@ -434,7 +434,7 @@ internal class AttachmentHandlerImplTest {
     fun `when prepare() and ByteArray size is 0`() {
         val givenByteArray = ByteArray(0)
         val expectedExceptionMessage = ErrorMessage.FileSizeIsToSmall
-        subject.fileAttachmentProfile = FileAttachmentProfile(maxFileSizeKB = 2)
+        subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 2)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
             subject.prepare(givenAttachmentId, givenByteArray, "image.png")
@@ -444,7 +444,7 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when prepare() and maxFileSizeKB in fileAttachmentProfile is greater then provided ByteArray size`() {
         val givenByteArray = ByteArray(2000)
-        subject.fileAttachmentProfile = FileAttachmentProfile(maxFileSizeKB = 100)
+        subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 100)
         val expectedFileSizeInKB = 100L
         val expectedOnAttachmentRequest = OnAttachmentRequest(
             token = givenToken,
@@ -467,7 +467,7 @@ internal class AttachmentHandlerImplTest {
         val givenByteArray = ByteArray(1)
         val expectedExceptionMessage = ErrorMessage.fileTypeIsProhibited(fileName = "foo.exe")
         subject.fileAttachmentProfile =
-            FileAttachmentProfile(maxFileSizeKB = 100, blockedFileTypes = listOf(".exe"))
+            FileAttachmentProfile(enabled = true, maxFileSizeKB = 100, blockedFileTypes = listOf(".exe"))
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
             subject.prepare(givenAttachmentId, givenByteArray, "foo.exe")
@@ -478,7 +478,7 @@ internal class AttachmentHandlerImplTest {
     fun `when prepare() and file extension is NOT included in blockedFileTypes list`() {
         val givenByteArray = ByteArray(1)
         subject.fileAttachmentProfile =
-            FileAttachmentProfile(maxFileSizeKB = 100, blockedFileTypes = listOf(".exe"))
+            FileAttachmentProfile(enabled = true, maxFileSizeKB = 100, blockedFileTypes = listOf(".exe"))
         val expectedOnAttachmentRequest = OnAttachmentRequest(
             token = givenToken,
             attachmentId = "99999999-9999-9999-9999-999999999999",

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -349,6 +349,7 @@ internal class MessageExtensionTest {
             blockedExtensions = listOf(".ade", ".adp")
         )
         val expectedFileAttachmentProfile = FileAttachmentProfile(
+            enabled = true,
             allowedFileTypes = listOf("video/mpg", "video/3gpp"),
             blockedFileTypes = listOf(".ade", ".adp"),
             maxFileSizeKB = 10240,
@@ -373,6 +374,7 @@ internal class MessageExtensionTest {
             blockedExtensions = listOf(".ade", ".adp")
         )
         val expectedFileAttachmentProfile = FileAttachmentProfile(
+            enabled = true,
             allowedFileTypes = listOf("video/3gpp"),
             blockedFileTypes = listOf(".ade", ".adp"),
             maxFileSizeKB = 10240,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -160,7 +160,7 @@ internal class AttachmentHandlerImpl(
     @Throws(IllegalArgumentException::class)
     private fun validate(byteArray: ByteArray, fileName: String) {
         fileAttachmentProfile?.let {
-            if (it.isDisabledFromDeploymentConfig()) {
+            if (!it.enabled) {
                 throw IllegalArgumentException(ErrorMessage.FileAttachmentIsDisabled)
             }
             if (byteArray.isEmpty()) {
@@ -188,9 +188,6 @@ internal class AttachmentHandlerImpl(
         )
     }
 }
-
-private fun FileAttachmentProfile.isDisabledFromDeploymentConfig(): Boolean =
-    !hasWildCard && allowedFileTypes.isEmpty() && maxFileSizeKB == 0L
 
 private fun ByteArray.isInvalid(maxFileSizeKB: Long?): Boolean =
     maxFileSizeKB?.let { this.toKB() > maxFileSizeKB } ?: false

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/FileAttachmentProfile.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/FileAttachmentProfile.kt
@@ -3,12 +3,14 @@ package com.genesys.cloud.messenger.transport.core
 /**
  * Represents a configuration for supported content profiles in the Admin Console.
  *
+ * @property enabled indicates if file attachment feature is enabled in Admin Console.
  * @property allowedFileTypes the list of file types allowed for upload.
  * @property blockedFileTypes the list of file types that are NOT allowed for upload.
  * @property maxFileSizeKB the maximum allowed file size in kilobytes.
  * @property hasWildCard indicates if a wildcard is present in [allowedFileTypes]
  */
 data class FileAttachmentProfile(
+    val enabled: Boolean = false,
     val allowedFileTypes: List<String> = emptyList(),
     val blockedFileTypes: List<String> = emptyList(),
     val maxFileSizeKB: Long = 0,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -538,7 +538,7 @@ internal class MessagingClientImpl(
                     }
                     is SessionResponse -> {
                         decoded.body.run {
-                            attachmentHandler.fileAttachmentProfile = this.toFileAttachmentProfile()
+                            attachmentHandler.fileAttachmentProfile = createFileAttachmentProfile(this)
                             reconnectionHandler.clear()
                             if (readOnly) {
                                 stateMachine.onReadOnly()
@@ -629,6 +629,12 @@ internal class MessagingClientImpl(
             stateMachine.onClosed(code, reason)
             cleanUp()
         }
+    }
+
+    private fun createFileAttachmentProfile(sessionResponse: SessionResponse): FileAttachmentProfile {
+        val fileUpload = deploymentConfig.get()?.messenger?.fileUpload
+        return fileUpload?.enableAttachments?.let { sessionResponse.toFileAttachmentProfile() }
+            ?: fileUpload.toFileAttachmentProfile()
     }
 }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -69,6 +69,7 @@ data class Styles(val primaryColor: String)
 data class LauncherButton(val visibility: String)
 
 @Serializable
+@Deprecated("Use [FileAttachmentProfile] instead.")
 data class FileUpload(
     val enableAttachments: Boolean? = null,
     val modes: List<Mode> = emptyList(),

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -16,20 +16,26 @@ fun createDeploymentConfigForTesting(
 
 fun createMessengerVOForTesting(
     apps: Apps = Apps(createConversationsVOForTesting()),
+    fileUpload: FileUpload = createFileUploadVOForTesting(),
 ) = Messenger(
     enabled = true,
     apps = apps,
     styles = Styles(primaryColor = "red"),
     launcherButton = LauncherButton(visibility = "On"),
-    fileUpload = FileUpload(
-        modes = listOf(
-            Mode(
-                fileTypes = listOf("png"),
-                maxFileSizeKB = 100,
-            ),
-        )
-    )
+    fileUpload = fileUpload
 )
+
+fun createFileUploadVOForTesting(
+    enableAttachments: Boolean? = false,
+    modes: List<Mode> = listOf(
+        Mode(
+            fileTypes = listOf("png"),
+            maxFileSizeKB = 100,
+        )
+    ),
+): FileUpload {
+    return FileUpload(enableAttachments, modes)
+}
 
 fun createConversationsVOForTesting(
     autoStart: Conversations.AutoStart = Conversations.AutoStart(),


### PR DESCRIPTION
The purpose of this work is to improve experience consuming Transport SDK API`s. 
Legacy configurations of attachment feature relies purely on DeploymentConfig.FileUpload property to provide information regarding allowed file types and maxFileSize. With this legacy configuration it is UI responsible to parse and decide  what file types to allow for attachment. 

With new SCP feature on, information about attachment configuration is provided by Shyrka (with SessionResponse) and therefore Transport SDK is capable of parsing and understanding this configurations. 

To help UI avoid complexity of handling legacy configuration, Transport SDK will seamlessly decide which configuration is relevant now and normalize both legacy and SCP via FileAttachmentProfile api. 

- Deprecate the DeploymentConfig.fileUpload. From now on, FileAttachmentProfile is a single source of truth for both legacy and new (SCP) attachment configurations.
- Add `enabled` field to FileAttachmentProfile to represent the Admin config toggle state of file attachment feature.
- Create FileAttachmentProfile depending on `enableAttachments` property in DeploymentConfig. When null - treat it as a legacy configuration.
- Add utility function to create FileAttachmentProfile from DeploymentConfig when enableAttachments=null (legacy configuration).
- Add/Update unit tests
- Add kdoc to include the newly added `enabled` property.
- Add fileAttachmentProfile command to both iOS and Android Testbed applications.