### PR TITLE
MTSDK-359 Provide API to step up

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -188,14 +188,19 @@ open class BaseMessagingClientTest {
     fun after() = clearAllMocks()
 
     protected fun MockKVerificationScope.connectSequence(shouldConfigureAuth: Boolean = false) {
-        val configureRequest =
-            if (shouldConfigureAuth) Request.configureAuthenticatedRequest() else Request.configureRequest()
         mockLogger.withTag(LogTag.STATE_MACHINE)
         mockLogger.withTag(LogTag.WEBSOCKET)
         mockLogger.i(capture(logSlot))
         mockStateChangedListener(fromIdleToConnecting)
         mockPlatformSocket.openSocket(any())
         mockStateChangedListener(fromConnectingToConnected)
+        configureSequence(shouldConfigureAuth)
+        mockStateChangedListener(fromConnectedToConfigured)
+    }
+
+    protected fun MockKVerificationScope.configureSequence(shouldConfigureAuth: Boolean = false) {
+        val configureRequest =
+            if (shouldConfigureAuth) Request.configureAuthenticatedRequest() else Request.configureRequest()
         mockLogger.i(capture(logSlot))
         if (shouldConfigureAuth) {
             mockAuthHandler.jwt // check if jwt is valid
@@ -206,7 +211,6 @@ open class BaseMessagingClientTest {
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()
         mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
-        mockStateChangedListener(fromConnectedToConfigured)
     }
 
     protected fun MockKVerificationScope.connectToReadOnlySequence() {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -136,11 +136,21 @@ interface MessagingClient {
     /**
      * Open and configure an authenticated and secure WebSocket connection to the Web Messaging service using the url and deploymentId
      * configured on this MessagingClient instance. Note, once Authenticated session is configured it can not be downgraded to Anonymous session.
+     * When called on a session that was previously configured as anonymous/guest, it will perform a Step-Up.
      *
      * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
      */
     @Throws(IllegalStateException::class)
     fun connectAuthenticatedSession()
+
+    /**
+     * Performs a step-up of from existing anonymous/guest session to an authenticated session.
+     * To perform this action, the MessagingClient must be in State.Configured and authorized(see [authorize] function)
+     *
+     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     */
+    @Throws(IllegalStateException::class)
+    fun stepUpToAuthenticatedSession()
 
     /**
      * Configure a new chat once the previous one is in State.ReadOnly.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -144,6 +144,14 @@ internal class MessagingClientImpl(
     }
 
     @Throws(IllegalStateException::class)
+    override fun stepUpToAuthenticatedSession() {
+        log.i { LogMessages.STEP_UP_TO_AUTHENTICATED_SESSION }
+        stateMachine.checkIfConfigured()
+        connectAuthenticated = true
+        configureSession()
+    }
+
+    @Throws(IllegalStateException::class)
     override fun startNewChat() {
         stateMachine.checkIfCanStartANewChat()
         isStartingANewSession = true
@@ -172,10 +180,10 @@ internal class MessagingClientImpl(
                 transitionToStateError(ErrorCode.AuthFailed, ErrorMessage.FailedToConfigureSession)
                 return
             }
-            encodeAuthenticatedConfigureSessionRequest(startNew)
+            encodeConfigureAuthenticatedSessionRequest(startNew)
         } else {
             log.i { LogMessages.configureSession(token, startNew) }
-            encodeAnonymousConfigureSessionRequest(startNew)
+            encodeConfigureGuestSessionRequest(startNew)
         }
         webSocket.sendMessage(encodedJson)
     }
@@ -557,7 +565,7 @@ internal class MessagingClientImpl(
         }
     }
 
-    private fun encodeAnonymousConfigureSessionRequest(startNew: Boolean) =
+    private fun encodeConfigureGuestSessionRequest(startNew: Boolean) =
         WebMessagingJson.json.encodeToString(
             ConfigureSessionRequest(
                 token = token,
@@ -570,7 +578,7 @@ internal class MessagingClientImpl(
             )
         )
 
-    private fun encodeAuthenticatedConfigureSessionRequest(startNew: Boolean) =
+    private fun encodeConfigureAuthenticatedSessionRequest(startNew: Boolean) =
         WebMessagingJson.json.encodeToString(
             ConfigureAuthenticatedSessionRequest(
                 token = token,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -58,6 +58,7 @@ internal object LogMessages {
     const val ON_SESSION_CLOSED = "onSessionClosed"
     const val CONNECT = "connect"
     const val CONNECT_AUTHENTICATED_SESSION = "connectAuthenticatedSession"
+    const val STEP_UP_TO_AUTHENTICATED_SESSION = "stepUpToAuthenticatedSession"
     const val DISCONNECT = "disconnect"
     fun onSentState(state: String) = "onSent. state = $state"
     const val CLOSE_SESSION = "closeSession"


### PR DESCRIPTION
- Add new `stepUpToAuthenticatedSession()` to allow step up from guest to authenticated session.
- Add/Update KDocs.
- Add unit tests to support new api.
- Rename encodeAuth/Anonymous functions.