### PR TITLE
techdebt/MTSDK-541_no_feedback_when_detach_is_called_with_an_invalid_id

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -293,12 +293,14 @@ internal class AttachmentHandlerImplTest {
 
     @Test
     fun `when detach() on not processed attachment`() {
-        val result = subject.detach(TestValues.Token, "not processed attachment id")
+        val invalidAttachmentId = "not processed attachment id"
 
-        verify {
-            listOf(mockAttachmentListener) wasNot Called
+        val exception = assertFailsWith<IllegalArgumentException> {
+            subject.detach(TestValues.Token, invalidAttachmentId)
         }
-        assertThat(result).isNull()
+        assertThat(exception.message).isEqualTo("Detach failed: Invalid attachment ID ($invalidAttachmentId)")
+
+        verify { listOf(mockAttachmentListener) wasNot Called }
     }
 
     @Test

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -293,12 +293,12 @@ internal class AttachmentHandlerImplTest {
 
     @Test
     fun `when detach() on not processed attachment`() {
-        val invalidAttachmentId = "not processed attachment id"
+        val givenAttachmentId = TestValues.DEFAULT_STRING
 
         val exception = assertFailsWith<IllegalArgumentException> {
-            subject.detach(TestValues.Token, invalidAttachmentId)
+            subject.detach(TestValues.Token, givenAttachmentId)
         }
-        assertThat(exception.message).isEqualTo("Detach failed: Invalid attachment ID ($invalidAttachmentId)")
+        assertThat(exception.message).isEqualTo(ErrorMessage.detachFailed(givenAttachmentId))
 
         verify { listOf(mockAttachmentListener) wasNot Called }
     }

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
@@ -83,6 +83,22 @@ class MCAttachmentTests : BaseMessagingClientTest() {
 
     @Test
     fun `when detach() non existing attachmentId`() {
+        val givenAttachmentId = TestValues.DEFAULT_STRING
+        subject.connect()
+        clearMocks(mockPlatformSocket)
+        every { mockAttachmentHandler.detach(any(), any()) } throws IllegalArgumentException(ErrorMessage.detachFailed(givenAttachmentId))
+
+        val exception = assertFailsWith<IllegalArgumentException> {
+            subject.detach(givenAttachmentId)
+        }
+
+        assertThat(exception.message).isEqualTo(ErrorMessage.detachFailed(givenAttachmentId))
+
+        verify { mockPlatformSocket wasNot Called }
+    }
+
+    @Test
+    fun `when detach() non uploaded attachment`() {
         subject.connect()
         clearMocks(mockPlatformSocket)
         every { mockAttachmentHandler.detach(any(), any()) } returns null

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandler.kt
@@ -19,6 +19,7 @@ internal interface AttachmentHandler {
 
     fun upload(presignedUrlResponse: PresignedUrlResponse)
 
+    @Throws(IllegalArgumentException::class)
     fun detach(token: String, attachmentId: String): DeleteAttachmentRequest?
 
     fun onUploadSuccess(uploadSuccessEvent: UploadSuccessEvent)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -84,11 +84,11 @@ internal class AttachmentHandlerImpl(
         }
     }
 
+    @Throws(IllegalArgumentException::class)
     override fun detach(token: String, attachmentId: String): DeleteAttachmentRequest? {
-        // Check if the attachment id exists before proceeding
         if (!processedAttachments.containsKey(attachmentId)) {
             log.e { LogMessages.invalidAttachmentId(attachmentId) }
-            throw IllegalArgumentException("Detach failed: Invalid attachment ID ($attachmentId)")
+            throw IllegalArgumentException(ErrorMessage.detachFailed(attachmentId))
         }
         processedAttachments[attachmentId]?.let {
             log.i { LogMessages.detachingAttachment(attachmentId) }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -85,6 +85,11 @@ internal class AttachmentHandlerImpl(
     }
 
     override fun detach(token: String, attachmentId: String): DeleteAttachmentRequest? {
+        // Check if the attachment id exists before proceeding
+        if (!processedAttachments.containsKey(attachmentId)) {
+            log.e { LogMessages.invalidAttachmentId(attachmentId) }
+            throw IllegalArgumentException("Detach failed: Invalid attachment ID ($attachmentId)")
+        }
         processedAttachments[attachmentId]?.let {
             log.i { LogMessages.detachingAttachment(attachmentId) }
             it.job?.cancel()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -83,6 +83,7 @@ object ErrorMessage {
     const val FailedToClearConversation = "Failed to clear conversation."
     const val FileSizeIsToSmall = "Attachment size cannot be less than 1 byte"
     const val FileAttachmentIsDisabled = "File attachment is disabled in Deployment Configuration."
+    fun detachFailed(attachmentId: String) = "Detach failed: Invalid attachment ID ($attachmentId)"
     fun fileSizeIsTooBig(maxFileSize: Long?) = "Reduce the attachment size to $maxFileSize KB or less."
     fun fileTypeIsProhibited(fileName: String) = "File type  $fileName is prohibited for upload."
     fun customAttributesSizeError(maxSize: Int) = "Error: Custom attributes exceed allowed max size of $maxSize bytes."

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -224,8 +224,9 @@ interface MessagingClient {
      * @param attachmentId the ID of the attachment to remove.
      *
      * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     * @throws IllegalArgumentException if the attachment ID is invalid.
      */
-    @Throws(IllegalStateException::class)
+    @Throws(IllegalStateException::class, IllegalArgumentException::class)
     fun detach(attachmentId: String)
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -242,7 +242,7 @@ internal class MessagingClientImpl(
         return request.attachmentId
     }
 
-    @Throws(IllegalStateException::class)
+    @Throws(IllegalStateException::class, IllegalArgumentException::class)
     override fun detach(attachmentId: String) {
         log.i { LogMessages.detach(attachmentId) }
         attachmentHandler.detach(token, attachmentId)?.let {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -23,6 +23,8 @@ internal object LogMessages {
     fun detach(attachmentId: String) = "detach(attachmentId = $attachmentId)"
     fun attachmentError(attachmentId: String, errorCode: ErrorCode, errorMessage: String) =
         "Attachment error with id: $attachmentId. ErrorCode: $errorCode, errorMessage: $errorMessage"
+    fun invalidAttachmentId(attachmentId: String) = "Invalid attachment ID: $attachmentId. Detach failed."
+
     // Authentication
     const val REFRESH_AUTH_TOKEN_SUCCESS = "refreshAuthToken success."
     fun configureAuthenticatedSession(token: String, startNew: Boolean) =


### PR DESCRIPTION
- Logs an error when detach is called with an invalid attachment ID.

- Update `when detach() on not processed attachment` test.