### PR TITLE
MTSDK-297 Notify UI when QuickReply received

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -362,23 +362,31 @@ internal class MessageStoreTest {
 
     @Test
     fun `when onQuickRepliesReceived()`() {
-        // TODO: update with proper (quick reply) message after MTSDK-296 is merged.
-        // For now, just ensure that regular message is added to the conversation, messageListener is invoked
-        // and nextPage has a proper value.
-        val givenMessage = outboundMessage()
         val expectedMessage = Message(
             id = "0",
             direction = Direction.Outbound,
             state = State.Sent,
-            type = "Text",
-            text = "message from agent number 0",
+            messageType = Message.Type.QuickReply,
+            text = "message from bot",
             timeStamp = 0,
             attachments = emptyMap(),
             events = emptyList(),
-            from = Participant(originatingEntity = Participant.OriginatingEntity.Human),
+            quickReplies = listOf(
+                ButtonResponse(
+                    text = "text_a",
+                    payload = "payload_a",
+                    type = "QuickReply"
+                ),
+                ButtonResponse(
+                    text = "text_b",
+                    payload = "payload_b",
+                    type = "QuickReply"
+                )
+            ),
+            from = Participant(originatingEntity = Participant.OriginatingEntity.Bot),
         )
 
-        subject.onQuickRepliesReceived(givenMessage)
+        subject.onQuickRepliesReceived(expectedMessage)
 
         assertThat(subject.getConversation()).contains(expectedMessage)
         assertThat(subject.nextPage).isEqualTo(1)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -70,6 +70,13 @@ internal class MessageStore(
         publish(MessageEvent.AttachmentUpdated(attachment))
     }
 
+    fun onQuickRepliesReceived(message: Message) {
+        log.i { "QuickReply received: $message" }
+        activeConversation.add(message)
+        nextPage = activeConversation.getNextPage()
+        publish(MessageEvent.QuickReplyReceived(message))
+    }
+
     fun updateMessageHistory(historyPage: List<Message>, total: Int) {
         startOfConversation = isAllHistoryFetched(total)
         with(historyPage.takeInactiveMessages().reversed()) {
@@ -152,4 +159,12 @@ sealed class MessageEvent {
      */
     class HistoryFetched(val messages: List<Message>, val startOfConversation: Boolean) :
         MessageEvent()
+
+    /**
+     * Dispatched when message with quick replies was sent by the Bot. To get the actual quick reply
+     * options refer to [Message.quickReplies] list of [ButtonResponse].
+     *
+     * @property message is the [Message] object with all the details.
+     */
+    class QuickReplyReceived(val message: Message) : MessageEvent()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -119,10 +119,6 @@ internal class MessageStore(
             }
         }
     }
-
-    fun onQuickRepliesReceived(message: Message) {
-        log.i { "TODO: Handle quick replies here: $message." }
-    }
 }
 
 /**


### PR DESCRIPTION
- Implement MessageStore.onQuickRepliesReceived function by adding Message with quick replies to conversation list and dispatching QuickReplyReceived message event.
- Add MessageEvent.QuickReplyReceived to be send.
- Add KDoc to document newly added MessageEvent.QuickReplyReceived
- Add/Update unit tests