### PR TITLE
MTSDK-322 Unexpected CASizeTooLarge on newChat flow.

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ResponsesTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ResponsesTests.kt
@@ -7,6 +7,7 @@ import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.core.ButtonResponse
 import com.genesys.cloud.messenger.transport.core.ErrorCode
+import com.genesys.cloud.messenger.transport.core.MAX_CUSTOM_DATA_BYTES_UNSET
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.utility.AttachmentValues
 import com.genesys.cloud.messenger.transport.utility.AuthTest
@@ -125,6 +126,7 @@ class ResponsesTests {
             assertThat(connected).isTrue()
             assertThat(newSession).isTrue()
             assertThat(readOnly).isFalse()
+            assertThat(maxCustomDataBytes).isEqualTo(MAX_CUSTOM_DATA_BYTES_UNSET)
         }
         givenDefaultSessionResponseConstructor.run {
             assertThat(connected).isTrue()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/SessionResponse.kt
@@ -1,5 +1,6 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
+import com.genesys.cloud.messenger.transport.core.MAX_CUSTOM_DATA_BYTES_UNSET
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -7,5 +8,5 @@ internal data class SessionResponse(
     val connected: Boolean,
     val newSession: Boolean = false,
     val readOnly: Boolean = false,
-    val maxCustomDataBytes: Int = 0
+    val maxCustomDataBytes: Int = MAX_CUSTOM_DATA_BYTES_UNSET,
 )


### PR DESCRIPTION
- Give SessionResponse.maxCustomDataBytes a default value of CustomAttributesStoreImpl.MAX_CUSTOM_DATA_BYTES_UNSET to prevent CA validation when maxCustomDataBytes are not present in SessionResponse.
- Update unit test.