### PR TITLE
Feature/MTSDK-272 iOS automation

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -370,7 +370,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             is MessageEvent.QuickReplyReceived -> event.message.run {
                 quickRepliesMap.clear()
                 quickRepliesMap.putAll(quickReplies.associateBy { it.text })
-                "QuickReplyReceived: $this"
+                "QuickReplyReceived: text: ${this.text} | quick reply options: ${this.quickReplies}"
             }
 
             else -> event.toString()

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -370,7 +370,7 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             is MessageEvent.QuickReplyReceived -> event.message.run {
                 quickRepliesMap.clear()
                 quickRepliesMap.putAll(quickReplies.associateBy { it.text })
-                "QuickReplyReceived: text: ${this.text} | quick reply options: ${this.quickReplies}"
+                "QuickReplyReceived: text: $text | quick reply options: $quickReplies"
             }
 
             else -> event.toString()

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -104,6 +104,15 @@ final class MessengerInteractor {
             throw error
         }
     }
+    
+    func sendQuickReply(buttonResponse: ButtonResponse) throws {
+        do {
+            try messagingClient.sendQuickReply(buttonResponse: buttonResponse)
+        } catch {
+            print("sendQuickReply(buttonResponse:) failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
 
     func fetchNextPage(completion: ((Error?) -> Void)? = nil) {
         messagingClient.fetchNextPage() { error in

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -20,6 +20,7 @@ class TestbedViewController: UIViewController {
     private var pkceEnabled = false
     private var authCode: String? = nil
     private var authState: AuthState = AuthState.noAuth
+    private var quickRepliesMap = [String: ButtonResponse]()
 
     init(messenger: MessengerInteractor) {
         self.messenger = messenger
@@ -41,6 +42,7 @@ class TestbedViewController: UIViewController {
         case connectAuthenticated
         case newChat
         case send
+        case sendQuickReply
         case history
         case selectAttachment
         case attach
@@ -59,6 +61,7 @@ class TestbedViewController: UIViewController {
             case .send: return "send <msg>"
             case .detach: return "detach <attachmentId>"
             case .addAttribute: return "addAttribute <key> <value>"
+            case .sendQuickReply: return "send <quickReply>"
             default: return rawValue
             }
         }
@@ -215,6 +218,9 @@ class TestbedViewController: UIViewController {
         case let history as MessageEvent.HistoryFetched:
             displayMessage = "History Fetched: startOfConversation: <\(history.startOfConversation.description)>, messages: <\(history.messages.description)> "
             print(displayMessage)
+        case let quickReplies as MessageEvent.QuickReplyReceived:
+            quickRepliesMap =  Dictionary(uniqueKeysWithValues: quickReplies.message.quickReplies.map { ($0.text, $0) })
+            displayMessage = "QuickReplyReceived: text: <\(quickReplies.message.text)> | quick reply optoins: <\(quickReplies.message.quickReplies)>"
         default:
             break
         }
@@ -248,6 +254,8 @@ class TestbedViewController: UIViewController {
             authState = AuthState.loggedOut
             updateAuthStateView()
             displayEvent = "Event received: \(logout.description)"
+        case let disconnect as Event.ConversationDisconnect:
+            displayEvent = "Event received: \(disconnect.description)"
         default:
             break
         }
@@ -381,6 +389,13 @@ extension TestbedViewController : UITextFieldDelegate {
                 try messenger.disconnect()
             case (.send, let msg?):
                 try messenger.sendMessage(text: msg.trimmingCharacters(in: .whitespaces))
+            case (.sendQuickReply, let quickReply?):
+                if let buttonResponse = quickRepliesMap[quickReply] {
+                    try messenger.sendQuickReply(buttonResponse: buttonResponse)
+                    quickRepliesMap.removeAll()
+                } else {
+                    self.info.text = "Selected quickReply option: \(quickReply) does not exist."
+                }
             case (.history, _):
                 messenger.fetchNextPage()
             case (.healthCheck, _):

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -61,7 +61,7 @@ class TestbedViewController: UIViewController {
             case .send: return "send <msg>"
             case .detach: return "detach <attachmentId>"
             case .addAttribute: return "addAttribute <key> <value>"
-            case .sendQuickReply: return "send <quickReply>"
+            case .sendQuickReply: return "sendQuickReply <quickReply>"
             default: return rawValue
             }
         }

--- a/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
+++ b/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
@@ -295,6 +295,10 @@ class MessengerInteractorTester {
         }
     }
 
+    func getQuickReplyOptions() -> [String] {
+        return Array(quickRepliesMap.keys)
+    }
+
     func attemptImageAttach(kotlinByteArray: KotlinByteArray, file: StaticString = #file, line: UInt = #line) {
         do {
             try attachImage(kotlinByteArray: kotlinByteArray)

--- a/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
+++ b/iosApp/iosAppTests/Support/MessengerInteractorTester.swift
@@ -24,6 +24,7 @@ class MessengerInteractorTester {
     var closedStateChange: XCTestExpectation?
     var conversationCleared: XCTestExpectation?
     var authExpectation: XCTestExpectation?
+    var quickReplyExpectation: XCTestExpectation?
     var receivedMessageText: String? = nil
     var receivedDownloadUrl: String? = nil
     var humanizeEnabled: Bool = true
@@ -32,7 +33,8 @@ class MessengerInteractorTester {
 
     private var historyExpectation: XCTestExpectation?
     private var historyMessages: [Message] = []
-    
+    var quickRepliesMap = [String: ButtonResponse]()
+
     private var cancellables = Set<AnyCancellable>()
 
     init(deployment: Deployment, reconnectTimeout: Int64 = 60 * 5) {
@@ -114,6 +116,10 @@ class MessengerInteractorTester {
                     }
                     self?.historyMessages = history.messages
                     self?.historyExpectation?.fulfill()
+                case let quickReplies as MessageEvent.QuickReplyReceived:
+                    self?.quickReplyExpectation?.fulfill()
+                    self?.quickRepliesMap =  Dictionary(uniqueKeysWithValues: quickReplies.message.quickReplies.map { ($0.text, $0) })
+                    print("Quick Replies received: <\(quickReplies.message.text ?? "N/A")> | quick reply optoins: <\(quickReplies.message.quickReplies)>")
                 default:
                     print("Unexpected messageListener event: \(message)")
                 }
@@ -277,6 +283,18 @@ class MessengerInteractorTester {
         verifyReceivedMessage(expectedMessage: text)
     }
 
+    func sendQuickReply(reply: String, file: StaticString = #file, line: UInt = #line) {
+        guard let button = quickRepliesMap[reply] else {
+            XCTFail("The quick reply \(reply) was not available.", file: file, line: line)
+            return
+        }
+        do {
+            try messenger.sendQuickReply(buttonResponse: button)
+        } catch {
+            XCTFail("Failed to send the quick reply message '\(reply)'\n\(error.localizedDescription)", file: file, line: line)
+        }
+    }
+
     func attemptImageAttach(kotlinByteArray: KotlinByteArray, file: StaticString = #file, line: UInt = #line) {
         do {
             try attachImage(kotlinByteArray: kotlinByteArray)
@@ -345,6 +363,14 @@ class MessengerInteractorTester {
 
     func waitForErrorExpectation(timeout: Double = 60.0) {
         guard let expectation = errorExpectation else {
+            XCTFail("No expectation to wait for.")
+            return
+        }
+        waitForExpectation(expectation, timeout: timeout)
+    }
+
+    func waitForQuickReplies(timeout: Double = 60.0) {
+        guard let expectation = quickReplyExpectation else {
             XCTFail("No expectation to wait for.")
             return
         }

--- a/iosApp/iosAppTests/Support/TestConfig.swift
+++ b/iosApp/iosAppTests/Support/TestConfig.swift
@@ -27,6 +27,7 @@ struct Config: Codable {
     public let authDeploymentId: String
     public let redirectUri: String
     public let oktaCodeVerifier: String
+    public let quickReplyBot: String
 }
 
 struct TestConfig {

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -428,21 +428,38 @@ class iosAppTests: XCTestCase {
     //   Second segment: One reply possible: "Done".
     //     - Selecting "Done" will end the flow.
     func testQuickReply() {
+        // Continuing after failure to ensure that we finish the bot flow.
+        continueAfterFailure = true
+
+        // Create a new instance of the MessengerInteractorTester.
+        // This will be used to handle sending/receiving messages through the SDK.
         // Connect to the quick reply bot.
         let deployment = try! Deployment()
         let testController = MessengerInteractorTester(deployment: Deployment(deploymentId: TestConfig.shared.config?.quickReplyBot ?? "", domain: deployment.domain))
         testController.quickReplyExpectation = XCTestExpectation(description: "Waiting for quick replies to show up.")
         testController.startNewMessengerConnection()
-        delay(10, reason: "Allow time for the bot to start.")
 
-        // Wait for quick replies to show up. Navigate to the Carousel portion using quick replies.
+        // Wait for quick replies to show up. Verify the expected options are shown.
         testController.waitForQuickReplies()
-        testController.testExpectation = XCTestExpectation(description: "Wait for a message to be received from the bot.")
-        testController.sendQuickReply(reply: "Carousel")
-        testController.waitForTestExpectation()
+        let repliesFirstSegment = testController.getQuickReplyOptions()
+        XCTAssertEqual(repliesFirstSegment.count, 2, "An unexpected number of replies were received.")
+        XCTAssertTrue(repliesFirstSegment.contains("Carousel"), "The \"Carousel\" quick reply option was not received.")
+        XCTAssertTrue(repliesFirstSegment.contains("Done"), "The \"Done\" quick reply option was not received.")
 
-        // Getting here means that we successfully handled a Carousel quick reply.
-        // Support for Carousel replies will be in a different Ticket.
+        // Create a test expectation to ensure the test waits for an incoming message from the bot.
+        // Send the quick reply to go to the Carousel digital menu.
+        testController.receivedMessageExpectation = XCTestExpectation(description: "Wait for a message to be received from the bot.")
+        testController.sendQuickReply(reply: "Carousel")
+
+        // After sending the quick reply, wait for the expected digital menu message to be received.
+        // Getting to this point ensures that we do not error out after getting to a Carousel digital menu.
+        // Send a "Done" message to end the bot flow.
+        testController.waitForMessageReceiveExpectation()
+        let receivedMessageText = "Welcome to the Carousel Pal. Reply \"Done\" to end the flow."
+        testController.verifyReceivedMessage(expectedMessage: receivedMessageText)
+        testController.sendText(text: "Done")
+
+        // Disconnect the test messenger.
         testController.disconnectMessenger()
     }
 

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -421,6 +421,31 @@ class iosAppTests: XCTestCase {
         messengerTester.disconnectMessenger()
     }
 
+    // The Quick Reply bot has the following structure:
+    //   First segment: Two replies possible: "Carousel", "Done".
+    //     - Selecting Carousel goes to another part of the flow where a Carousel Reply option is given.
+    //     - Selecting Done will end the flow.
+    //   Second segment: One reply possible: "Done".
+    //     - Selecting "Done" will end the flow.
+    func testQuickReply() {
+        // Connect to the quick reply bot.
+        let deployment = try! Deployment()
+        let testController = MessengerInteractorTester(deployment: Deployment(deploymentId: TestConfig.shared.config?.quickReplyBot ?? "", domain: deployment.domain))
+        testController.quickReplyExpectation = XCTestExpectation(description: "Waiting for quick replies to show up.")
+        testController.startNewMessengerConnection()
+        delay(10, reason: "Allow time for the bot to start.")
+
+        // Wait for quick replies to show up. Navigate to the Carousel portion using quick replies.
+        testController.waitForQuickReplies()
+        testController.testExpectation = XCTestExpectation(description: "Wait for a message to be received from the bot.")
+        testController.sendQuickReply(reply: "Carousel")
+        testController.waitForTestExpectation()
+
+        // Getting here means that we successfully handled a Carousel quick reply.
+        // Support for Carousel replies will be in a different Ticket.
+        testController.disconnectMessenger()
+    }
+
     func testSendAndReceiveMessage() {
         // Setup the session. Send a message.
         guard let messengerTester = messengerTester else {

--- a/iosApp/iosAppTests/iosAppTests.swift
+++ b/iosApp/iosAppTests/iosAppTests.swift
@@ -455,7 +455,7 @@ class iosAppTests: XCTestCase {
         // Getting to this point ensures that we do not error out after getting to a Carousel digital menu.
         // Send a "Done" message to end the bot flow.
         testController.waitForMessageReceiveExpectation()
-        let receivedMessageText = "Welcome to the Carousel Pal. Reply \"Done\" to end the flow."
+        let receivedMessageText = "Welcome to the Carousel menu. Reply \"Done\" to end the flow."
         testController.verifyReceivedMessage(expectedMessage: receivedMessageText)
         testController.sendText(text: "Done")
 


### PR DESCRIPTION
- New automated test for iOS to verify Quick Replies.
- Test ensures that we can reach a Carousel reply section in a bot and not throw an error. 
    - Additional automation will be needed for this later once the SDK supports Carousel quick replies. 
- Test verifies that we can send a quick reply to the bot and get an expected response.