### PR TITLE
MTSDK-301 Notify UI of progress state

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -27,7 +27,9 @@ import com.genesys.cloud.messenger.transport.util.extensions.isOutbound
 import com.genesys.cloud.messenger.transport.util.extensions.mapOriginatingEntity
 import com.genesys.cloud.messenger.transport.util.extensions.toMessage
 import com.genesys.cloud.messenger.transport.util.extensions.toMessageList
+import com.genesys.cloud.messenger.transport.utility.MessageValues
 import com.genesys.cloud.messenger.transport.utility.QuickReplyTestValues
+import com.genesys.cloud.messenger.transport.utility.StructuredMessageValues
 import net.bytebuddy.utility.RandomString
 import org.junit.Test
 
@@ -347,5 +349,98 @@ internal class MessageExtensionTest {
         val givenMessage = Message(direction = Direction.Inbound)
 
         assertThat(givenMessage.isOutbound()).isFalse()
+    }
+
+    @Test
+    fun `when StructureMessage toMessage() has Content with QuickReplyContent`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(StructuredMessageValues.createQuickReplyContentForTesting())
+        )
+        val expectedButtonResponse = ButtonResponse(
+            text = MessageValues.Text,
+            payload = StructuredMessageValues.Payload,
+            type = StructuredMessageValues.QuickReply
+        )
+        val expectedMessage = Message(
+            id = MessageValues.Id,
+            state = State.Sent,
+            type = Message.Type.QuickReply.name,
+            messageType = Message.Type.QuickReply,
+            quickReplies = listOf(expectedButtonResponse)
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when StructureMessage toMessage() has Content with ButtonResponseContent`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(StructuredMessageValues.createButtonResponseContentForTesting())
+        )
+        val expectedButtonResponse = ButtonResponse(
+            text = MessageValues.Text,
+            payload = StructuredMessageValues.Payload,
+            type = StructuredMessageValues.QuickReply
+        )
+        val expectedMessage = Message(
+            id = MessageValues.Id,
+            state = State.Sent,
+            type = Message.Type.QuickReply.name,
+            messageType = Message.Type.QuickReply,
+            quickReplies = listOf(expectedButtonResponse)
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when StructureMessage toMessage() has Content with QuickReplyContent and ButtonResponseContent`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(
+                StructuredMessageValues.createQuickReplyContentForTesting(),
+                StructuredMessageValues.createButtonResponseContentForTesting(),
+            )
+        )
+        val expectedButtonResponse = ButtonResponse(
+            text = MessageValues.Text,
+            payload = StructuredMessageValues.Payload,
+            type = StructuredMessageValues.QuickReply
+        )
+        val expectedMessage = Message(
+            id = MessageValues.Id,
+            state = State.Sent,
+            type = Message.Type.QuickReply.name,
+            messageType = Message.Type.QuickReply,
+            quickReplies = listOf(expectedButtonResponse)
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when StructureMessage toMessage() has Content without QuickReplyContent or ButtonResponseContent`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured
+        )
+
+        val expectedMessage = Message(
+            id = MessageValues.Id,
+            state = State.Sent,
+            type = Message.Type.Unknown.name,
+            messageType = Message.Type.Unknown,
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result).isEqualTo(expectedMessage)
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -363,7 +363,7 @@ internal class MessageStoreTest {
     }
 
     @Test
-    fun `when onQuickRepliesReceived()`() {
+    fun `when update() message with Direction=Outbound and quick replies`() {
         val expectedMessage = Message(
             id = "0",
             direction = Direction.Outbound,
@@ -388,6 +388,34 @@ internal class MessageStoreTest {
         assertEquals(
             expectedMessage,
             (messageSlot.captured as MessageEvent.QuickReplyReceived).message
+        )
+    }
+
+    @Test
+    fun `when update() message with Direction=Inbound and quick replies`() {
+        val expectedMessage = Message(
+            id = "0",
+            direction = Direction.Inbound,
+            state = State.Sent,
+            messageType = Message.Type.QuickReply,
+            timeStamp = 0,
+            attachments = emptyMap(),
+            events = emptyList(),
+            quickReplies = listOf(
+                QuickReplyTestValues.buttonResponse_a,
+                QuickReplyTestValues.buttonResponse_b,
+            ),
+            from = Participant(originatingEntity = Participant.OriginatingEntity.Bot),
+        )
+
+        subject.update(expectedMessage)
+
+        assertThat(subject.getConversation()).contains(expectedMessage)
+        assertThat(subject.nextPage).isEqualTo(1)
+        verify { mockMessageListener(capture(messageSlot)) }
+        assertEquals(
+            expectedMessage,
+            (messageSlot.captured as MessageEvent.MessageInserted).message
         )
     }
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -380,7 +380,7 @@ internal class MessageStoreTest {
             from = Participant(originatingEntity = Participant.OriginatingEntity.Bot),
         )
 
-        subject.onQuickRepliesReceived(expectedMessage)
+        subject.update(expectedMessage)
 
         assertThat(subject.getConversation()).contains(expectedMessage)
         assertThat(subject.nextPage).isEqualTo(1)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCQuickReplyTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCQuickReplyTests.kt
@@ -33,7 +33,7 @@ class MCQuickReplyTests : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence()
-            mockMessageStore.onQuickRepliesReceived(expectedMessage)
+            mockMessageStore.update(expectedMessage)
         }
     }
 
@@ -47,7 +47,7 @@ class MCQuickReplyTests : BaseMessagingClientTest() {
             connectSequence()
         }
         verify(exactly = 0) {
-            mockMessageStore.onQuickRepliesReceived(any())
+            mockMessageStore.update(any())
             mockCustomAttributesStore.onSent()
             mockAttachmentHandler.onSent(any())
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -35,11 +35,20 @@ data class Message(
     ),
 ) {
 
+    /**
+     * The enum type representation of the message.
+     *
+     * @property Text when message is a text.
+     * @property Event when message is an event.
+     * @property QuickReply when message is a quick reply.
+     * @property Unknown when system could not recognize the message type.
+     */
     @Serializable
     enum class Type {
         Text,
         Event,
         QuickReply,
+        Unknown,
     }
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -150,7 +150,7 @@ internal class MessageStore(
 }
 
 private fun Message.toMessageEvent(): MessageEvent =
-    if (this.messageType == Message.Type.QuickReply) {
+    if (messageType == Message.Type.QuickReply) {
         MessageEvent.QuickReplyReceived(this)
     } else {
         MessageEvent.MessageInserted(this)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -74,22 +74,13 @@ internal class MessageStore(
         )
     }
 
-    fun update(message: Message) {
-        log.i { "Message state updated: $message" }
-        when (message.direction) {
-            Direction.Inbound -> {
-                activeConversation.find { it.id == message.id }?.let {
-                    activeConversation[it.getIndex()] = message
-                    publish(MessageEvent.MessageUpdated(message))
-                } ?: run {
-                    activeConversation.add(message)
-                    publish(MessageEvent.MessageInserted(message))
-                }
-            }
-
+    fun update(message: Message) = message.run {
+        log.i { "Message state updated: $this" }
+        when (direction) {
+            Direction.Inbound -> findAndPublish(this)
             Direction.Outbound -> {
-                activeConversation.add(message)
-                publish(MessageEvent.MessageInserted(message))
+                activeConversation.add(this)
+                publish(this.toMessageEvent())
             }
         }
         nextPage = activeConversation.getNextPage()
@@ -102,13 +93,6 @@ internal class MessageStore(
         }
         pendingMessage = pendingMessage.copy(attachments = attachments)
         publish(MessageEvent.AttachmentUpdated(attachment))
-    }
-
-    fun onQuickRepliesReceived(message: Message) {
-        log.i { "QuickReply received: $message" }
-        activeConversation.add(message)
-        nextPage = activeConversation.getNextPage()
-        publish(MessageEvent.QuickReplyReceived(message))
     }
 
     fun updateMessageHistory(historyPage: List<Message>, total: Int) {
@@ -135,6 +119,16 @@ internal class MessageStore(
         startOfConversation = false
     }
 
+    private fun findAndPublish(message: Message) {
+        activeConversation.find { it.id == message.id }?.let {
+            activeConversation[it.getIndex()] = message
+            publish(MessageEvent.MessageUpdated(message))
+        } ?: run {
+            activeConversation.add(message)
+            publish(MessageEvent.MessageInserted(message))
+        }
+    }
+
     private fun publish(event: MessageEvent) {
         messageListener?.invoke(event)
     }
@@ -154,6 +148,13 @@ internal class MessageStore(
         }
     }
 }
+
+private fun Message.toMessageEvent(): MessageEvent =
+    if (this.messageType == Message.Type.QuickReply) {
+        MessageEvent.QuickReplyReceived(this)
+    } else {
+        MessageEvent.MessageInserted(this)
+    }
 
 /**
  * Communicates conversation related updates to the UI.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -479,10 +479,10 @@ internal class MessagingClientImpl(
     }
 
     private fun Message.handleAsStructuredMessage() {
-        if (messageType == Message.Type.QuickReply && quickReplies.isNotEmpty()) {
-            messageStore.onQuickRepliesReceived(this)
-        } else {
-            log.w { "Messages of type Structure without quick replies are not supported." }
+        when (messageType) {
+            Message.Type.QuickReply -> messageStore.update(this)
+            Message.Type.Unknown -> log.w { "Unknown messages of type Structure are not supported." }
+            else -> log.w { "Should not happen." }
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessage.kt
@@ -63,6 +63,7 @@ internal data class StructuredMessage(
         enum class Type {
             Attachment,
             QuickReply,
+            ButtonResponse,
         }
 
         @Serializable
@@ -97,6 +98,19 @@ internal data class StructuredMessage(
         }
 
         @Serializable
+        data class ButtonResponseContent(
+            val contentType: String,
+            val buttonResponse: ButtonResponse,
+        ) : Content() {
+            @Serializable
+            data class ButtonResponse(
+                val text: String,
+                val payload: String,
+                val type: String,
+            )
+        }
+
+        @Serializable
         internal object UnknownContent : Content()
     }
 
@@ -106,6 +120,7 @@ internal data class StructuredMessage(
             return when (element.jsonObject["contentType"]?.jsonPrimitive?.content) {
                 Content.Type.Attachment.name -> Content.AttachmentContent.serializer()
                 Content.Type.QuickReply.name -> Content.QuickReplyContent.serializer()
+                Content.Type.ButtonResponse.name -> Content.ButtonResponseContent.serializer()
                 else -> Content.UnknownContent.serializer()
             }
         }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -85,7 +85,7 @@ object StructuredMessageValues {
     internal fun createButtonResponseContentForTesting(
         text: String = MessageValues.Text,
         payload: String = Payload,
-    ) = ButtonResponseContent (
+    ) = ButtonResponseContent(
         contentType = StructuredMessage.Content.Type.ButtonResponse.name,
         buttonResponse = ButtonResponseContent.ButtonResponse(
             text = text,

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -1,12 +1,21 @@
 package com.genesys.cloud.messenger.transport.utility
 
 import com.genesys.cloud.messenger.transport.core.ButtonResponse
+import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.ButtonResponseContent
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.QuickReplyContent
 
 internal const val DEFAULT_TIMEOUT = 10000L
 
 object TestValues {
     internal const val Domain: String = "inindca.com"
     internal const val DeploymentId = "deploymentId"
+}
+
+object MessageValues {
+    internal const val Id = "test_message_id"
+    internal const val Text = "some text."
 }
 
 object AuthTest {
@@ -42,5 +51,46 @@ object QuickReplyTestValues {
         text = "text_b",
         payload = "payload_b",
         type = "QuickReply"
+    )
+}
+
+object StructuredMessageValues {
+    internal const val Payload = "payload"
+    internal const val QuickReply = "QuickReply"
+
+    internal fun createStructuredMessageForTesting(
+        id: String = MessageValues.Id,
+        type: StructuredMessage.Type = StructuredMessage.Type.Text,
+        direction: String = Message.Direction.Inbound.name,
+        content: List<StructuredMessage.Content> = emptyList(),
+    ) = StructuredMessage(
+        id = id,
+        type = type,
+        direction = direction,
+        content = content,
+    )
+
+    internal fun createQuickReplyContentForTesting(
+        text: String = MessageValues.Text,
+        payload: String = Payload,
+    ) = QuickReplyContent(
+        contentType = StructuredMessage.Content.Type.QuickReply.name,
+        quickReply = QuickReplyContent.QuickReply(
+            text = text,
+            payload = payload,
+            action = "action"
+        )
+    )
+
+    internal fun createButtonResponseContentForTesting(
+        text: String = MessageValues.Text,
+        payload: String = Payload,
+    ) = ButtonResponseContent (
+        contentType = StructuredMessage.Content.Type.ButtonResponse.name,
+        buttonResponse = ButtonResponseContent.ButtonResponse(
+            text = text,
+            payload = payload,
+            type = QuickReply,
+        )
     )
 }


### PR DESCRIPTION
- Normalize conversation of StructuredMessage to Message when it comes to quick replies. NOTE: QuickReplies can come from Shyrka as either QuickReplyContent or ButtonResponseContent. Transport will normalize it to QuickReply with ButtonResponse.kt.
- Assign Message.Type.QuickReply to Message when it is Type.Structured AND has quick replies. Otherwise Type.Unknown.
- Add Message.Type.Unknown when Transport failed to identify the message type.
- Refactor MessageStore.update function so that it will be more generic when handling messages with type text and quick reply.
- Add/Update KDoc
- Add/Update unit test.