### PR TITLE
MTSDK-300 QuickReplies should be available in history

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/MessageExtensionTest.kt
@@ -443,4 +443,17 @@ internal class MessageExtensionTest {
 
         assertThat(result).isEqualTo(expectedMessage)
     }
+
+    @Test
+    fun `when MessageEntityList toMessageList() has message with type Unknown`() {
+        val givenStructuredMessageList = listOf(
+            StructuredMessageValues.createStructuredMessageForTesting(
+                type = StructuredMessage.Type.Structured
+            )
+        )
+
+        val result = givenStructuredMessageList.toMessageList()
+
+        assertThat(result).isEmpty()
+    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -13,7 +13,9 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.isInbound
 import com.genesys.cloud.messenger.transport.shyrka.send.HealthCheckID
 import com.soywiz.klock.DateTime
 
-internal fun List<StructuredMessage>.toMessageList(): List<Message> = map { it.toMessage() }
+internal fun List<StructuredMessage>.toMessageList(): List<Message> =
+    map { it.toMessage() }
+        .filter { it.messageType != Message.Type.Unknown }
 
 internal fun StructuredMessage.toMessage(): Message {
     val quickReplies = content.toQuickReplies()


### PR DESCRIPTION
- Filter out all Message.Type.Unknown when history response is received.
- Add/Update unit tests.