### PR TITLE
MTSDK-299 Provide API to send Quick Replies

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -12,6 +12,7 @@ import com.genesys.cloud.messenger.transport.core.Result
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.core.events.EventHandler
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
 import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
 import com.genesys.cloud.messenger.transport.util.VAULT_KEY
@@ -30,6 +31,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -408,6 +411,17 @@ class AuthHandlerTest {
 
         assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
         assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
+    }
+
+    @Test
+    fun `AuthJwt serialization test`() {
+        val authJwt = AuthJwt("jwt", "refreshToken")
+
+        val json = WebMessagingJson.json.encodeToString(authJwt)
+        val deserializedAuthJwt = WebMessagingJson.json.decodeFromString<AuthJwt>(json)
+
+        assertThat(authJwt.jwt).isEqualTo(deserializedAuthJwt.jwt)
+        assertThat(authJwt.refreshToken).isEqualTo(deserializedAuthJwt.refreshToken)
     }
 
     private fun buildAuthHandler(givenAutoRefreshTokenWhenExpired: Boolean = true): AuthHandlerImpl {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -133,28 +133,6 @@ class AuthHandlerTest {
     }
 
     @Test
-    fun `when authorize() success but refreshToken is null`() {
-        coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns
-            Result.Success(AuthJwt(AuthTest.JwtToken, null))
-        subject = buildAuthHandler(false)
-
-        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
-
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
-
-        coVerify {
-            mockWebMessagingApi.fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier
-            )
-        }
-        verify { mockEventHandler.onEvent(Event.Authorized) }
-        assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
-        assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
-    }
-
-    @Test
     fun `when authorize() failure`() {
         val expectedErrorCode = ErrorCode.AuthFailed
         val expectedErrorMessage = ErrorTest.Message

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -135,7 +135,7 @@ class AuthHandlerTest {
     @Test
     fun `when authorize() success but refreshToken is null`() {
         coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns
-                Result.Success(AuthJwt(AuthTest.JwtToken, null))
+            Result.Success(AuthJwt(AuthTest.JwtToken, null))
         subject = buildAuthHandler(false)
 
         val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -133,6 +133,28 @@ class AuthHandlerTest {
     }
 
     @Test
+    fun `when authorize() success but refreshToken is null`() {
+        coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns
+                Result.Success(AuthJwt(AuthTest.JwtToken, null))
+        subject = buildAuthHandler(false)
+
+        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
+
+        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+
+        coVerify {
+            mockWebMessagingApi.fetchAuthJwt(
+                AuthTest.AuthCode,
+                AuthTest.RedirectUri,
+                AuthTest.CodeVerifier
+            )
+        }
+        verify { mockEventHandler.onEvent(Event.Authorized) }
+        assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
+        assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
+    }
+
+    @Test
     fun `when authorize() failure`() {
         val expectedErrorCode = ErrorCode.AuthFailed
         val expectedErrorMessage = ErrorTest.Message

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -415,13 +415,29 @@ class AuthHandlerTest {
 
     @Test
     fun `AuthJwt serialization test`() {
-        val authJwt = AuthJwt("jwt", "refreshToken")
+        val givenAuthJwt = AuthJwt("jwt", "refreshToken")
+        val expectedAuthJwt = AuthJwt("jwt", "refreshToken")
+        val expectedAuthJwtAsJson = """{"jwt":"jwt","refreshToken":"refreshToken"}"""
 
-        val json = WebMessagingJson.json.encodeToString(authJwt)
+        val json = WebMessagingJson.json.encodeToString(givenAuthJwt)
         val deserializedAuthJwt = WebMessagingJson.json.decodeFromString<AuthJwt>(json)
 
-        assertThat(authJwt.jwt).isEqualTo(deserializedAuthJwt.jwt)
-        assertThat(authJwt.refreshToken).isEqualTo(deserializedAuthJwt.refreshToken)
+        assertThat(json).isEqualTo(expectedAuthJwtAsJson)
+        assertThat(deserializedAuthJwt.jwt).isEqualTo(expectedAuthJwt.jwt)
+        assertThat(deserializedAuthJwt.refreshToken).isEqualTo(expectedAuthJwt.refreshToken)
+    }
+
+    @Test
+    fun `RefreshToken serialization test`() {
+        val givenRefreshToken = RefreshToken("refreshToken")
+        val expectedRefreshToken = RefreshToken("refreshToken")
+        val expectedRefreshTokenAsJson = """{"refreshToken":"refreshToken"}"""
+
+        val json = WebMessagingJson.json.encodeToString(givenRefreshToken)
+        val deserializedRefreshToken = WebMessagingJson.json.decodeFromString<RefreshToken>(json)
+
+        assertThat(json).isEqualTo(expectedRefreshTokenAsJson)
+        assertThat(deserializedRefreshToken.refreshToken).isEqualTo(expectedRefreshToken.refreshToken)
     }
 
     private fun buildAuthHandler(givenAutoRefreshTokenWhenExpired: Boolean = true): AuthHandlerImpl {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerTest.kt
@@ -133,6 +133,28 @@ class AuthHandlerTest {
     }
 
     @Test
+    fun `when authorize() success but refreshToken is null`() {
+        coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns
+            Result.Success(AuthJwt(AuthTest.JwtToken, null))
+        subject = buildAuthHandler()
+
+        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
+
+        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+
+        coVerify {
+            mockWebMessagingApi.fetchAuthJwt(
+                AuthTest.AuthCode,
+                AuthTest.RedirectUri,
+                AuthTest.CodeVerifier
+            )
+        }
+        verify { mockEventHandler.onEvent(Event.Authorized) }
+        assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
+        assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
+    }
+
+    @Test
     fun `when authorize() failure`() {
         val expectedErrorCode = ErrorCode.AuthFailed
         val expectedErrorMessage = ErrorTest.Message

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -27,6 +27,7 @@ import com.genesys.cloud.messenger.transport.util.extensions.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.mapOriginatingEntity
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
 import com.genesys.cloud.messenger.transport.util.extensions.toMessageList
+import com.genesys.cloud.messenger.transport.utility.QuickReplyTestValues
 import net.bytebuddy.utility.RandomString
 import org.junit.Test
 
@@ -61,8 +62,8 @@ internal class MessageExtensionTest {
             text = "quick reply text",
             timeStamp = null,
             quickReplies = listOf(
-                ButtonResponse("text_a", "payload_a", "QuickReply"),
-                ButtonResponse("text_b", "payload_b", "QuickReply"),
+                QuickReplyTestValues.buttonResponse_a,
+                QuickReplyTestValues.buttonResponse_b,
             ),
             from = Participant(originatingEntity = Participant.OriginatingEntity.Bot),
         )

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -5,6 +5,7 @@ import com.genesys.cloud.messenger.transport.core.AttachmentHandler
 import com.genesys.cloud.messenger.transport.core.Configuration
 import com.genesys.cloud.messenger.transport.core.CustomAttributesStoreImpl
 import com.genesys.cloud.messenger.transport.core.Empty
+import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.MessageStore
 import com.genesys.cloud.messenger.transport.core.MessagingClient
 import com.genesys.cloud.messenger.transport.core.MessagingClientImpl
@@ -34,6 +35,7 @@ import com.genesys.cloud.messenger.transport.util.fromConnectingToConnected
 import com.genesys.cloud.messenger.transport.util.fromIdleToConnecting
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.utility.AuthTest
+import com.genesys.cloud.messenger.transport.utility.QuickReplyTestValues
 import io.mockk.MockKVerificationScope
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -52,6 +54,18 @@ open class BaseMessagingClientTest {
         every { prepareMessage(any(), any()) } returns OnMessageRequest(
             token = Request.token,
             message = TextMessage("Hello world!")
+        )
+        every { prepareMessageWith(any(), null) } returns OnMessageRequest(
+            token = Request.token,
+            message = TextMessage(
+                text = "",
+                content = listOf(
+                    Message.Content(
+                        contentType = Message.Content.Type.ButtonResponse,
+                        buttonResponse = QuickReplyTestValues.buttonResponse_a,
+                    )
+                ),
+            ),
         )
     }
     internal val mockAttachmentHandler: AttachmentHandler = mockk(relaxed = true) {

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Request.kt
@@ -15,6 +15,10 @@ internal object Request {
         """{"token":"$token","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"$HealthCheckID"},"type":"Text"}}"""
     fun autostart(channelWithCustomAttributes: String = """"channel":{"metadata":{"customAttributes":{"A":"B"}}},""") =
         """{"token":"$token","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],$channelWithCustomAttributes"type":"Event"}}"""
+    fun quickReplyWith(
+        content: String = """"content":[{"contentType":"ButtonResponse","buttonResponse":{"text":"text_a","payload":"payload_a","type":"QuickReply"}}]""",
+        channel: String = ""
+    ) = """{"token":"$token","message":{"text":"",$content,$channel"type":"Text"},"action":"onMessage"}"""
     fun textMessage(text: String = "Hello world!") =
         """{"token":"$token","message":{"text":"$text","type":"Text"},"action":"onMessage"}"""
     const val closeAllConnections =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -10,7 +10,8 @@ import kotlinx.serialization.Serializable
  *  @property id a unique message identifier.
  *  @property direction the direction in which the message was sent.
  *  @property state the current message state.
- *  @property type the message type. The default type is "Text".
+ *  @property messageType the message type as enum. The default type is Type.Text.
+ *  @property type the message type as String. The default type is "Text".
  *  @property text the text payload of the message.
  *  @property timeStamp the time when the message occurred represented in Unix epoch time, the number of milliseconds since January 1, 1970 UTC.
  *  @property attachments a map of [Attachment] files to the message. Empty by default.
@@ -91,11 +92,13 @@ data class Message(
     @Serializable
     data class Content(
         val contentType: Type,
-        val attachment: Attachment,
+        val attachment: Attachment? = null,
+        val buttonResponse: ButtonResponse? = null,
     ) {
         @Serializable
         enum class Type {
-            Attachment
+            Attachment,
+            ButtonResponse,
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -150,6 +150,15 @@ interface MessagingClient {
     fun sendMessage(text: String, customAttributes: Map<String, String> = emptyMap())
 
     /**
+     * Send a quick reply to the Agent/Bot.
+     *
+     * @param buttonResponse the quick reply to send.
+     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     */
+    @Throws(IllegalStateException::class)
+    fun sendQuickReply(buttonResponse: ButtonResponse)
+
+    /**
      * Perform a health check of the connection by sending an echo message.
      * This command sends a single echo request and should be called a maximum of once every 30 seconds.
      * If called more frequently, this command will be rate limited in order to optimize network traffic.

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -1,5 +1,7 @@
 package com.genesys.cloud.messenger.transport.utility
 
+import com.genesys.cloud.messenger.transport.core.ButtonResponse
+
 internal const val DEFAULT_TIMEOUT = 10000L
 
 object TestValues {
@@ -27,4 +29,18 @@ object InvalidValues {
     internal const val InvalidJwt = "invalid_jwt"
     internal const val UnauthorizedJwt = "unauthorized_jwt"
     internal const val InvalidRefreshToken = "invalid_refresh_token"
+}
+
+object QuickReplyTestValues {
+    internal val buttonResponse_a = ButtonResponse(
+        text = "text_a",
+        payload = "payload_a",
+        type = "QuickReply"
+    )
+
+    internal val buttonResponse_b = ButtonResponse(
+        text = "text_b",
+        payload = "payload_b",
+        type = "QuickReply"
+    )
 }


### PR DESCRIPTION
- Add new MessagingClient.sendQuickReply API that enable sending of quick reply selection to the Agent/Bot.
- Extract preparation of custom attributes to separate function and reuse it from sendMessage/sendAutostart/sendQuickReplies functions.
- Small renaming/refactor.
- Add/Update KDoc
- Add/Update unit tests