### PR TITLE
MTSDK-336 Handle step up errors

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/Command.kt
@@ -24,5 +24,6 @@ enum class Command(val description: String) {
     SEND("send <msg>"),
     SEND_QUICK_REPLY("sendQuickReply <quickReply>"),
     STEP_UP("stepUp"),
-    TYPING("typing")
+    TYPING("typing"),
+    WAS_AUTHENTICATED("wasAuthenticated"),
 }

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/testbed/TestBedViewModel.kt
@@ -156,11 +156,17 @@ class TestBedViewModel : ViewModel(), CoroutineScope {
             "removeToken" -> doRemoveTokenFromVault()
             "removeAuthRefreshToken" -> doRemoveAuthRefreshTokenFromVault()
             "stepUp" -> doStepUp()
+            "wasAuthenticated" -> doWasAuthenticated()
             else -> {
                 Log.e(TAG, "Invalid command")
                 commandWaiting = false
             }
         }
+    }
+
+    private fun doWasAuthenticated() {
+        onSocketMessageReceived("wasAuthenticated: ${client.wasAuthenticated}")
+        commandWaiting = false
     }
 
     private fun doOktaSignIn(withPKCE: Boolean) {

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -29,7 +29,7 @@ final class MessengerInteractor {
                                            logging: true,
                                            reconnectionTimeoutInSeconds: reconnectTimeout,
                                            autoRefreshTokenWhenExpired: true)
-        self.tokenVault = DefaultVault(keys: Vault.Keys(vaultKey: "com.genesys.cloud.messenger", tokenKey: "token", authRefreshTokenKey: "auth_refresh_token"))
+        self.tokenVault = DefaultVault(keys: Vault.Keys(vaultKey: "com.genesys.cloud.messenger", tokenKey: "token", authRefreshTokenKey: "auth_refresh_token", wasAuthenticated: "wasAuthenticated"))
         self.messengerTransport = MessengerTransportSDK(configuration: self.configuration, vault: self.tokenVault)
         self.messagingClient = self.messengerTransport.createMessagingClient()
         
@@ -208,5 +208,9 @@ final class MessengerInteractor {
         } catch {
             print("stepUp() failed. \(error.localizedDescription)")
         }
+    }
+    
+    func wasAuthenticated() -> Bool {
+        return messagingClient.wasAuthenticated
     }
 }

--- a/iosApp/iosApp/TestbedViewController.swift
+++ b/iosApp/iosApp/TestbedViewController.swift
@@ -56,6 +56,7 @@ class TestbedViewController: UIViewController {
         case removeToken
         case removeAuthRefreshToken
         case stepUp
+        case wasAuthenticated
 
         var helpDescription: String {
             switch self {
@@ -226,7 +227,9 @@ class TestbedViewController: UIViewController {
         default:
             break
         }
-        info.text = displayMessage
+        DispatchQueue.main.async {
+            self.info.text = displayMessage
+        }
     }
     
     private func updateWithEvent(_ event: Event) {
@@ -493,6 +496,8 @@ extension TestbedViewController : UITextFieldDelegate {
                 messenger.removeAuthRefreshToken()
             case (.stepUp, _):
                 try messenger.stepUp()
+            case (.wasAuthenticated, _):
+                self.info.text = "wasAuthenticated: \(messenger.wasAuthenticated())"
             default:
                 self.info.text = "Invalid command"
             }

--- a/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
@@ -15,14 +15,11 @@ import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.core.events.EventHandler
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
-import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.VAULT_KEY
-import com.genesys.cloud.messenger.transport.util.Vault
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import com.genesys.cloud.messenger.transport.utility.AuthTest
 import com.genesys.cloud.messenger.transport.utility.ErrorTest
+import com.genesys.cloud.messenger.transport.utility.TestValues
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,7 +32,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import org.junit.After
 import org.junit.Before
@@ -79,13 +75,7 @@ class AuthHandlerTest {
         )
     }
 
-    private val fakeVault: FakeVault = FakeVault(
-        Vault.Keys(
-            vaultKey = VAULT_KEY,
-            tokenKey = TOKEN_KEY,
-            authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
-        )
-    )
+    private val fakeVault: FakeVault = FakeVault(TestValues.vaultKeys)
     private val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
 
     private var subject = buildAuthHandler()

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -58,7 +58,6 @@ internal class AttachmentHandlerImplTest {
 
     private val subject = AttachmentHandlerImpl(
         mockApi,
-        TestValues.Token,
         mockLogger,
         mockAttachmentListener,
         processedAttachments,
@@ -97,7 +96,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(AttachmentValues.Id, ByteArray(AttachmentValues.FileSize), AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, ByteArray(AttachmentValues.FileSize), AttachmentValues.FileName)
 
         verify {
             mockLogger.i(capture(logSlot))
@@ -253,7 +252,7 @@ internal class AttachmentHandlerImplTest {
         givenPrepareCalled()
         givenUploadSuccessCalled()
 
-        val result = subject.detach(AttachmentValues.Id)
+        val result = subject.detach(TestValues.Token, AttachmentValues.Id)
 
         verify {
             mockLogger.i(capture(logSlot))
@@ -272,7 +271,7 @@ internal class AttachmentHandlerImplTest {
 
         givenPrepareCalled()
 
-        val result = subject.detach(AttachmentValues.Id)
+        val result = subject.detach(TestValues.Token, AttachmentValues.Id)
 
         verify {
             mockLogger.i(capture(logSlot))
@@ -286,7 +285,7 @@ internal class AttachmentHandlerImplTest {
 
     @Test
     fun `when detach() on not processed attachment`() {
-        val result = subject.detach("not processed attachment id")
+        val result = subject.detach(TestValues.Token, "not processed attachment id")
 
         verify {
             listOf(mockAttachmentListener) wasNot Called
@@ -532,7 +531,7 @@ internal class AttachmentHandlerImplTest {
         val givenByteArray = ByteArray(2000)
 
         val onAttachmentRequest =
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
 
         assertThat(subject.fileAttachmentProfile).isNull()
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -545,7 +544,7 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 1)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
         }
     }
 
@@ -565,7 +564,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
 
         assertThat(subject.fileAttachmentProfile?.maxFileSizeKB).isEqualTo(expectedFileSizeInKB)
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -578,7 +577,7 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 2)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
         }
     }
 
@@ -598,7 +597,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
 
         assertThat(subject.fileAttachmentProfile?.maxFileSizeKB).isEqualTo(expectedFileSizeInKB)
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -616,7 +615,7 @@ internal class AttachmentHandlerImplTest {
             )
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(AttachmentValues.Id, givenByteArray, "foo.exe")
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, "foo.exe")
         }
     }
 
@@ -640,7 +639,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
 
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
     }
@@ -652,7 +651,7 @@ internal class AttachmentHandlerImplTest {
         val expectedExceptionMessage = ErrorMessage.FileAttachmentIsDisabled
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
         }
     }
 
@@ -707,6 +706,7 @@ internal class AttachmentHandlerImplTest {
         uploadProgress: ((Float) -> Unit)? = null,
     ) {
         subject.prepare(
+            token = TestValues.Token,
             attachmentId = attachmentId,
             byteArray = byteArray,
             fileName = fileName,

--- a/transport/src/androidUnitTest/kotlin/transport/core/JwtHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/JwtHandlerTest.kt
@@ -25,7 +25,7 @@ class JwtHandlerTest {
     private val mockWebSocket: PlatformSocket = mockk(relaxed = true)
     val mockJwtFn: (String) -> Any = mockk(relaxed = true)
 
-    private val subject = JwtHandler(mockWebSocket, Request.token)
+    private val subject = JwtHandler(mockWebSocket)
 
     @ExperimentalCoroutinesApi
     private val threadSurrogate = newSingleThreadContext("main thread")
@@ -52,7 +52,7 @@ class JwtHandlerTest {
         val givenJwtResponse = JwtResponse(AuthTest.JwtToken, givenExpiry)
         subject.jwtResponse = givenJwtResponse
 
-        subject.withJwt(mockJwtFn)
+        subject.withJwt(Request.token, mockJwtFn)
 
         coVerify { mockJwtFn(AuthTest.JwtToken) }
         coVerify(exactly = 0) { mockWebSocket.sendMessage(Request.jwt) }
@@ -69,7 +69,7 @@ class JwtHandlerTest {
         val givenJwtResponse = JwtResponse(AuthTest.JwtToken, 0)
         subject.jwtResponse = givenJwtResponse
 
-        subject.withJwt(mockJwtFn)
+        subject.withJwt(Request.token, mockJwtFn)
 
         coVerify {
             mockJwtFn(AuthTest.JwtToken)

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -30,6 +30,7 @@ import com.genesys.cloud.messenger.transport.util.DefaultVault
 import com.genesys.cloud.messenger.transport.util.Platform
 import com.genesys.cloud.messenger.transport.util.Request
 import com.genesys.cloud.messenger.transport.util.Response
+import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
 import com.genesys.cloud.messenger.transport.util.fromConnectedToConfigured
 import com.genesys.cloud.messenger.transport.util.fromConnectedToReadOnly
 import com.genesys.cloud.messenger.transport.util.fromConnectingToConnected
@@ -44,6 +45,7 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.invoke
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
@@ -51,15 +53,16 @@ import kotlin.reflect.KProperty0
 import kotlin.test.AfterTest
 
 open class BaseMessagingClientTest {
+    private var testToken = Request.token
     internal val slot = slot<PlatformSocketListener>()
     protected val mockStateChangedListener: (StateChange) -> Unit = spyk()
     internal val mockMessageStore: MessageStore = mockk(relaxed = true) {
-        every { prepareMessage(any(), any()) } returns OnMessageRequest(
-            token = Request.token,
+        every { prepareMessage(any(), any(), any()) } returns OnMessageRequest(
+            token = testToken,
             message = TextMessage("Hello world!")
         )
-        every { prepareMessageWith(any(), null) } returns OnMessageRequest(
-            token = Request.token,
+        every { prepareMessageWith(any(), any(), null) } returns OnMessageRequest(
+            token = testToken,
             message = TextMessage(
                 text = "",
                 content = listOf(
@@ -77,6 +80,7 @@ open class BaseMessagingClientTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         } returns OnAttachmentRequest(
@@ -87,7 +91,7 @@ open class BaseMessagingClientTest {
             errorsAsJson = true,
         )
 
-        every { detach(any()) } returns DeleteAttachmentRequest(
+        every { detach(any(), any()) } returns DeleteAttachmentRequest(
             token = Request.token,
             attachmentId = "88888888-8888-8888-8888-888888888888"
         )
@@ -154,9 +158,12 @@ open class BaseMessagingClientTest {
         every { add(eq(emptyMap())) } returns true.also { dummyCustomAttributes.clear() }
     }
 
-    private val mockVault: DefaultVault = mockk {
-        every { fetch("token") } returns Request.token
-        every { token } returns Request.token
+    internal val mockVault: DefaultVault = mockk {
+        every { fetch(TOKEN_KEY) } returns testToken
+        every { token } returns testToken
+        every { remove(TOKEN_KEY) } answers { testToken = TestValues.SecondaryToken }
+        every { keys } returns TestValues.vaultKeys
+        justRun { wasAuthenticated = any() }
     }
     internal val mockJwtHandler: JwtHandler = mockk(relaxed = true)
 
@@ -168,7 +175,7 @@ open class BaseMessagingClientTest {
         configuration = Configuration("deploymentId", "inindca.com"),
         webSocket = mockPlatformSocket,
         api = mockWebMessagingApi,
-        token = Request.token,
+        token = testToken,
         jwtHandler = mockJwtHandler,
         vault = mockVault,
         attachmentHandler = mockAttachmentHandler,
@@ -187,13 +194,17 @@ open class BaseMessagingClientTest {
     @AfterTest
     fun after() = clearAllMocks()
 
-    protected fun MockKVerificationScope.connectSequence(shouldConfigureAuth: Boolean = false) {
+    protected fun MockKVerificationScope.fromIdleToConnectedSequence() {
         mockLogger.withTag(LogTag.STATE_MACHINE)
         mockLogger.withTag(LogTag.WEBSOCKET)
         mockLogger.i(capture(logSlot))
         mockStateChangedListener(fromIdleToConnecting)
         mockPlatformSocket.openSocket(any())
         mockStateChangedListener(fromConnectingToConnected)
+    }
+
+    protected fun MockKVerificationScope.connectSequence(shouldConfigureAuth: Boolean = false) {
+        fromIdleToConnectedSequence()
         configureSequence(shouldConfigureAuth)
         mockStateChangedListener(fromConnectedToConfigured)
     }
@@ -207,6 +218,7 @@ open class BaseMessagingClientTest {
             mockAuthHandler.jwt // use jwt for request
         }
         mockPlatformSocket.sendMessage(configureRequest)
+        mockVault.wasAuthenticated = shouldConfigureAuth
         mockAttachmentHandler.fileAttachmentProfile = any()
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()
@@ -214,12 +226,7 @@ open class BaseMessagingClientTest {
     }
 
     protected fun MockKVerificationScope.connectToReadOnlySequence() {
-        mockLogger.withTag(LogTag.STATE_MACHINE)
-        mockLogger.withTag(LogTag.WEBSOCKET)
-        mockLogger.i(capture(logSlot))
-        mockStateChangedListener(fromIdleToConnecting)
-        mockPlatformSocket.openSocket(any())
-        mockStateChangedListener(fromConnectingToConnected)
+        fromIdleToConnectedSequence()
         mockLogger.i(capture(logSlot))
         mockPlatformSocket.sendMessage(Request.configureRequest())
         mockAttachmentHandler.fileAttachmentProfile = any()
@@ -264,6 +271,12 @@ open class BaseMessagingClientTest {
         mockAttachmentHandler.clearAll()
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()
+    }
+    protected fun MockKVerificationScope.invalidateSessionTokenSequence() {
+        mockLogger.i(capture(logSlot))
+        mockVault.keys
+        mockVault.remove(TOKEN_KEY)
+        mockVault.token
     }
 
     protected fun verifyCleanUp() {

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
@@ -50,7 +50,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
         verifySequence {
             connectSequence()
             mockLogger.i(capture(logSlot))
-            mockAttachmentHandler.prepare(any(), any(), any())
+            mockAttachmentHandler.prepare(Request.token, any(), any(), any())
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(expectedMessage)
         }
@@ -72,7 +72,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
 
         verify {
             mockLogger.i(capture(logSlot))
-            mockAttachmentHandler.detach(capture(attachmentIdSlot))
+            mockAttachmentHandler.detach(Request.token, capture(attachmentIdSlot))
             mockPlatformSocket.sendMessage(expectedMessage)
         }
         assertThat(attachmentIdSlot.captured).isEqualTo(expectedAttachmentId)
@@ -85,12 +85,12 @@ class MCAttachmentTests : BaseMessagingClientTest() {
     fun `when detach() non existing attachmentId`() {
         subject.connect()
         clearMocks(mockPlatformSocket)
-        every { mockAttachmentHandler.detach(any()) } returns null
+        every { mockAttachmentHandler.detach(any(), any()) } returns null
 
         subject.detach("88888888-8888-8888-8888-888888888888")
 
         verify {
-            mockAttachmentHandler.detach("88888888-8888-8888-8888-888888888888")
+            mockAttachmentHandler.detach(Request.token, "88888888-8888-8888-8888-888888888888")
             mockPlatformSocket wasNot Called
         }
     }
@@ -318,6 +318,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
         val givenByteArray = ByteArray(1)
         every {
             mockAttachmentHandler.prepare(
+                any(),
                 any(),
                 any(),
                 any()

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConversationDisconnectTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConversationDisconnectTests.kt
@@ -291,6 +291,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
         assertThat(subject.currentState).isReadOnly()
         verifySequence {
             connectSequence()
+            mockVault.wasAuthenticated = false
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCustomAttributesTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCustomAttributesTests.kt
@@ -40,7 +40,7 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
         val expectedText = "Hello world"
         val expectedCustomAttributes = mapOf("A" to "B")
         val expectedChannel = Channel(Channel.Metadata(expectedCustomAttributes))
-        every { mockMessageStore.prepareMessage(any(), any()) } returns OnMessageRequest(
+        every { mockMessageStore.prepareMessage(any(), any(), any()) } returns OnMessageRequest(
             token = Request.token,
             message = TextMessage(
                 text = "Hello world",
@@ -58,7 +58,7 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
             mockCustomAttributesStore.add(expectedCustomAttributes)
             mockCustomAttributesStore.getCustomAttributesToSend()
             mockCustomAttributesStore.onSending()
-            mockMessageStore.prepareMessage(expectedText, expectedChannel)
+            mockMessageStore.prepareMessage(Request.token, expectedText, expectedChannel)
             mockAttachmentHandler.onSending()
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(expectedMessage)
@@ -162,7 +162,7 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
         val expectedButtonResponse = QuickReplyTestValues.buttonResponse_a
         val expectedCustomAttributes = mapOf("A" to "B")
         val expectedChannel = Channel(Channel.Metadata(expectedCustomAttributes))
-        every { mockMessageStore.prepareMessageWith(any(), expectedChannel) } returns OnMessageRequest(
+        every { mockMessageStore.prepareMessageWith(Request.token, any(), expectedChannel) } returns OnMessageRequest(
             token = Request.token,
             message = TextMessage(
                 text = "",
@@ -185,7 +185,7 @@ class MCCustomAttributesTests : BaseMessagingClientTest() {
             mockLogger.i(capture(logSlot))
             mockCustomAttributesStore.getCustomAttributesToSend()
             mockCustomAttributesStore.onSending()
-            mockMessageStore.prepareMessageWith(expectedButtonResponse, expectedChannel)
+            mockMessageStore.prepareMessageWith(Request.token, expectedButtonResponse, expectedChannel)
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(Request.quickReplyWith(channel = """"channel":{"metadata":{"customAttributes":{"A":"B"}}},"""))
         }

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCEventHandlingTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCEventHandlingTests.kt
@@ -75,16 +75,32 @@ class MCEventHandlingTests : BaseMessagingClientTest() {
     }
 
     @Test
-    fun `when event ConnectionClosed is received`() {
+    fun `when event ConnectionClosed with no reason is received`() {
         val expectedEvent = Event.ConnectionClosed(Event.ConnectionClosed.Reason.SessionLimitReached)
 
         subject.connect()
-        slot.captured.onMessage(Response.connectionClosedEvent)
+        slot.captured.onMessage(Response.connectionClosedEventNoReason)
 
         verifySequence {
             connectSequence()
-            disconnectSequence()
             mockEventHandler.onEvent(eq(expectedEvent))
+            disconnectSequence()
+        }
+    }
+
+    @Test
+    fun `when event ConnectionClosed with reason=signedIn is received`() {
+        val expectedEvent = Event.ConnectionClosed(Event.ConnectionClosed.Reason.UserSignedIn)
+
+        subject.connect()
+        slot.captured.onMessage(Response.connectionClosedEventReasonSignIn)
+
+        verifySequence {
+            connectSequence()
+            invalidateSessionTokenSequence()
+            mockVault.wasAuthenticated = false
+            mockEventHandler.onEvent(eq(expectedEvent))
+            disconnectSequence()
         }
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCHealthCheckTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCHealthCheckTests.kt
@@ -94,6 +94,7 @@ class MCHealthCheckTests : BaseMessagingClientTest() {
             mockStateChangedListener(fromConnectingToConnected)
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(Request.configureRequest())
+            mockVault.wasAuthenticated = false
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCMessageTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCMessageTests.kt
@@ -74,7 +74,7 @@ class MCMessageTests : BaseMessagingClientTest() {
             mockLogger.i(capture(logSlot))
             mockCustomAttributesStore.add(emptyMap())
             mockCustomAttributesStore.getCustomAttributesToSend()
-            mockMessageStore.prepareMessage(MessageValues.Text)
+            mockMessageStore.prepareMessage(Request.token, MessageValues.Text)
             mockAttachmentHandler.onSending()
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(expectedMessageRequest)

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCQuickReplyTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCQuickReplyTests.kt
@@ -66,7 +66,7 @@ class MCQuickReplyTests : BaseMessagingClientTest() {
             connectSequence()
             mockLogger.i(capture(logSlot))
             mockCustomAttributesStore.getCustomAttributesToSend()
-            mockMessageStore.prepareMessageWith(expectedButtonResponse, null)
+            mockMessageStore.prepareMessageWith(Request.token, expectedButtonResponse, null)
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(Request.quickReplyWith())
         }

--- a/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
@@ -45,13 +45,15 @@ class AndroidPlatformTest {
         val result = Vault.Keys(
             vaultKey = TestValues.VaultKey,
             tokenKey = TestValues.TokenKey,
-            authRefreshTokenKey = TestValues.AuthRefreshTokenKey
+            authRefreshTokenKey = TestValues.AuthRefreshTokenKey,
+            wasAuthenticated = TestValues.WasAuthenticated,
         )
 
         result.run {
             assertThat(vaultKey).isEqualTo(TestValues.VaultKey)
             assertThat(tokenKey).isEqualTo(TestValues.TokenKey)
             assertThat(authRefreshTokenKey).isEqualTo(TestValues.AuthRefreshTokenKey)
+            assertThat(wasAuthenticated).isEqualTo(TestValues.WasAuthenticated)
         }
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/util/Response.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/Response.kt
@@ -2,6 +2,7 @@ package com.genesys.cloud.messenger.transport.util
 
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.utility.AttachmentValues
+import com.genesys.cloud.messenger.transport.utility.ErrorTest
 import com.genesys.cloud.messenger.transport.utility.TestValues
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -37,6 +38,8 @@ internal object Response {
         """{"type": "response","class": "string","code": 4007,"body": "session not found error message"}"""
     const val sessionExpired =
         """{"type": "response","class": "string","code": 4006,"body": "session expired error message"}"""
+    const val cannotDowngradeToUnauthenticated =
+        """{"type": "response","class": "string","code": 4017,"body": "${ErrorTest.Message}"}"""
     const val sessionExpiredEvent =
         """{"type": "response","class": "SessionExpiredEvent","code": 200,"body": {}}"""
     const val messageTooLong =
@@ -45,8 +48,10 @@ internal object Response {
         """{"type":"response","class":"TooManyRequestsErrorMessage","code":429,"body":{"retryAfter":3,"errorCode":4029,"errorMessage":"Message rate too high for this session"}}"""
     const val customAttributeSizeTooLarge =
         """{"type":"response","class":"string","code":4013,"body":"Custom Attributes in channel metadata is larger than 2048 bytes"}"""
-    const val connectionClosedEvent =
+    const val connectionClosedEventNoReason =
         """{"type":"message","class":"ConnectionClosedEvent","code":200,"body":{}}"""
+    const val connectionClosedEventReasonSignIn =
+        """{"type":"message","class":"ConnectionClosedEvent","code":200,"body":{"reason":"$SIGNED_IN"}}"""
     const val logoutEvent =
         """{"type":"message","class":"LogoutEvent","code":200,"body":{}}"""
     const val unauthorized =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -10,6 +10,7 @@ internal interface AttachmentHandler {
 
     @Throws(IllegalArgumentException::class)
     fun prepare(
+        token: String,
         attachmentId: String,
         byteArray: ByteArray,
         fileName: String,
@@ -18,7 +19,7 @@ internal interface AttachmentHandler {
 
     fun upload(presignedUrlResponse: PresignedUrlResponse)
 
-    fun detach(attachmentId: String): DeleteAttachmentRequest?
+    fun detach(token: String, attachmentId: String): DeleteAttachmentRequest?
 
     fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.launch
 
 internal class AttachmentHandlerImpl(
     private val api: WebMessagingApi,
-    private val token: String,
     private val log: Log,
     private val updateAttachmentStateWith: (Attachment) -> Unit,
     private val processedAttachments: MutableMap<String, ProcessedAttachment> = mutableMapOf(),
@@ -35,6 +34,7 @@ internal class AttachmentHandlerImpl(
 
     @Throws(IllegalArgumentException::class)
     override fun prepare(
+        token: String,
         attachmentId: String,
         byteArray: ByteArray,
         fileName: String,
@@ -84,7 +84,7 @@ internal class AttachmentHandlerImpl(
         }
     }
 
-    override fun detach(attachmentId: String): DeleteAttachmentRequest? {
+    override fun detach(token: String, attachmentId: String): DeleteAttachmentRequest? {
         processedAttachments[attachmentId]?.let {
             log.i { LogMessages.detachingAttachment(attachmentId) }
             it.job?.cancel()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -19,6 +19,7 @@ sealed class ErrorCode(val code: Int) {
     data object AttachmentNotSuccessfullyUploaded : ErrorCode(4010)
     data object MessageTooLong : ErrorCode(4011)
     data object CustomAttributeSizeTooLarge : ErrorCode(4013)
+    data object CannotDowngradeToUnauthenticated : ErrorCode(4017)
     data object MissingParameter : ErrorCode(4020)
     data object RequestRateTooHigh : ErrorCode(4029)
     data object UnexpectedError : ErrorCode(5000)
@@ -53,6 +54,7 @@ sealed class ErrorCode(val code: Int) {
                 4010 -> AttachmentNotSuccessfullyUploaded
                 4011 -> MessageTooLong
                 4013 -> CustomAttributeSizeTooLarge
+                4017 -> CannotDowngradeToUnauthenticated
                 4020 -> MissingParameter
                 4029 -> RequestRateTooHigh
                 6000 -> CancellationError

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -10,10 +10,7 @@ import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 
 internal const val DEFAULT_PAGE_SIZE = 25
 
-internal class MessageStore(
-    private val token: String,
-    private val log: Log,
-) {
+internal class MessageStore(private val log: Log) {
     var nextPage: Int = 1
         private set
     var startOfConversation = false
@@ -24,7 +21,7 @@ internal class MessageStore(
     val updateAttachmentStateWith = { attachment: Attachment -> update(attachment) }
     var messageListener: ((MessageEvent) -> Unit)? = null
 
-    fun prepareMessage(text: String, channel: Channel? = null): OnMessageRequest {
+    fun prepareMessage(token: String, text: String, channel: Channel? = null): OnMessageRequest {
         val messageToSend = pendingMessage.copy(text = text, state = Message.State.Sending).also {
             log.i { LogMessages.messagePreparedToSend(it) }
             activeConversation.add(it)
@@ -43,6 +40,7 @@ internal class MessageStore(
     }
 
     fun prepareMessageWith(
+        token: String,
         buttonResponse: ButtonResponse,
         channel: Channel? = null,
     ): OnMessageRequest {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -125,6 +125,11 @@ interface MessagingClient {
     val fileAttachmentProfile: FileAttachmentProfile?
 
     /**
+     * This property helps to indicate if previously connected session was guest or authenticated.
+     */
+    val wasAuthenticated: Boolean
+
+    /**
      * Open and Configure a secure WebSocket connection to the Web Messaging service with the url and
      * deploymentId configured on this MessagingClient instance.
      *

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
@@ -79,10 +79,9 @@ class MessengerTransportSDK(
         )
         // Support old TokenStore. If TokenStore not present fallback to the Vault.
         val token = tokenStore?.token ?: vault.token
-        val messageStore = MessageStore(token, log.withTag(LogTag.MESSAGE_STORE))
+        val messageStore = MessageStore(log.withTag(LogTag.MESSAGE_STORE))
         val attachmentHandler = AttachmentHandlerImpl(
             api,
-            token,
             log.withTag(LogTag.ATTACHMENT_HANDLER),
             messageStore.updateAttachmentStateWith,
         )
@@ -94,7 +93,7 @@ class MessengerTransportSDK(
             token = token,
             vault = vault,
             configuration = configuration,
-            jwtHandler = JwtHandler(webSocket, token),
+            jwtHandler = JwtHandler(webSocket),
             attachmentHandler = attachmentHandler,
             messageStore = messageStore,
             reconnectionHandler = ReconnectionHandlerImpl(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
@@ -3,6 +3,7 @@ package com.genesys.cloud.messenger.transport.util
 internal const val VAULT_KEY = "com.genesys.cloud.messenger"
 internal const val TOKEN_KEY = "token"
 internal const val AUTH_REFRESH_TOKEN_KEY = "auth_refresh_token"
+internal const val WAS_AUTHENTICATED = "was_authenticated"
 
 /**
  * A default implementation of the [Vault] that should be sufficient for most users of the
@@ -13,5 +14,6 @@ expect class DefaultVault(
         vaultKey = VAULT_KEY,
         tokenKey = TOKEN_KEY,
         authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
+        wasAuthenticated = WAS_AUTHENTICATED,
     ),
 ) : Vault

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
@@ -31,6 +31,16 @@ abstract class Vault(val keys: Keys) {
         }
 
     /**
+     * Retrieves the wasAuthenticated value from the vault or false if it doesn't exist.
+     * The wasAuthenticated can also be set to a new value, which will then be stored in the vault.
+     */
+    internal var wasAuthenticated: Boolean
+        get() = fetch(keys.wasAuthenticated).toBoolean()
+        set(value) {
+            store(keys.wasAuthenticated, value.toString())
+        }
+
+    /**
      * Stores the value with given key into the storage for later fetching.
      *
      * @param key the key to use for storage.
@@ -56,10 +66,12 @@ abstract class Vault(val keys: Keys) {
      * @param vaultKey the key used to access the Vault itself.
      * @param tokenKey the key used to fetch the token value from the Vault.
      * @param authRefreshTokenKey the key used to fetch the auth refresh token value from the Vault.
+     * @param wasAuthenticated the key used to fetch the wasAuthenticated boolean value from the Vault.
      */
     data class Keys(
         val vaultKey: String,
         val tokenKey: String,
         val authRefreshTokenKey: String,
+        val wasAuthenticated: String,
     )
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -82,6 +82,7 @@ internal object LogMessages {
     const val SEND_AUTO_START = "sendAutoStart()"
     const val FORCE_CLOSE_WEB_SOCKET = "Force close web socket."
     const val ON_OPEN = "onOpen"
+    const val INVALIDATE_SESSION_TOKEN = "invalidate session token"
     fun failedFetchDeploymentConfig(error: Throwable) = "Failed to fetch deployment config: $error"
     fun healthCheckCoolDown(milliseconds: Long) =
         "Health check can be sent only once every $milliseconds milliseconds."

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -6,6 +6,11 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.ButtonResponseContent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.QuickReplyContent
+import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
+import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
+import com.genesys.cloud.messenger.transport.util.VAULT_KEY
+import com.genesys.cloud.messenger.transport.util.Vault
+import com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED
 
 internal const val DEFAULT_TIMEOUT = 10000L
 
@@ -16,14 +21,22 @@ object TestValues {
     internal const val DefaultNumber = 1
     internal const val Timestamp = "2022-08-22T19:24:26.704Z"
     internal const val Token = "<token>"
+    internal const val SecondaryToken = "<secondary_token>"
     internal const val ReconnectionTimeout = 5000L
     internal const val NoReconnectionAttempts = 0L
     internal const val VaultKey = "vault_key"
     internal const val TokenKey = "token_key"
     internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
+    internal const val WasAuthenticated = "was_authenticated"
     internal const val LogTag = "TestLogTag"
     internal val defaultMap = mapOf("A" to "B")
-    internal val DEFAULT_STRING = "any string"
+    internal const val DEFAULT_STRING = "any string"
+    internal val vaultKeys = Vault.Keys(
+        vaultKey = VAULT_KEY,
+        tokenKey = TOKEN_KEY,
+        authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
+        wasAuthenticated = WAS_AUTHENTICATED,
+    )
 }
 
 object AuthTest {


### PR DESCRIPTION
- Token has to be reset upon Logout, 4017(CannotDowngradeToUnauthenticated) to allow user connect as guest.
- Add wasAuthenticated api to help ui identify if previously connected session was authenticated.
- Add wasAuthenticated to Vault.Keys
- Add/Update unit tests.
- Add wasAuthenticated to testbed applications