### PR TITLE
MTSDK 312-Error_Event_Is_Dispatched_When_CA_Set_Before_Session_Connected

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
@@ -84,8 +84,8 @@ class CustomAttributesStoreTest {
     @Test
     fun `when add customAttributes with similar key but different value`() {
         val initialCustomAttributes = TestValues.defaultMap
-        val updatedCustomAttributes = TestValues.defaultMap
-        val expectedCustomAttributes = TestValues.defaultMap
+        val updatedCustomAttributes = mapOf("A" to "C")
+        val expectedCustomAttributes = mapOf("A" to "C")
 
         subject.add(initialCustomAttributes)
         subject.add(updatedCustomAttributes)

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreTest.kt
@@ -19,13 +19,13 @@ class CustomAttributesStoreTest {
     private val mockLogger: Log = mockk(relaxed = true)
     private val logSlot = mutableListOf<() -> String>()
     private val mockEventHandler = mockk<EventHandler>(relaxed = true)
-    private val subject: CustomAttributesStoreImpl =
+    private var subject: CustomAttributesStoreImpl =
         CustomAttributesStoreImpl(mockLogger, mockEventHandler).also { it.maxCustomDataBytes = TestValues.MaxCustomDataBytes }
 
     @Test
     fun `when add a new customAttribute`() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
 
         val result = subject.add(givenCustomAttributes)
 
@@ -34,7 +34,12 @@ class CustomAttributesStoreTest {
         assertThat(subject.get()).isEqualTo(expectedCustomAttributes)
         assertThat(subject.getCustomAttributesToSend()).isEqualTo(expectedCustomAttributes)
         assertThat(result).isTrue()
-        assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.addCustomAttribute(expectedCustomAttributes, State.PENDING.name))
+        assertThat(logSlot[0].invoke()).isEqualTo(
+            LogMessages.addCustomAttribute(
+                expectedCustomAttributes,
+                State.PENDING.name
+            )
+        )
     }
 
     @Test
@@ -60,8 +65,8 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when add the same customAttribute twice`() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
 
         val result1 = subject.add(givenCustomAttributes)
         val result2 = subject.add(givenCustomAttributes)
@@ -78,9 +83,9 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when add customAttributes with similar key but different value`() {
-        val initialCustomAttributes = mapOf("A" to "B")
-        val updatedCustomAttributes = mapOf("A" to "C")
-        val expectedCustomAttributes = mapOf("A" to "C")
+        val initialCustomAttributes = TestValues.defaultMap
+        val updatedCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
 
         subject.add(initialCustomAttributes)
         subject.add(updatedCustomAttributes)
@@ -92,8 +97,8 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when getCustomAttributesToSend and current state is Pending `() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
         subject.add(givenCustomAttributes)
 
         val result = subject.getCustomAttributesToSend()
@@ -105,8 +110,8 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when getCustomAttributesToSend and current state is Sending`() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
         subject.add(givenCustomAttributes)
         subject.onSending()
 
@@ -119,8 +124,8 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when getCustomAttributesToSend and current state is Sent`() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
         subject.add(givenCustomAttributes)
         subject.onSending()
         subject.onSent()
@@ -134,7 +139,7 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when getCustomAttributesToSend and current state is Error`() {
-        val givenCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
         subject.add(givenCustomAttributes)
         subject.onError()
 
@@ -170,6 +175,7 @@ class CustomAttributesStoreTest {
         subject.onSessionClosed()
 
         assertThat(subject.state).isPending()
+        assertThat(subject.maxCustomDataBytes).isEqualTo(MAX_CUSTOM_DATA_BYTES_UNSET)
         verify { mockLogger.i(capture(logSlot)) }
         assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.ON_SESSION_CLOSED)
     }
@@ -185,8 +191,8 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when add customAttributes and then onSessionClosed`() {
-        val givenCustomAttributes = mapOf("A" to "B")
-        val expectedCustomAttributes = mapOf("A" to "B")
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
 
         subject.add(givenCustomAttributes)
         subject.onSessionClosed()
@@ -253,7 +259,7 @@ class CustomAttributesStoreTest {
         )
         subject.maxCustomDataBytes = 0
 
-        val result = subject.add(mapOf("A" to "B"))
+        val result = subject.add(TestValues.defaultMap)
 
         assertThat(subject.get()).isEmpty()
         assertThat(subject.getCustomAttributesToSend()).isEmpty()
@@ -264,5 +270,55 @@ class CustomAttributesStoreTest {
             mockLogger.e(capture(logSlot))
         }
         assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.CUSTOM_ATTRIBUTES_SIZE_EXCEEDED)
+    }
+
+    @Test
+    fun `when maxCustomDataBytes was not set yet`() {
+        // Given
+        val expectedMaxCustomDataBytes = MAX_CUSTOM_DATA_BYTES_UNSET
+        subject = CustomAttributesStoreImpl(mockLogger, mockEventHandler)
+
+        // When
+        val result = subject.maxCustomDataBytes
+
+        // Then
+        assertThat(result).isEqualTo(expectedMaxCustomDataBytes)
+    }
+
+    @Test
+    fun `when maxCustomDataBytes is updated with valid size and ca are already added`() {
+        // Given
+        subject = CustomAttributesStoreImpl(mockLogger, mockEventHandler)
+        val givenMaxCustomDataBytes = TestValues.MaxCustomDataBytes
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedCustomAttributes = TestValues.defaultMap
+        val result = subject.add(givenCustomAttributes)
+        assertThat(subject.maxCustomDataBytes).isEqualTo(MAX_CUSTOM_DATA_BYTES_UNSET)
+        // When
+        subject.maxCustomDataBytes = givenMaxCustomDataBytes
+        // Then
+        verify(exactly = 0) {
+            mockEventHandler.onEvent(any())
+        }
+        assertThat(subject.get()).isEqualTo(expectedCustomAttributes)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `when custom attributes are already added but are bigger than updated maxCustomDataBytes`() {
+        // Given
+        subject = CustomAttributesStoreImpl(mockLogger, mockEventHandler)
+        val givenMaxCustomDataBytes = TestValues.DefaultNumber
+        val givenCustomAttributes = TestValues.defaultMap
+        val result = subject.add(givenCustomAttributes)
+        assertThat(subject.maxCustomDataBytes).isEqualTo(MAX_CUSTOM_DATA_BYTES_UNSET)
+        // When
+        subject.maxCustomDataBytes = givenMaxCustomDataBytes
+        // Then
+        verify {
+            mockEventHandler.onEvent(any())
+        }
+        assertThat(subject.get()).isEmpty()
+        assertThat(result).isTrue()
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
@@ -7,12 +7,22 @@ import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.core.toByteArray
 
+private const val MAX_CUSTOM_DATA_BYTES_UNSET = -1
+
 internal class CustomAttributesStoreImpl(
     private val log: Log,
     private val eventHandler: EventHandler,
 ) : CustomAttributesStore {
     private var customAttributes: MutableMap<String, String> = mutableMapOf()
-    var maxCustomDataBytes: Int = 0
+    var maxCustomDataBytes: Int = MAX_CUSTOM_DATA_BYTES_UNSET
+        internal set(value) {
+            if (!value.isUnset()) {
+                if (maybeReportFailure(customAttributes)) {
+                    customAttributes.clear()
+                }
+            }
+            field = value
+        }
 
     internal var state: State = State.PENDING
         private set
@@ -30,10 +40,14 @@ internal class CustomAttributesStoreImpl(
     }
 
     private fun isCustomAttributesValid(customAttributes: Map<String, String>): Boolean {
-        if (customAttributes.isEmpty() || this.customAttributes == customAttributes) {
-            log.w { LogMessages.CUSTOM_ATTRIBUTES_EMPTY_OR_SAME }
-            return false
-        } else if (isSizeExceeded(customAttributes)) {
+        return maxCustomDataBytes.isUnset() || (
+            !(customAttributes.isEmpty() || this.customAttributes == customAttributes) &&
+                !maybeReportFailure(customAttributes)
+            )
+    }
+
+    private fun maybeReportFailure(customAttributes: Map<String, String>): Boolean {
+        return isSizeExceeded(customAttributes).also {
             eventHandler.onEvent(
                 Event.Error(
                     ErrorCode.CustomAttributeSizeTooLarge,
@@ -42,13 +56,12 @@ internal class CustomAttributesStoreImpl(
                 )
             )
             log.e { LogMessages.CUSTOM_ATTRIBUTES_SIZE_EXCEEDED }
-            return false
         }
-        return true
     }
 
     private fun isSizeExceeded(attributes: Map<String, String>): Boolean {
-        val totalSize = attributes.entries.sumOf { (key, value) ->
+        val attributesToValidate = customAttributes + attributes
+        val totalSize = attributesToValidate.entries.sumOf { (key, value) ->
             key.toByteArray(Charsets.UTF_8).size + value.toByteArray(Charsets.UTF_8).size
         }
         return totalSize > maxCustomDataBytes
@@ -86,6 +99,7 @@ internal class CustomAttributesStoreImpl(
     internal fun onSessionClosed() {
         log.i { LogMessages.ON_SESSION_CLOSED }
         state = State.PENDING
+        maxCustomDataBytes = MAX_CUSTOM_DATA_BYTES_UNSET
     }
 
     internal enum class State {
@@ -95,3 +109,5 @@ internal class CustomAttributesStoreImpl(
         ERROR,
     }
 }
+
+private fun Int.isUnset(): Boolean = this == MAX_CUSTOM_DATA_BYTES_UNSET

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/CustomAttributesStoreImpl.kt
@@ -7,7 +7,7 @@ import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import io.ktor.utils.io.charsets.Charsets
 import io.ktor.utils.io.core.toByteArray
 
-private const val MAX_CUSTOM_DATA_BYTES_UNSET = -1
+internal const val MAX_CUSTOM_DATA_BYTES_UNSET = -1
 
 internal class CustomAttributesStoreImpl(
     private val log: Log,
@@ -40,18 +40,13 @@ internal class CustomAttributesStoreImpl(
     }
 
     private fun isCustomAttributesValid(customAttributes: Map<String, String>): Boolean {
-        // Check if the size limit is unset, which means any size is valid
         if (maxCustomDataBytes.isUnset()) {
             return true
         }
-        // Check if the custom attributes map is empty or the same
-        // If so, it's not valid
         if (customAttributes.isEmpty() || this.customAttributes == customAttributes) {
             log.w { LogMessages.CUSTOM_ATTRIBUTES_EMPTY_OR_SAME }
             return false
         }
-        // Check if adding the new custom attributes would exceed the size limit
-        // If so report failure
         if (maybeReportFailure(customAttributes)) {
             return false
         }
@@ -60,7 +55,7 @@ internal class CustomAttributesStoreImpl(
 
     private fun maybeReportFailure(customAttributes: Map<String, String>): Boolean {
         val isSizeExceeded = isSizeExceeded(customAttributes)
-        if (isSizeExceeded)  {
+        if (isSizeExceeded) {
             eventHandler.onEvent(
                 Event.Error(
                     ErrorCode.CustomAttributeSizeTooLarge,

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -13,6 +13,7 @@ object TestValues {
     internal const val Domain: String = "inindca.com"
     internal const val DeploymentId = "deploymentId"
     internal const val MaxCustomDataBytes = 100
+    internal const val DefaultNumber = 1
     internal const val Timestamp = "2022-08-22T19:24:26.704Z"
     internal const val Token = "<token>"
     internal const val ReconnectionTimeout = 5000L
@@ -21,6 +22,7 @@ object TestValues {
     internal const val TokenKey = "token_key"
     internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
     internal const val LogTag = "TestLogTag"
+    internal val defaultMap = mapOf("A" to "B")
 }
 
 object AuthTest {


### PR DESCRIPTION
- Implement MAX_CUSTOM_DATA_BYTES_UNSET for clear indication of unset size limits.
- Add maxCustomDataBytes setter to validate and potentially clear attributes if size limit is exceeded upon configuration.
- Simplify isCustomAttributesValid method by extracting the size exceeded check to separate function maybeReportFailure.
- Create maybeReportFailure function for a centralized CA size check.
- Reset maxCustomDataBytes upon session closure.