### PR TITLE
MTSDK-553 Text file upload failure

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -128,13 +128,14 @@ internal class AttachmentHandlerImplTest {
         val mockUploadProgress: ((Float) -> Unit) = spyk()
         val progressSlot = slot<Float>()
         givenPrepareCalled(uploadProgress = mockUploadProgress)
+        val expectedPresignedUrlResponse = givenPresignedUrlResponse.copy(fileName = AttachmentValues.FileName)
 
         subject.upload(givenPresignedUrlResponse)
 
         coVerify {
             mockLogger.i(capture(logSlot))
             mockAttachmentListener.invoke(capture(attachmentSlot))
-            mockApi.uploadFile(givenPresignedUrlResponse, ByteArray(1), mockUploadProgress)
+            mockApi.uploadFile(expectedPresignedUrlResponse, ByteArray(1), mockUploadProgress)
             mockUploadProgress.invoke(capture(progressSlot))
         }
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -66,7 +66,7 @@ internal class AttachmentHandlerImpl(
             it.attachment = it.attachment.copy(state = Uploading)
                 .also(updateAttachmentStateWith)
             it.job = uploadDispatcher.launch {
-                when (val result = api.uploadFile(presignedUrlResponse, it.byteArray, it.uploadProgress)) {
+                when (val result = api.uploadFile(presignedUrlResponse.copy(fileName = it.attachment.fileName), it.byteArray, it.uploadProgress)) {
                     is Result.Success -> {} // Nothing to do here. We are waiting for UploadSuccess/Failure Event from Shyrka.
                     is Result.Failure -> handleUploadFailure(presignedUrlResponse.attachmentId, result)
                 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -25,6 +25,8 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.defaultForFilePath
 import io.ktor.http.isSuccess
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -67,6 +69,9 @@ internal class WebMessagingApi(
         val response = client.put(presignedUrlResponse.url) {
             presignedUrlResponse.headers.forEach {
                 header(it.key, it.value)
+            }
+            presignedUrlResponse.fileName?.let {
+                contentType(ContentType.defaultForFilePath(it))
             }
             onUpload { bytesSendTotal: Long, contentLength: Long ->
                 progressCallback?.let { it((bytesSendTotal / contentLength.toFloat()) * 100) }


### PR DESCRIPTION
- Explicitly specify contentType when uploading an attachment.
- Update unit tests