### PR TITLE
Techdebt/mtsdk 307 move commands list on android testbed to hamburger…

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
@@ -1,0 +1,23 @@
+package com.genesys.cloud.messenger.androidcomposeprototype.ui.testbed
+
+enum class Command(val description: String) {
+    ADD_ATTRIBUTE("addAttribute <key> <value>"),
+    ATTACH("attach"),
+    AUTHORIZE("authorize"),
+    BYE("bye"),
+    CLEAR_CONVERSATION("clearConversation"),
+    CONNECT("connect"),
+    CONNECT_AUTHENTICATED("connectAuthenticated"),
+    DELETE("delete <attachmentID>"),
+    DEPLOYMENT("deployment"),
+    DETACH("detach"),
+    HEALTH_CHECK("healthcheck"),
+    HISTORY("history"),
+    INVALIDATE_CONVERSATION_CACHE("invalidateConversationCache"),
+    NEW_CHAT("newChat"),
+    OKTA_LOGOUT("oktaLogout"),
+    OKTA_SIGN_IN_WITH_PKCE("oktaSignInWithPKCE"),
+    SEND("send <msg>"),
+    SEND_QUICK_REPLY("sendQuickReply <quickReply>"),
+    TYPING("typing")
+}


### PR DESCRIPTION
… menu (#259)

* MTSDK 307-Move-Commands-List-on-Android-Testbed-to-Hamburger-Menu

- Move command list from main screen to hamburger menu/drawer
- Allow clicking command in drawer to populate send box
- Organize commands alphabetically in drawer
- Create separate enum for list of commands
- General code cleanup