### PR TITLE
MTSDK-358 Enable Vault clear.

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
@@ -19,6 +19,8 @@ enum class Command(val description: String) {
     NEW_CHAT("newChat"),
     OKTA_LOGOUT("oktaLogout"),
     OKTA_SIGN_IN_WITH_PKCE("oktaSignInWithPKCE"),
+    REMOVE_TOKEN_FROM_VAULT("removeToken"),
+    REMOVE_AUTH_REFRESH_TOKEN_FROM_VAULT("removeAuthRefreshToken"),
     SEND("send <msg>"),
     SEND_QUICK_REPLY("sendQuickReply <quickReply>"),
     TYPING("typing")

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -153,6 +153,8 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "refreshAttachment" -> doRefreshAttachmentUrl(input)
             "savedFileName" -> doChangeFileName(input)
             "fileAttachmentProfile" -> doFileAttachmentProfile()
+            "removeToken" -> doRemoveTokenFromVault()
+            "removeAuthRefreshToken" -> doRemoveAuthRefreshTokenFromVault()
             else -> {
                 Log.e(TAG, "Invalid command")
                 commandWaiting = false
@@ -353,6 +355,20 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             redirectUri = BuildConfig.SIGN_IN_REDIRECT_URI,
             codeVerifier = if (pkceEnabled) BuildConfig.CODE_VERIFIER else null
         )
+    }
+
+    private fun doRemoveTokenFromVault() {
+        messengerTransport.vault.run {
+            remove(keys.tokenKey)
+            commandWaiting = false
+        }
+    }
+
+    private fun doRemoveAuthRefreshTokenFromVault() {
+        messengerTransport.vault.run {
+            remove(keys.authRefreshTokenKey)
+            commandWaiting = false
+        }
     }
 
     private fun onClientStateChanged(oldState: State, newState: State) {

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -191,4 +191,14 @@ final class MessengerInteractor {
     func addCustomAttributes(customAttributes: [String: String] = [:]) -> Bool {
          return messagingClient.customAttributesStore.add(customAttributes: customAttributes)
     }
+    
+    func removeToken() {
+        let tokenKey = messengerTransport.vault.keys.tokenKey
+        messengerTransport.vault.remove(key: tokenKey)
+    }
+    
+    func removeAuthRefreshToken() {
+        let authRefreshTokenKey = messengerTransport.vault.keys.authRefreshTokenKey
+        messengerTransport.vault.remove(key: authRefreshTokenKey)
+    }
 }

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -53,6 +53,8 @@ class TestbedViewController: UIViewController {
         case typing
         case authorize
         case clearConversation
+        case removeToken
+        case removeAuthRefreshToken
 
         var helpDescription: String {
             switch self {
@@ -476,6 +478,10 @@ extension TestbedViewController : UITextFieldDelegate {
                 messenger.authorize(authCode: self.authCode ?? "", redirectUri: signInRedirectURI, codeVerifier: codeVerifier)
             case (.clearConversation, _):
                 try messenger.clearConversation()
+            case (.removeToken, _):
+                messenger.removeToken()
+            case (.removeAuthRefreshToken, _):
+                messenger.removeAuthRefreshToken()
             default:
                 self.info.text = "Invalid command"
             }

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
@@ -25,6 +25,13 @@ actual class DefaultVault actual constructor(keys: Keys) : Vault(keys) {
         return sharedPreferences.getString(key, null)
     }
 
+    override fun remove(key: String) {
+        with(sharedPreferences.edit()) {
+            remove(key)
+            apply()
+        }
+    }
+
     companion object {
         private var contextRef: WeakReference<Context>? = null
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
@@ -21,11 +21,13 @@ import kotlinx.coroutines.launch
 
 /**
  * The entry point to the services provided by the transport SDK.
+ *
+ * @param vault the storage mechanism for managing session-related data.
  */
 class MessengerTransportSDK(
     private val configuration: Configuration,
     @Deprecated("Use Vault instead.") private val tokenStore: TokenStore?,
-    private val vault: Vault,
+    val vault: Vault,
 ) {
     private var deploymentConfig: DeploymentConfig? = null
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
@@ -10,7 +10,7 @@ import com.genesys.cloud.messenger.transport.auth.NO_REFRESH_TOKEN
  *
  * @param keys The set of keys used to access stored data in the vault.
  */
-abstract class Vault(private val keys: Keys) {
+abstract class Vault(val keys: Keys) {
     /**
      * Retrieves the token value from the vault or generates a new token if it doesn't exist.
      * The token is stored in the vault for future retrieval.
@@ -44,6 +44,11 @@ abstract class Vault(private val keys: Keys) {
      * @return the previous stored value for specified key or null if not in storage.
      */
     abstract fun fetch(key: String): String?
+
+    /**
+     * Removes specified key from storage.
+     */
+    abstract fun remove(key: String)
 
     /**
      * Set of keys Vault will use to access stored data.

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalVault.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalVault.kt
@@ -26,6 +26,7 @@ import platform.Foundation.CFBridgingRetain
 import platform.Foundation.NSData
 import platform.Security.SecItemAdd
 import platform.Security.SecItemCopyMatching
+import platform.Security.SecItemDelete
 import platform.Security.SecItemUpdate
 import platform.Security.kSecAttrAccount
 import platform.Security.kSecAttrService
@@ -53,6 +54,16 @@ internal class InternalVault(private val serviceName: String) {
      * @return The stored string value, or null if it is missing
      */
     fun string(forKey: String): String? = value(forKey)?.string()
+
+    fun remove(key: String) = context(key) { (account) ->
+        val query = query(
+            kSecClass to kSecClassGenericPassword,
+            kSecAttrAccount to account
+        )
+
+        SecItemDelete(query)
+            .validate()
+    }
 
     private fun existsObject(forKey: String): Boolean = context(forKey) { (account) ->
         val query = query(

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
@@ -13,4 +13,8 @@ actual class DefaultVault actual constructor(keys: Keys) : Vault(keys) {
     override fun fetch(key: String): String? {
         return vault.string(key)
     }
+
+    override fun remove(key: String) {
+        vault.remove(key)
+    }
 }


### PR DESCRIPTION
- Expose Vault to allow direct access vie MessengerTransportSDK
- Add new `remove(key: String)` api to Vault. Calling this function will remove provided key from storage.
- Expose Keys object to allow more straightforward work with Vault.
- Add/Update KDoc
- Implement vault clear on Android and iOS Testbed applications.