### PR TITLE
MTSDK-348 Support ConnectionClosed(reason:SignIn)

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/events/EventHandlerTest.kt
@@ -50,7 +50,7 @@ class EventHandlerTest {
             ),
             ConversationAutostart,
             ConversationDisconnect,
-            ConnectionClosed,
+            ConnectionClosed(ConnectionClosed.Reason.UserSignedIn),
             Authorized,
             Logout,
             ConversationCleared,

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCEventHandlingTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCEventHandlingTests.kt
@@ -76,7 +76,7 @@ class MCEventHandlingTests : BaseMessagingClientTest() {
 
     @Test
     fun `when event ConnectionClosed is received`() {
-        val expectedEvent = Event.ConnectionClosed
+        val expectedEvent = Event.ConnectionClosed(Event.ConnectionClosed.Reason.SessionLimitReached)
 
         subject.connect()
         slot.captured.onMessage(Response.connectionClosedEvent)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/events/Event.kt
@@ -45,10 +45,23 @@ sealed class Event {
     object ConversationDisconnect : Event()
 
     /**
-     * Sent when the connection is closed due to exceeding the maximum number of simultaneously open sessions.
+     * Sent when the connection is closed. A more detailed reason is provided in the [reason] parameter.
      * Detailed information about Genesys Cloud Web Messaging capabilities is available in the [Developer Center](https://developer.genesys.cloud).
      */
-    object ConnectionClosed : Event()
+    data class ConnectionClosed(val reason: Reason) : Event() {
+        /**
+         * Reasons for connection closure.
+         *
+         * @property UserSignedIn Indicates the connection was closed because the user signed in to an authenticated session on another device.
+         * @property ConversationCleared Indicates the connection was closed because the user cleared the conversation.
+         * @property SessionLimitReached Indicates the connection was closed due to exceeding the maximum number of simultaneously open sessions.
+         */
+        enum class Reason {
+            UserSignedIn,
+            ConversationCleared,
+            SessionLimitReached,
+        }
+    }
 
     /**
      * Sent when auth code was successfully exchanged for access token.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ConnectionClosedEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ConnectionClosedEvent.kt
@@ -1,6 +1,7 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
 import com.genesys.cloud.messenger.transport.core.events.Event.ConnectionClosed
+import com.genesys.cloud.messenger.transport.util.SIGNED_IN
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -8,7 +9,7 @@ internal class ConnectionClosedEvent(val reason: String? = null)
 
 internal fun String?.toTransportConnectionClosedReason(clearingConversation: Boolean): ConnectionClosed.Reason {
     return when {
-        this == "signedIn" -> ConnectionClosed.Reason.UserSignedIn
+        this == SIGNED_IN -> ConnectionClosed.Reason.UserSignedIn
         clearingConversation -> ConnectionClosed.Reason.ConversationCleared
         else -> ConnectionClosed.Reason.SessionLimitReached
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ConnectionClosedEvent.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/ConnectionClosedEvent.kt
@@ -1,6 +1,15 @@
 package com.genesys.cloud.messenger.transport.shyrka.receive
 
+import com.genesys.cloud.messenger.transport.core.events.Event.ConnectionClosed
 import kotlinx.serialization.Serializable
 
 @Serializable
-internal class ConnectionClosedEvent
+internal class ConnectionClosedEvent(val reason: String? = null)
+
+internal fun String?.toTransportConnectionClosedReason(clearingConversation: Boolean): ConnectionClosed.Reason {
+    return when {
+        this == "signedIn" -> ConnectionClosed.Reason.UserSignedIn
+        clearingConversation -> ConnectionClosed.Reason.ConversationCleared
+        else -> ConnectionClosed.Reason.SessionLimitReached
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
@@ -1,3 +1,4 @@
 package com.genesys.cloud.messenger.transport.util
 
 internal const val WILD_CARD = "*/*"
+internal const val SIGNED_IN = "signedIn"

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -23,6 +23,7 @@ object TestValues {
     internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
     internal const val LogTag = "TestLogTag"
     internal val defaultMap = mapOf("A" to "B")
+    internal val DEFAULT_STRING = "any string"
 }
 
 object AuthTest {


### PR DESCRIPTION
- Add reason to Event.ConnectionClosed and notify user when it happens:
1. When explicitly specified "signedIn" the reason will be UserSignedIn.
2. When ConnectionClosedEvent is received during clearconversation flow -> the reason will be ConversationCleared
3. In all other cases -> SessionLimitReached This is a temporary solution. Once Shyrka provide proper reasons for ConversationCleared and SessionLimitReached we will remove this logic and rely purely on value provided by Shyrka. -