### PR TITLE
MTSDK-349 Provide SignIn indicator

### DIFF
--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCAutostartTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCAutostartTests.kt
@@ -112,14 +112,13 @@ class MCAutostartTests : BaseMessagingClientTest() {
 
     @Test
     fun `when event Presence Join received`() {
-        val givenPresenceJoinEvent = """{"eventType":"Presence","presence":{"type":"Join"}}"""
         val expectedEvent = Event.ConversationAutostart
 
         subject.connect()
         slot.captured.onMessage(
             Response.structuredMessageWithEvents(
                 direction = Message.Direction.Inbound,
-                events = givenPresenceJoinEvent
+                events = Response.StructuredEvent.presenceJoin
             )
         )
 

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCConversationDisconnectTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCConversationDisconnectTests.kt
@@ -35,12 +35,10 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
 
     @Test
     fun `when event Presence Disconnect received and there is no readOnly field in metadata`() {
-        val givenPresenceDisconnectEvent =
-            """{"eventType":"Presence","presence":{"type":"Disconnect"}}"""
         val expectedEvent = Event.ConversationDisconnect
 
         subject.connect()
-        slot.captured.onMessage(Response.structuredMessageWithEvents(events = givenPresenceDisconnectEvent))
+        slot.captured.onMessage(Response.structuredMessageWithEvents(events = Response.StructuredEvent.presenceDisconnect))
 
         assertThat(subject.currentState).isConfigured(connected = true, newSession = true)
         verify { mockEventHandler.onEvent(eq(expectedEvent)) }
@@ -52,14 +50,12 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
 
     @Test
     fun `when event Presence Disconnect received and readOnly field in metadata is true`() {
-        val givenPresenceDisconnectEvent =
-            """{"eventType":"Presence","presence":{"type":"Disconnect"}}"""
         val expectedEvent = Event.ConversationDisconnect
 
         subject.connect()
         slot.captured.onMessage(
             Response.structuredMessageWithEvents(
-                events = givenPresenceDisconnectEvent,
+                events = Response.StructuredEvent.presenceDisconnect,
                 metadata = mapOf("readOnly" to "true")
             )
         )
@@ -74,14 +70,12 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
 
     @Test
     fun `when event Presence Disconnect received and readOnly field in metadata is false`() {
-        val givenPresenceDisconnectEvent =
-            """{"eventType":"Presence","presence":{"type":"Disconnect"}}"""
         val expectedEvent = Event.ConversationDisconnect
 
         subject.connect()
         slot.captured.onMessage(
             Response.structuredMessageWithEvents(
-                events = givenPresenceDisconnectEvent,
+                events = Response.StructuredEvent.presenceDisconnect,
                 metadata = mapOf("readOnly" to "false")
             )
         )

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCEventHandlingTests.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/core/messagingclient/MCEventHandlingTests.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.core.messagingclient
 
 import assertk.assertThat
+import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
 import com.genesys.cloud.messenger.transport.core.ErrorCode
 import com.genesys.cloud.messenger.transport.core.Message
@@ -8,6 +9,7 @@ import com.genesys.cloud.messenger.transport.core.MessagingClient
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.util.Response
 import com.genesys.cloud.messenger.transport.util.fromConfiguredToError
+import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import io.mockk.verify
 import io.mockk.verifySequence
 import org.junit.Test
@@ -49,10 +51,9 @@ class MCEventHandlingTests : BaseMessagingClientTest() {
 
     @Test
     fun `when StructuredMessage with outbound Unknown event type is received`() {
-        val givenUnknownEvent = """{"eventType": "Fake","bloop": {"bip": "bop"}}"""
         subject.connect()
 
-        slot.captured.onMessage(Response.structuredMessageWithEvents(givenUnknownEvent))
+        slot.captured.onMessage(Response.structuredMessageWithEvents(Response.StructuredEvent.unknown))
 
         verify(exactly = 0) { mockEventHandler.onEvent(any()) }
         verify(exactly = 0) { mockMessageStore.update(any()) }
@@ -65,9 +66,12 @@ class MCEventHandlingTests : BaseMessagingClientTest() {
 
         slot.captured.onMessage(Response.structuredMessageWithEvents(direction = Message.Direction.Inbound))
 
+        verify { mockLogger.i(capture(logSlot)) }
         verify(exactly = 0) { mockEventHandler.onEvent(any()) }
         verify(exactly = 0) { mockMessageStore.update(any()) }
         verify(exactly = 0) { mockAttachmentHandler.onSent(any()) }
+        assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.ignoreInboundEvent(Event.AgentTyping(1000)))
+        assertThat(logSlot[3].invoke()).isEqualTo(LogMessages.ignoreInboundEvent(Event.AgentTyping(5000)))
     }
 
     @Test
@@ -95,6 +99,39 @@ class MCEventHandlingTests : BaseMessagingClientTest() {
         verifySequence {
             connectSequence()
             errorSequence(fromConfiguredToError(expectedErrorState))
+        }
+    }
+
+    @Test
+    fun `when StructuredMessage with inbound event PresenceJoin is received`() {
+        val givenStructuredMessage = Response.structuredMessageWithEvents(
+            direction = Message.Direction.Inbound,
+            events = Response.StructuredEvent.presenceJoin,
+        )
+        subject.connect()
+
+        slot.captured.onMessage(givenStructuredMessage)
+
+        verifySequence {
+            connectSequence()
+            mockCustomAttributesStore.onSent()
+            mockEventHandler.onEvent(Event.ConversationAutostart)
+        }
+    }
+
+    @Test
+    fun `when StructuredMessage with inbound event SignIn is received`() {
+        val givenStructuredMessage = Response.structuredMessageWithEvents(
+            direction = Message.Direction.Inbound,
+            events = Response.StructuredEvent.presenceSignIn,
+        )
+        subject.connect()
+
+        slot.captured.onMessage(givenStructuredMessage)
+
+        verifySequence {
+            connectSequence()
+            mockEventHandler.onEvent(Event.SignedIn())
         }
     }
 }

--- a/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
+++ b/transport/src/androidTest/kotlin/com/genesys/cloud/messenger/transport/util/Response.kt
@@ -18,8 +18,7 @@ internal object Response {
         """{"type":"response","class":"SessionResponse","code":200,"body":{"connected":true,"newSession":false}}"""
     const val webSocketRequestFailed =
         """{"type":"response","class":"string","code":400,"body":"Request failed."}"""
-    const val defaultStructuredEvents =
-        """{"eventType": "Typing","typing": {"type": "Off","duration": 1000}},{"eventType": "Typing","typing": {"type": "On","duration": 5000}}"""
+    const val defaultStructuredEvents = """${StructuredEvent.typingOff},${StructuredEvent.typingOn}"""
     fun onMessage(direction: Message.Direction = Message.Direction.Inbound) =
         """{"type":"message","class":"StructuredMessage","code":200,"body":{"text":"Hello world!","direction":"${direction.name}","id":"test_id","channel":{"time":"2022-08-22T19:24:26.704Z","messageId":"message_id"},"type":"Text","metadata":{"customMessageId":"some_custom_message_id"}}}"""
     fun onMessageWithAttachment(direction: Message.Direction = Message.Direction.Outbound) =
@@ -100,5 +99,14 @@ internal object Response {
         const val emptyInbound = ""","allowedMedia":{"inbound":{}}"""
         const val listOfFileTypesWithMaxSize = ""","allowedMedia":{"inbound":{"fileTypes":[{"type":"video/mpg"},{"type":"video/3gpp"}],"maxFileSizeKB":10240}}"""
         const val listOfFileTypesWithWildcardAndMaxSize = ""","allowedMedia":{"inbound":{"fileTypes":[{"type":"*/*"},{"type":"video/3gpp"}],"maxFileSizeKB":10240}}"""
+    }
+
+    object StructuredEvent {
+        const val presenceJoin = """{"eventType":"Presence","presence":{"type":"Join"}}"""
+        const val presenceDisconnect = """{"eventType":"Presence","presence":{"type":"Disconnect"}}"""
+        const val presenceSignIn = """{"eventType":"Presence","presence":{"type":"SignIn"}}"""
+        const val typingOn = """{"eventType": "Typing","typing": {"type": "On","duration": 5000}}"""
+        const val typingOff = """{"eventType": "Typing","typing": {"type": "Off","duration": 1000}}"""
+        const val unknown = """{"eventType":"Fake","bloop":{"bip":"bop"}}"""
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -511,11 +511,19 @@ internal class MessagingClientImpl(
                 eventHandler.onEvent(it)
             }
         } else {
-            // Autostart is the only Inbound event that should be reported to UI.
-            events.find { it is Event.ConversationAutostart }?.let { autostart ->
-                sendingAutostart = false
-                internalCustomAttributesStore.onSent()
-                eventHandler.onEvent(autostart)
+            events.forEach {
+                when (it) {
+                    is Event.ConversationAutostart -> {
+                        sendingAutostart = false
+                        internalCustomAttributesStore.onSent()
+                        eventHandler.onEvent(it)
+                    }
+                    is Event.SignedIn -> eventHandler.onEvent(it)
+                    else -> {
+                        // Do nothing. Autostart and SignedIn are the only Inbound events that should be reported to UI.
+                        log.i { LogMessages.ignoreInboundEvent(it) }
+                    }
+                }
             }
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -64,4 +64,12 @@ sealed class Event {
      * Sent when conversation was successfully cleared.
      */
     object ConversationCleared : Event()
+
+    /**
+     * Sent when user successfully stepped up from guest to authenticated session.
+     *
+     * @param firstName is an optional first name of the user.
+     * @param lastName is an optional last name of the user.
+     */
+    data class SignedIn(val firstName: String? = null, val lastName: String? = null) : Event()
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/EventHandlerImpl.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.core.events
 
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
+import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessageEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.TypingEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.Unknown
@@ -22,7 +23,7 @@ internal class EventHandlerImpl(
     }
 }
 
-internal fun StructuredMessageEvent.toTransportEvent(): Event? {
+internal fun StructuredMessageEvent.toTransportEvent(from: StructuredMessage.Participant? = null): Event? {
     return when (this) {
         is TypingEvent -> {
             Event.AgentTyping(typing.duration ?: FALLBACK_TYPING_INDICATOR_DURATION)
@@ -32,6 +33,7 @@ internal fun StructuredMessageEvent.toTransportEvent(): Event? {
                 PresenceEvent.Presence.Type.Join -> Event.ConversationAutostart
                 PresenceEvent.Presence.Type.Disconnect -> Event.ConversationDisconnect
                 PresenceEvent.Presence.Type.Clear -> null // Ignore. Event.ConversationClear should be dispatched upon receiving SessionClearedEvent and not StructuredMessageEvent with Type.Clear
+                PresenceEvent.Presence.Type.SignIn -> Event.SignedIn(firstName = from?.firstName, lastName = from?.lastName)
             }
         }
         is Unknown -> null

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/StructuredMessageEvent.kt
@@ -44,6 +44,7 @@ internal data class PresenceEvent(
             Disconnect,
             Join,
             Clear,
+            SignIn,
         }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -33,7 +33,7 @@ internal fun StructuredMessage.toMessage(): Message {
         timeStamp = channel?.time.fromIsoToEpochMilliseconds(),
         attachments = content.filterIsInstance<AttachmentContent>().toAttachments(),
         quickReplies = quickReplies,
-        events = events.mapNotNull { it.toTransportEvent() },
+        events = events.mapNotNull { it.toTransportEvent(channel?.from) },
         from = Message.Participant(
             name = channel?.from?.nickname,
             imageUrl = channel?.from?.image,

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -107,4 +107,5 @@ internal object LogMessages {
     // Quick Replies
     fun quickReplyPrepareToSend(message: Message) = "Message with quick reply prepared to send: $message"
     fun sendQuickReply(buttonResponse: ButtonResponse) = "sendQuickReply(buttonResponse: $buttonResponse)"
+    fun ignoreInboundEvent(event: Event) = "Ignore inbound event: $event."
 }


### PR DESCRIPTION
- Add Event.SignedIn to represent the successful step up.
- Allow eventHandler to dispatch Inbound event SignedIn and ignore + print to log when other kind of inbound event is received.
- Add KDoc
- Add/Update unit tests