### PR TITLE
Feature/mtsdk 198 implement quick replies on i os testbed app

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -370,7 +370,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             is MessageEvent.QuickReplyReceived -> event.message.run {
                 quickRepliesMap.clear()
                 quickRepliesMap.putAll(quickReplies.associateBy { it.text })
-                "QuickReplyReceived: $this"
+                "QuickReplyReceived: text: ${this.text} | quick reply options: ${this.quickReplies}"
             }
 
             else -> event.toString()

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -370,7 +370,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             is MessageEvent.QuickReplyReceived -> event.message.run {
                 quickRepliesMap.clear()
                 quickRepliesMap.putAll(quickReplies.associateBy { it.text })
-                "QuickReplyReceived: text: ${this.text} | quick reply options: ${this.quickReplies}"
+                "QuickReplyReceived: text: $text | quick reply options: $quickReplies"
             }
 
             else -> event.toString()

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -104,6 +104,15 @@ final class MessengerInteractor {
             throw error
         }
     }
+    
+    func sendQuickReply(buttonResponse: ButtonResponse) throws {
+        do {
+            try messagingClient.sendQuickReply(buttonResponse: buttonResponse)
+        } catch {
+            print("sendQuickReply(buttonResponse:) failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func fetchNextPage(completion: ((Error?) -> Void)? = nil) {
         messagingClient.fetchNextPage() { error in

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -20,6 +20,7 @@ class TestbedViewController: UIViewController {
     private var pkceEnabled = false
     private var authCode: String? = nil
     private var authState: AuthState = AuthState.noAuth
+    private var quickRepliesMap = [String: ButtonResponse]()
 
     init(messenger: MessengerInteractor) {
         self.messenger = messenger
@@ -41,6 +42,7 @@ class TestbedViewController: UIViewController {
         case connectAuthenticated
         case newChat
         case send
+        case sendQuickReply
         case history
         case selectAttachment
         case attach
@@ -59,6 +61,7 @@ class TestbedViewController: UIViewController {
             case .send: return "send <msg>"
             case .detach: return "detach <attachmentId>"
             case .addAttribute: return "addAttribute <key> <value>"
+            case .sendQuickReply: return "send <quickReply>"
             default: return rawValue
             }
         }
@@ -215,6 +218,9 @@ class TestbedViewController: UIViewController {
         case let history as MessageEvent.HistoryFetched:
             displayMessage = "History Fetched: startOfConversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)> "
             print(displayMessage)
+        case let quickReplies as MessageEvent.QuickReplyReceived:
+            quickRepliesMap =  Dictionary(uniqueKeysWithValues: quickReplies.message.quickReplies.map { ($0.text, $0) })
+            displayMessage = "QuickReplyReceived: text: <\(quickReplies.message.text)> | quick reply optoins: <\(quickReplies.message.quickReplies)>"
         default:
             break
         }
@@ -248,6 +254,8 @@ class TestbedViewController: UIViewController {
             authState = AuthState.loggedOut
             updateAuthStateView()
             displayEvent = "Event received: \(logout.description)"
+        case let disconnect as Event.ConversationDisconnect:
+            displayEvent = "Event received: \(disconnect.description)"
         default:
             break
         }
@@ -381,6 +389,13 @@ extension TestbedViewController : UITextFieldDelegate {
                 try messenger.disconnect()
             case (.send, let msg?):
                 try messenger.sendMessage(text: msg.trimmingCharacters(in: .whitespaces))
+            case (.sendQuickReply, let quickReply?):
+                if let buttonResponse = quickRepliesMap[quickReply] {
+                    try messenger.sendQuickReply(buttonResponse: buttonResponse)
+                    quickRepliesMap.removeAll()
+                } else {
+                    self.info.text = "Selected quickReply option: \(quickReply) does not exist."
+                }
             case (.history, _):
                 messenger.fetchNextPage()
             case (.healthCheck, _):

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -61,7 +61,7 @@ class TestbedViewController: UIViewController {
             case .send: return "send <msg>"
             case .detach: return "detach <attachmentId>"
             case .addAttribute: return "addAttribute <key> <value>"
-            case .sendQuickReply: return "send <quickReply>"
+            case .sendQuickReply: return "sendQuickReply <quickReply>"
             default: return rawValue
             }
         }


### PR DESCRIPTION
- Store quick replies as map when received.
- Implement sendQuickReply command.
- Add sendQuickReply command to MessengerInteractor.swift
- Add print of Event.ConversationDisconnect that was missing on iOS.
- Align print of quick replies received message between iOS and Android.