### PR TITLE
MTSDK-304 Ensure Attachment not sent with quick reply

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -355,12 +355,12 @@ internal class MessageExtensionTest {
     fun `when StructureMessage toMessage() has Content with QuickReplyContent`() {
         val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
             type = StructuredMessage.Type.Structured,
-            content = listOf(StructuredMessageValues.createQuickReplyContentForTesting())
+            content = listOf(QuickReplyTestValues.createQuickReplyContentForTesting())
         )
         val expectedButtonResponse = ButtonResponse(
             text = MessageValues.Text,
-            payload = StructuredMessageValues.Payload,
-            type = StructuredMessageValues.QuickReply
+            payload = QuickReplyTestValues.Payload_A,
+            type = QuickReplyTestValues.QuickReply
         )
         val expectedMessage = Message(
             id = MessageValues.Id,
@@ -379,12 +379,12 @@ internal class MessageExtensionTest {
     fun `when StructureMessage toMessage() has Content with ButtonResponseContent`() {
         val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
             type = StructuredMessage.Type.Structured,
-            content = listOf(StructuredMessageValues.createButtonResponseContentForTesting())
+            content = listOf(QuickReplyTestValues.createButtonResponseContentForTesting())
         )
         val expectedButtonResponse = ButtonResponse(
             text = MessageValues.Text,
-            payload = StructuredMessageValues.Payload,
-            type = StructuredMessageValues.QuickReply
+            payload = QuickReplyTestValues.Payload_A,
+            type = QuickReplyTestValues.QuickReply
         )
         val expectedMessage = Message(
             id = MessageValues.Id,
@@ -404,14 +404,14 @@ internal class MessageExtensionTest {
         val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
             type = StructuredMessage.Type.Structured,
             content = listOf(
-                StructuredMessageValues.createQuickReplyContentForTesting(),
-                StructuredMessageValues.createButtonResponseContentForTesting(),
+                QuickReplyTestValues.createQuickReplyContentForTesting(),
+                QuickReplyTestValues.createButtonResponseContentForTesting(),
             )
         )
         val expectedButtonResponse = ButtonResponse(
             text = MessageValues.Text,
-            payload = StructuredMessageValues.Payload,
-            type = StructuredMessageValues.QuickReply
+            payload = QuickReplyTestValues.Payload_A,
+            type = QuickReplyTestValues.QuickReply
         )
         val expectedMessage = Message(
             id = MessageValues.Id,

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageStoreTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.contains
 import assertk.assertions.containsExactly
 import assertk.assertions.containsOnly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
 import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.core.Message.Content
 import com.genesys.cloud.messenger.transport.core.Message.Direction
@@ -500,6 +501,25 @@ internal class MessageStoreTest {
             expectedMessage,
             (messageSlot.captured as MessageEvent.MessageInserted).message
         )
+    }
+
+    @Test
+    fun `when pending message has uploaded attachment and prepareMessageWith() ButtonResponse`() {
+        val givenButtonResponse = QuickReplyTestValues.buttonResponse_a
+        val givenAttachment = attachment(state = Attachment.State.Uploaded("http://someurl.com"))
+        val expectedContent = listOf(
+            Content(
+                contentType = Content.Type.ButtonResponse,
+                buttonResponse = givenButtonResponse
+            )
+        )
+        subject.updateAttachmentStateWith(givenAttachment)
+
+        val result = subject.prepareMessageWith(givenButtonResponse)
+
+        assertThat(result.message.content).containsOnly(*expectedContent.toTypedArray())
+        assertThat(subject.pendingMessage.attachments).isNotEmpty()
+        assertThat(subject.pendingMessage.attachments).contains(givenAttachment.id to givenAttachment)
     }
 
     private fun outboundMessage(messageId: Int = 0): Message = Message(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -55,7 +55,7 @@ internal class MessageStore(
             log.i { "Message with quick reply prepared to send: $it" }
             activeConversation.add(it)
             publish(MessageEvent.MessageInserted(it))
-            pendingMessage = Message()
+            pendingMessage = Message(attachments = it.attachments)
         }
         val content = listOf(
             Message.Content(

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -41,38 +41,25 @@ object InvalidValues {
 }
 
 object QuickReplyTestValues {
+    internal const val Payload_A = "payload_a"
+    internal const val Payload_B = "payload_b"
+    internal const val QuickReply = "QuickReply"
+
     internal val buttonResponse_a = ButtonResponse(
         text = "text_a",
-        payload = "payload_a",
-        type = "QuickReply"
+        payload = Payload_A,
+        type = QuickReply
     )
 
     internal val buttonResponse_b = ButtonResponse(
         text = "text_b",
-        payload = "payload_b",
-        type = "QuickReply"
-    )
-}
-
-object StructuredMessageValues {
-    internal const val Payload = "payload"
-    internal const val QuickReply = "QuickReply"
-
-    internal fun createStructuredMessageForTesting(
-        id: String = MessageValues.Id,
-        type: StructuredMessage.Type = StructuredMessage.Type.Text,
-        direction: String = Message.Direction.Inbound.name,
-        content: List<StructuredMessage.Content> = emptyList(),
-    ) = StructuredMessage(
-        id = id,
-        type = type,
-        direction = direction,
-        content = content,
+        payload = Payload_B,
+        type = QuickReply
     )
 
     internal fun createQuickReplyContentForTesting(
         text: String = MessageValues.Text,
-        payload: String = Payload,
+        payload: String = Payload_A,
     ) = QuickReplyContent(
         contentType = StructuredMessage.Content.Type.QuickReply.name,
         quickReply = QuickReplyContent.QuickReply(
@@ -84,7 +71,7 @@ object StructuredMessageValues {
 
     internal fun createButtonResponseContentForTesting(
         text: String = MessageValues.Text,
-        payload: String = Payload,
+        payload: String = Payload_A,
     ) = ButtonResponseContent(
         contentType = StructuredMessage.Content.Type.ButtonResponse.name,
         buttonResponse = ButtonResponseContent.ButtonResponse(
@@ -92,5 +79,19 @@ object StructuredMessageValues {
             payload = payload,
             type = QuickReply,
         )
+    )
+}
+
+object StructuredMessageValues {
+    internal fun createStructuredMessageForTesting(
+        id: String = MessageValues.Id,
+        type: StructuredMessage.Type = StructuredMessage.Type.Text,
+        direction: String = Message.Direction.Inbound.name,
+        content: List<StructuredMessage.Content> = emptyList(),
+    ) = StructuredMessage(
+        id = id,
+        type = type,
+        direction = direction,
+        content = content,
     )
 }


### PR DESCRIPTION
### Shyrka does not support mix content messages.
Attempt to send ButtonResponse + Attachment will fail on Shyrka side.
Therefore, to avoid unnecessary error flows, Transport will ensure that Attachment content is not sent along with `onMessage` requests that contains ButtonResponse content.


- Preserve the `attachments` in PendingMessage so that any uploaded attachment can be sent along with the next message.
- Add/Update unit tests