### PR TITLE
Feature/mtsdk 526 support push config storage in vault

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
@@ -3,7 +3,6 @@ package com.genesys.cloud.messenger.transport.util
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNotEmpty
-import com.genesys.cloud.messenger.transport.utility.TestValues
 import org.junit.Test
 import kotlin.test.assertTrue
 
@@ -43,17 +42,19 @@ class AndroidPlatformTest {
     @Test
     fun `test Vault Keys`() {
         val result = Vault.Keys(
-            vaultKey = TestValues.VaultKey,
-            tokenKey = TestValues.TokenKey,
-            authRefreshTokenKey = TestValues.AuthRefreshTokenKey,
-            wasAuthenticated = TestValues.WasAuthenticated,
+            vaultKey = VAULT_KEY,
+            tokenKey = TOKEN_KEY,
+            authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
+            wasAuthenticated = WAS_AUTHENTICATED,
+            pushConfigKey = PUSH_CONFIG_KEY
         )
 
         result.run {
-            assertThat(vaultKey).isEqualTo(TestValues.VaultKey)
-            assertThat(tokenKey).isEqualTo(TestValues.TokenKey)
-            assertThat(authRefreshTokenKey).isEqualTo(TestValues.AuthRefreshTokenKey)
-            assertThat(wasAuthenticated).isEqualTo(TestValues.WasAuthenticated)
+            assertThat(vaultKey).isEqualTo(VAULT_KEY)
+            assertThat(tokenKey).isEqualTo(TOKEN_KEY)
+            assertThat(authRefreshTokenKey).isEqualTo(AUTH_REFRESH_TOKEN_KEY)
+            assertThat(wasAuthenticated).isEqualTo(WAS_AUTHENTICATED)
+            assertThat(pushConfigKey).isEqualTo(PUSH_CONFIG_KEY)
         }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushConfig.kt
@@ -1,10 +1,24 @@
 package com.genesys.cloud.messenger.transport.push
 
+import com.genesys.cloud.messenger.transport.util.UNKNOWN
+import com.genesys.cloud.messenger.transport.util.UNKNOWN_LONG
+import kotlinx.serialization.Serializable
+
+@Serializable
 internal data class PushConfig(
     val token: String,
     val deviceToken: String,
     val preferredLanguage: String,
     val lastSyncTimestamp: Long,
     val deviceType: String,
-    val pushProvider: PushProvider,
+    val pushProvider: PushProvider?,
+)
+
+internal val DEFAULT_PUSH_CONFIG = PushConfig(
+    token = UNKNOWN,
+    deviceToken = UNKNOWN,
+    preferredLanguage = UNKNOWN,
+    lastSyncTimestamp = UNKNOWN_LONG,
+    deviceType = UNKNOWN,
+    pushProvider = null,
 )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Const.kt
@@ -2,3 +2,5 @@ package com.genesys.cloud.messenger.transport.util
 
 internal const val WILD_CARD = "*/*"
 internal const val SIGNED_IN = "signedIn"
+internal const val UNKNOWN = "unknown"
+internal const val UNKNOWN_LONG = -1L

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/DefaultVault.kt
@@ -4,6 +4,7 @@ internal const val VAULT_KEY = "com.genesys.cloud.messenger"
 internal const val TOKEN_KEY = "token"
 internal const val AUTH_REFRESH_TOKEN_KEY = "auth_refresh_token"
 internal const val WAS_AUTHENTICATED = "was_authenticated"
+internal const val PUSH_CONFIG_KEY = "push_config"
 
 /**
  * A default implementation of the [Vault] that should be sufficient for most users of the
@@ -15,5 +16,6 @@ expect class DefaultVault(
         tokenKey = TOKEN_KEY,
         authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
         wasAuthenticated = WAS_AUTHENTICATED,
+        pushConfigKey = PUSH_CONFIG_KEY,
     ),
 ) : Vault

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Vault.kt
@@ -1,6 +1,10 @@
 package com.genesys.cloud.messenger.transport.util
 
 import com.genesys.cloud.messenger.transport.auth.NO_REFRESH_TOKEN
+import com.genesys.cloud.messenger.transport.push.DEFAULT_PUSH_CONFIG
+import com.genesys.cloud.messenger.transport.push.PushConfig
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
+import kotlinx.serialization.encodeToString
 
 /**
  * Abstract class representing a vault that stores and retrieves sensitive data using a provided set of keys.
@@ -41,6 +45,18 @@ abstract class Vault(val keys: Keys) {
         }
 
     /**
+     * Retrieves the PushConfig from the vault or returns [DEFAULT_PUSH_CONFIG] if it doesn't exist.
+     * The PushConfig can also be set to a new value, which will then be stored in the vault.
+     */
+    internal var pushConfig: PushConfig
+        get() = fetch(keys.pushConfigKey)?.let {
+            WebMessagingJson.json.decodeFromString<PushConfig>(it)
+        } ?: DEFAULT_PUSH_CONFIG
+        set(value) {
+            store(keys.pushConfigKey, WebMessagingJson.json.encodeToString(value))
+        }
+
+    /**
      * Stores the value with given key into the storage for later fetching.
      *
      * @param key the key to use for storage.
@@ -67,11 +83,13 @@ abstract class Vault(val keys: Keys) {
      * @param tokenKey the key used to fetch the token value from the Vault.
      * @param authRefreshTokenKey the key used to fetch the auth refresh token value from the Vault.
      * @param wasAuthenticated the key used to fetch the wasAuthenticated boolean value from the Vault.
+     * @param pushConfigKey the key used to fetch the [PushConfig] object from the Vault.
      */
     data class Keys(
         val vaultKey: String,
         val tokenKey: String,
         val authRefreshTokenKey: String,
         val wasAuthenticated: String,
+        val pushConfigKey: String,
     )
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/push/PushConfigTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/push/PushConfigTest.kt
@@ -1,0 +1,44 @@
+package com.genesys.cloud.messenger.transport.push
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
+import com.genesys.cloud.messenger.transport.util.UNKNOWN
+import com.genesys.cloud.messenger.transport.util.UNKNOWN_LONG
+import com.genesys.cloud.messenger.transport.utility.PushTestValues
+import kotlinx.serialization.encodeToString
+import kotlin.test.Test
+
+class PushConfigTest {
+
+    @Test
+    fun `test PushConfig serialization`() {
+        val expectedPushConfigString = """{"token":"<token>","deviceToken":"<device_token>","preferredLanguage":"Eng","lastSyncTimestamp":1,"deviceType":"Android","pushProvider":"APNS"}"""
+
+        val encodedString = WebMessagingJson.json.encodeToString(PushTestValues.CONFIG)
+
+        assertThat(encodedString).isEqualTo(expectedPushConfigString)
+    }
+
+    @Test
+    fun `test PushConfig deserialization`() {
+        val givenPushConfigString = """{"token":"<token>","deviceToken":"<device_token>","preferredLanguage":"Eng","lastSyncTimestamp":1,"deviceType":"Android","pushProvider":"APNS"}"""
+
+        val result = WebMessagingJson.json.decodeFromString<PushConfig>(givenPushConfigString)
+
+        assertThat(result).isEqualTo(PushTestValues.CONFIG)
+    }
+
+    @Test
+    fun `test DEFAULT_PUSH_CONFIG values`() {
+        DEFAULT_PUSH_CONFIG.run {
+            assertThat(token).isEqualTo(UNKNOWN)
+            assertThat(deviceToken).isEqualTo(UNKNOWN)
+            assertThat(preferredLanguage).isEqualTo(UNKNOWN)
+            assertThat(lastSyncTimestamp).isEqualTo(UNKNOWN_LONG)
+            assertThat(deviceType).isEqualTo(UNKNOWN)
+            assertThat(pushProvider).isNull()
+        }
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/ConcreteVault.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/ConcreteVault.kt
@@ -1,0 +1,34 @@
+package com.genesys.cloud.messenger.transport.util
+
+/**
+ * A concrete implementation of [Vault] for testing purposes.
+ *
+ * This class uses in-memory storage to simulate a real vault,
+ * allowing easy manipulation and inspection of stored values
+ * during unit tests.
+ *
+ * @property keys The set of keys used to access stored data.
+ */
+class ConcreteVault(
+    keys: Keys = Keys(
+        vaultKey = VAULT_KEY,
+        tokenKey = TOKEN_KEY,
+        authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
+        wasAuthenticated = WAS_AUTHENTICATED,
+        pushConfigKey = PUSH_CONFIG_KEY,
+    ),
+) : Vault(keys) {
+    private val storage = mutableMapOf<String, String>()
+
+    override fun store(key: String, value: String) {
+        storage[key] = value
+    }
+
+    override fun fetch(key: String): String? {
+        return storage[key]
+    }
+
+    override fun remove(key: String) {
+        storage.remove(key)
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/VaultTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/VaultTest.kt
@@ -1,0 +1,112 @@
+package com.genesys.cloud.messenger.transport.util
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNotEmpty
+import assertk.assertions.isTrue
+import com.genesys.cloud.messenger.transport.auth.NO_REFRESH_TOKEN
+import com.genesys.cloud.messenger.transport.push.DEFAULT_PUSH_CONFIG
+import com.genesys.cloud.messenger.transport.push.PushConfig
+import com.genesys.cloud.messenger.transport.push.PushProvider
+import com.genesys.cloud.messenger.transport.utility.AuthTest
+import com.genesys.cloud.messenger.transport.utility.TestValues
+import kotlin.test.Test
+
+class VaultTest {
+
+    val subject = ConcreteVault()
+
+    @Test
+    fun `when getToken`() {
+        val result = subject.token
+
+        assertThat(result).isNotEmpty()
+    }
+
+    @Test
+    fun `when token is removed and then getToken`() {
+        subject.remove(TOKEN_KEY)
+        val result = subject.token
+
+        assertThat(result).isNotEmpty()
+    }
+
+    @Test
+    fun `when getAuthToken but it was never set before`() {
+        val result = subject.authRefreshToken
+
+        assertThat(result).isEqualTo(NO_REFRESH_TOKEN)
+    }
+
+    @Test
+    fun `when getAuthToken after it was set`() {
+        subject.authRefreshToken = AuthTest.JwtToken
+        val result = subject.authRefreshToken
+
+        assertThat(result).isEqualTo(AuthTest.JwtToken)
+    }
+
+    @Test
+    fun `when authToken is removed and then getAuthToken`() {
+        subject.remove(AUTH_REFRESH_TOKEN_KEY)
+        val result = subject.authRefreshToken
+
+        assertThat(result).isEqualTo(NO_REFRESH_TOKEN)
+    }
+
+    @Test
+    fun `when getWasAuthenticated but it was never set before`() {
+        val result = subject.wasAuthenticated
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when getWasAuthenticated after it was set`() {
+        subject.wasAuthenticated = true
+        val result = subject.wasAuthenticated
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `when wasAuthenticated is removed and then getWasAuthenticated`() {
+        subject.remove(WAS_AUTHENTICATED)
+        val result = subject.wasAuthenticated
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `when getPushConfig but it was never set before`() {
+        val result = subject.pushConfig
+
+        assertThat(result).isEqualTo(DEFAULT_PUSH_CONFIG)
+    }
+
+    @Test
+    fun `when getPushConfig after it was set`() {
+        val givenPushConfig = PushConfig(
+            token = TestValues.Token,
+            deviceToken = TestValues.DEVICE_TOKEN,
+            preferredLanguage = TestValues.PREFERRED_LANGUAGE,
+            lastSyncTimestamp = TestValues.PUSH_SYNC_TIMESTAMP,
+            deviceType = TestValues.DEVICE_TYPE,
+            pushProvider = PushProvider.APNS,
+        )
+
+        subject.pushConfig = givenPushConfig
+        val result = subject.pushConfig
+
+        assertThat(result).isEqualTo(givenPushConfig)
+    }
+
+    @Test
+    fun `when pushConfig is removed and then getPushConfig`() {
+        subject.remove(PUSH_CONFIG_KEY)
+        val result = subject.pushConfig
+
+        assertThat(result).isEqualTo(DEFAULT_PUSH_CONFIG)
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/VaultTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/util/VaultTest.kt
@@ -27,6 +27,7 @@ class VaultTest {
     @Test
     fun `when token is removed and then getToken`() {
         subject.remove(TOKEN_KEY)
+
         val result = subject.token
 
         assertThat(result).isNotEmpty()
@@ -42,6 +43,7 @@ class VaultTest {
     @Test
     fun `when getAuthToken after it was set`() {
         subject.authRefreshToken = AuthTest.JwtToken
+
         val result = subject.authRefreshToken
 
         assertThat(result).isEqualTo(AuthTest.JwtToken)
@@ -50,6 +52,7 @@ class VaultTest {
     @Test
     fun `when authToken is removed and then getAuthToken`() {
         subject.remove(AUTH_REFRESH_TOKEN_KEY)
+
         val result = subject.authRefreshToken
 
         assertThat(result).isEqualTo(NO_REFRESH_TOKEN)
@@ -65,6 +68,7 @@ class VaultTest {
     @Test
     fun `when getWasAuthenticated after it was set`() {
         subject.wasAuthenticated = true
+
         val result = subject.wasAuthenticated
 
         assertThat(result).isTrue()
@@ -73,6 +77,7 @@ class VaultTest {
     @Test
     fun `when wasAuthenticated is removed and then getWasAuthenticated`() {
         subject.remove(WAS_AUTHENTICATED)
+
         val result = subject.wasAuthenticated
 
         assertThat(result).isFalse()
@@ -95,8 +100,8 @@ class VaultTest {
             deviceType = TestValues.DEVICE_TYPE,
             pushProvider = PushProvider.APNS,
         )
-
         subject.pushConfig = givenPushConfig
+
         val result = subject.pushConfig
 
         assertThat(result).isEqualTo(givenPushConfig)
@@ -105,6 +110,7 @@ class VaultTest {
     @Test
     fun `when pushConfig is removed and then getPushConfig`() {
         subject.remove(PUSH_CONFIG_KEY)
+
         val result = subject.pushConfig
 
         assertThat(result).isEqualTo(DEFAULT_PUSH_CONFIG)

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -2,11 +2,14 @@ package com.genesys.cloud.messenger.transport.utility
 
 import com.genesys.cloud.messenger.transport.core.ButtonResponse
 import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.push.PushConfig
+import com.genesys.cloud.messenger.transport.push.PushProvider
 import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.ButtonResponseContent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.QuickReplyContent
 import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
+import com.genesys.cloud.messenger.transport.util.PUSH_CONFIG_KEY
 import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
 import com.genesys.cloud.messenger.transport.util.VAULT_KEY
 import com.genesys.cloud.messenger.transport.util.Vault
@@ -24,18 +27,19 @@ object TestValues {
     internal const val SecondaryToken = "<secondary_token>"
     internal const val ReconnectionTimeout = 5000L
     internal const val NoReconnectionAttempts = 0L
-    internal const val VaultKey = "vault_key"
-    internal const val TokenKey = "token_key"
-    internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
-    internal const val WasAuthenticated = "was_authenticated"
     internal const val LogTag = "TestLogTag"
     internal val defaultMap = mapOf("A" to "B")
     internal const val DEFAULT_STRING = "any string"
+    internal const val DEVICE_TOKEN = "<device_token>"
+    internal const val PUSH_SYNC_TIMESTAMP = 1L
+    internal const val DEVICE_TYPE = "Android"
+    internal const val PREFERRED_LANGUAGE = "Eng"
     internal val vaultKeys = Vault.Keys(
         vaultKey = VAULT_KEY,
         tokenKey = TOKEN_KEY,
         authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
         wasAuthenticated = WAS_AUTHENTICATED,
+        pushConfigKey = PUSH_CONFIG_KEY,
     )
 }
 
@@ -176,5 +180,16 @@ object StructuredMessageValues {
         type = type,
         direction = direction,
         content = content,
+    )
+}
+
+object PushTestValues {
+    internal val CONFIG = PushConfig(
+        token = TestValues.Token,
+        deviceToken = TestValues.DEVICE_TOKEN,
+        preferredLanguage = TestValues.PREFERRED_LANGUAGE,
+        lastSyncTimestamp = TestValues.PUSH_SYNC_TIMESTAMP,
+        deviceType = TestValues.DEVICE_TYPE,
+        pushProvider = PushProvider.APNS,
     )
 }


### PR DESCRIPTION
- Add functionality to store and retrieve PushConfig from/to Vault.
- Add DEFAULT_PUSH_CONFIG to represent the "unset" state of PushConfig and fallback to this value when Vault fails to retrieve it from storage.
- Update PushConfig.kt to be serializable to simplify its storage.
- Change PushConfig.pushProvider to be nullable to represent state when push provider is not set.
- Add `pushConfigKey` to Keys, for easy access to the stored data.
- Implement ConcreteVault.kt to assist with testing of the abstract Vault.
- Add/Update unit tests according to code changes.
- Add/Update KDoc