### PR TITLE
Feature/mtsdk 529 implement register device token

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
@@ -68,7 +68,8 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.NONE))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenIsInSync(expectedUserConfig)
         )
     }
@@ -92,7 +93,8 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.NO_TOKEN))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)
         )
     }
@@ -118,10 +120,11 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.TOKEN))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenWasDeleted(expectedUserConfig)
         )
-        assertThat(logSlot[2].invoke()).isEqualTo(
+        assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)
         )
     }
@@ -145,7 +148,8 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.DEVICE_TOKEN))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenWasUpdated(expectedUserConfig)
         )
     }
@@ -169,7 +173,8 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.LANGUAGE))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenWasUpdated(expectedUserConfig)
         )
     }
@@ -193,7 +198,8 @@ class PushServiceImplTest {
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.synchronizingPush(TestValues.DEVICE_TOKEN, TestValues.PUSH_PROVIDER)
         )
-        assertThat(logSlot[1].invoke()).isEqualTo(
+        assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.pushDiff(Diff.EXPIRED))
+        assertThat(logSlot[2].invoke()).isEqualTo(
             LogMessages.deviceTokenWasUpdated(expectedUserConfig)
         )
     }
@@ -206,5 +212,6 @@ class PushServiceImplTest {
         mockPlatform.epochMillis()
         mockPlatform.os
         mockPushConfigComparator.compare(expectedUserConfig, expectedStoredConfig)
+        mockLogger.i(capture(logSlot))
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
@@ -1,9 +1,5 @@
 package com.genesys.cloud.messenger.transport.core
 
-import io.ktor.http.URLBuilder
-import io.ktor.http.Url
-import io.ktor.http.path
-
 /**
  * @param deploymentId the ID of the Genesys Cloud Messenger deployment.
  * @param domain the regional base domain address for a Genesys Cloud Web Messaging service. For example, "mypurecloud.com".
@@ -39,42 +35,4 @@ data class Configuration(
         reconnectionTimeoutInSeconds = reconnectionTimeoutInSeconds,
         autoRefreshTokenWhenExpired = true,
     )
-
-    internal val webSocketUrl: Url by lazy {
-        URLBuilder("wss://webmessaging.$domain")
-            .apply {
-                path("v1")
-                parameters.append("deploymentId", deploymentId)
-                parameters.append("application", "TransportSDK-${MessengerTransportSDK.sdkVersion}")
-            }
-            .build()
-    }
-
-    internal val apiBaseUrl: Url by lazy {
-        URLBuilder("https://api.$domain").build()
-    }
-
-    internal val deploymentConfigUrl: Url by lazy {
-        URLBuilder("https://api-cdn.$domain").apply {
-            path("webdeployments/v1/deployments/$deploymentId/config.json")
-        }.build()
-    }
-
-    internal val jwtAuthUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/oauthcodegrantjwtexchange")
-        }.build()
-    }
-
-    internal val logoutUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/revoke")
-        }.build()
-    }
-
-    internal val refreshAuthTokenUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/refresh")
-        }.build()
-    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -46,7 +46,7 @@ internal class WebMessagingApi(
         pageNumber: Int,
         pageSize: Int = DEFAULT_PAGE_SIZE,
     ): Result<MessageEntityList> = try {
-        val response = client.get("${urls.apiBaseUrl}/api/v2/webmessaging/messages") {
+        val response = client.get(urls.history.toString()) {
             headerAuthorizationBearer(jwt)
             headerOrigin(configuration.domain)
             parameter("pageNumber", pageNumber)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -12,6 +12,7 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.MessageEntityList
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.send.AuthJwtRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OAuth
+import com.genesys.cloud.messenger.transport.util.Urls
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.onUpload
@@ -30,6 +31,7 @@ import io.ktor.http.isSuccess
 import kotlin.coroutines.cancellation.CancellationException
 
 internal class WebMessagingApi(
+    private val urls: Urls,
     private val configuration: Configuration,
     private val client: HttpClient = defaultHttpClient(configuration.logging),
 ) {
@@ -43,7 +45,7 @@ internal class WebMessagingApi(
         pageNumber: Int,
         pageSize: Int = DEFAULT_PAGE_SIZE,
     ): Result<MessageEntityList> = try {
-        val response = client.get("${configuration.apiBaseUrl}/api/v2/webmessaging/messages") {
+        val response = client.get("${urls.apiBaseUrl}/api/v2/webmessaging/messages") {
             headerAuthorizationBearer(jwt)
             headerOrigin(configuration.domain)
             parameter("pageNumber", pageNumber)
@@ -98,7 +100,7 @@ internal class WebMessagingApi(
                 codeVerifier = codeVerifier,
             )
         )
-        val response = client.post(configuration.jwtAuthUrl.toString()) {
+        val response = client.post(urls.jwtAuthUrl.toString()) {
             header("content-type", ContentType.Application.Json)
             setBody(requestBody)
         }
@@ -114,7 +116,7 @@ internal class WebMessagingApi(
     }
 
     suspend fun logoutFromAuthenticatedSession(jwt: String): Result<Empty> = try {
-        val response = client.delete(configuration.logoutUrl.toString()) {
+        val response = client.delete(urls.logoutUrl.toString()) {
             headerAuthorizationBearer(jwt)
         }
         if (response.status.isSuccess()) {
@@ -130,7 +132,7 @@ internal class WebMessagingApi(
     }
 
     suspend fun refreshAuthJwt(refreshToken: String): Result<AuthJwt> = try {
-        val response = client.post(configuration.refreshAuthTokenUrl.toString()) {
+        val response = client.post(urls.refreshAuthTokenUrl.toString()) {
             header("content-type", ContentType.Application.Json)
             setBody(RefreshToken(refreshToken))
         }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushConfig.kt
@@ -4,7 +4,7 @@ import com.genesys.cloud.messenger.transport.util.UNKNOWN
 import com.genesys.cloud.messenger.transport.util.UNKNOWN_LONG
 import kotlinx.serialization.Serializable
 
-internal const val DEVICE_TOKEN_EXPIRATION_IN_SECONDS = 30000
+internal const val DEVICE_TOKEN_EXPIRATION_IN_SECONDS = 2592000L // 30 days in seconds
 
 @Serializable
 internal data class PushConfig(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
@@ -24,6 +24,7 @@ internal class PushServiceImpl(
         val storedPushConfig = vault.pushConfig
         val userPushConfig = buildPushConfigFromUserData(deviceToken, pushProvider)
         val diff = pushConfigComparator.compare(userPushConfig, storedPushConfig)
+        log.i { LogMessages.pushDiff(diff) }
         handleDiff(diff, userPushConfig)
     }
 
@@ -47,8 +48,7 @@ internal class PushServiceImpl(
     }
 
     private suspend fun register(userPushConfig: PushConfig) {
-        val result = api.registerDeviceToken(userPushConfig)
-        when (result) {
+        when (api.registerDeviceToken(userPushConfig)) {
             is Result.Success -> {
                 log.i { LogMessages.deviceTokenWasRegistered(userPushConfig) }
                 vault.pushConfig = userPushConfig

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/RegisterDeviceTokenRequestBody.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/RegisterDeviceTokenRequestBody.kt
@@ -1,0 +1,11 @@
+package com.genesys.cloud.messenger.transport.push
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class RegisterDeviceTokenRequestBody(
+    val deviceToken: String,
+    val notificationProvider: PushProvider,
+    val language: String,
+    val deviceType: String,
+)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
@@ -5,6 +5,9 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.path
 
+private const val BASE_WEBDEPLOYMENTS_PATH = "api/v2/webdeployments"
+private const val BASE_WEBMESSAGING_PATH = "api/v2/webmessaging"
+
 internal class Urls(val domain: String, val deploymentId: String) {
 
     internal val webSocketUrl: Url by lazy {
@@ -17,7 +20,7 @@ internal class Urls(val domain: String, val deploymentId: String) {
             .build()
     }
 
-    internal val apiBaseUrl: Url by lazy {
+    private val apiBaseUrl: Url by lazy {
         URLBuilder("https://api.$domain").build()
     }
 
@@ -27,27 +30,24 @@ internal class Urls(val domain: String, val deploymentId: String) {
         }.build()
     }
 
+    internal val history: Url by lazy {
+        URLBuilder(apiBaseUrl).apply { path("$BASE_WEBMESSAGING_PATH/messages") }.build()
+    }
+
     internal val jwtAuthUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/oauthcodegrantjwtexchange")
-        }.build()
+        URLBuilder(apiBaseUrl).apply { path("$BASE_WEBDEPLOYMENTS_PATH/token/oauthcodegrantjwtexchange") }.build()
     }
 
     internal val logoutUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/revoke")
-        }.build()
+        URLBuilder(apiBaseUrl).apply { path("$BASE_WEBDEPLOYMENTS_PATH/token/revoke") }.build()
     }
 
     internal val refreshAuthTokenUrl: Url by lazy {
-        URLBuilder("https://api.$domain").apply {
-            path("api/v2/webdeployments/token/refresh")
-        }.build()
+        URLBuilder(apiBaseUrl).apply { path("$BASE_WEBDEPLOYMENTS_PATH/token/refresh") }.build()
     }
 
     internal val registerDeviceToken: (String, String) -> Url = { deploymentId, token ->
-        URLBuilder("https://api.$domain").apply {
-            path("/api/v2/webmessaging/deployments/$deploymentId/pushdevices/$token")
-        }.build()
+        URLBuilder(apiBaseUrl).apply { path("$BASE_WEBMESSAGING_PATH/deployments/$deploymentId/pushdevices/$token") }
+            .build()
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
@@ -44,4 +44,10 @@ internal class Urls(val domain: String, val deploymentId: String) {
             path("api/v2/webdeployments/token/refresh")
         }.build()
     }
+
+    internal val registerDeviceToken: (String, String) -> Url = { deploymentId, token ->
+        URLBuilder("https://api.$domain").apply {
+            path("/api/v2/webmessaging/deployments/$deploymentId/pushdevices/$token")
+        }.build()
+    }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/Urls.kt
@@ -1,0 +1,47 @@
+package com.genesys.cloud.messenger.transport.util
+
+import com.genesys.cloud.messenger.transport.core.MessengerTransportSDK
+import io.ktor.http.URLBuilder
+import io.ktor.http.Url
+import io.ktor.http.path
+
+internal class Urls(val domain: String, val deploymentId: String) {
+
+    internal val webSocketUrl: Url by lazy {
+        URLBuilder("wss://webmessaging.$domain")
+            .apply {
+                path("v1")
+                parameters.append("deploymentId", deploymentId)
+                parameters.append("application", "TransportSDK-${MessengerTransportSDK.sdkVersion}")
+            }
+            .build()
+    }
+
+    internal val apiBaseUrl: Url by lazy {
+        URLBuilder("https://api.$domain").build()
+    }
+
+    internal val deploymentConfigUrl: Url by lazy {
+        URLBuilder("https://api-cdn.$domain").apply {
+            path("webdeployments/v1/deployments/$deploymentId/config.json")
+        }.build()
+    }
+
+    internal val jwtAuthUrl: Url by lazy {
+        URLBuilder("https://api.$domain").apply {
+            path("api/v2/webdeployments/token/oauthcodegrantjwtexchange")
+        }.build()
+    }
+
+    internal val logoutUrl: Url by lazy {
+        URLBuilder("https://api.$domain").apply {
+            path("api/v2/webdeployments/token/revoke")
+        }.build()
+    }
+
+    internal val refreshAuthTokenUrl: Url by lazy {
+        URLBuilder("https://api.$domain").apply {
+            path("api/v2/webdeployments/token/refresh")
+        }.build()
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -8,6 +8,7 @@ import com.genesys.cloud.messenger.transport.core.MessagingClient
 import com.genesys.cloud.messenger.transport.core.Result
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.push.PushConfig
+import com.genesys.cloud.messenger.transport.push.PushConfigComparator
 import com.genesys.cloud.messenger.transport.push.PushProvider
 import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
 
@@ -114,6 +115,7 @@ internal object LogMessages {
     fun ignoreInboundEvent(event: Event) = "Ignore inbound event: $event."
     // Push
     fun synchronizingPush(deviceToken: String, pushProvider: PushProvider) = "Synchronizing deviceToken: $deviceToken with $pushProvider."
+    fun pushDiff(diff: PushConfigComparator.Diff) = "The diff between user and stored push config is: $diff."
     fun deviceTokenIsInSync(pushConfig: PushConfig) = "deviceToken: ${pushConfig.deviceToken} with ${pushConfig.pushProvider} is already in sync."
     fun deviceTokenWasRegistered(pushConfig: PushConfig) = "deviceToken: ${pushConfig.deviceToken} with ${pushConfig.pushProvider} was registered."
     fun deviceTokenWasUpdated(pushConfig: PushConfig) = "deviceToken: ${pushConfig.deviceToken} with ${pushConfig.pushProvider} was updated."

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
@@ -5,9 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
 import com.genesys.cloud.messenger.transport.core.Configuration
-import com.genesys.cloud.messenger.transport.core.MessengerTransportSDK
 import com.genesys.cloud.messenger.transport.utility.TestValues
-import io.ktor.http.Url
 import kotlin.test.Test
 
 class ConfigurationTest {
@@ -48,83 +46,5 @@ class ConfigurationTest {
             assertThat(reconnectionTimeoutInSeconds).isEqualTo(expectedReconnectionTimeout)
             assertThat(autoRefreshTokenWhenExpired).isTrue()
         }
-    }
-
-    @Test
-    fun `it should get webSocketUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-
-        val actual = configuration.webSocketUrl
-        val expected = Url("wss://webmessaging.mypurecloud.com/v1?deploymentId=foo&application=TransportSDK-${MessengerTransportSDK.sdkVersion}")
-
-        assertThat(actual, "WebSocket URL").isEqualTo(expected)
-    }
-
-    @Test
-    fun `it should get apiBaseUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-        val expected = Url("https://api.mypurecloud.com")
-
-        val result = configuration.apiBaseUrl
-
-        assertThat(result, "API Base URL").isEqualTo(expected)
-    }
-
-    @Test
-    fun `it should get deploymentConfigUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-        val expected = Url("https://api-cdn.mypurecloud.com/webdeployments/v1/deployments/foo/config.json")
-
-        val result = configuration.deploymentConfigUrl
-
-        assertThat(result, "Deployment config URL").isEqualTo(expected)
-    }
-
-    @Test
-    fun `it should get jwtAuthUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-        val expected = Url("https://api.mypurecloud.com/api/v2/webdeployments/token/oauthcodegrantjwtexchange")
-
-        val result = configuration.jwtAuthUrl
-
-        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
-    }
-
-    @Test
-    fun `it should get logoutUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-        val expected = Url("https://api.mypurecloud.com/api/v2/webdeployments/token/revoke")
-
-        val result = configuration.logoutUrl
-
-        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
-    }
-
-    @Test
-    fun `it should get refreshAuthTokenUrl`() {
-        val configuration = Configuration(
-            deploymentId = "foo",
-            domain = "mypurecloud.com",
-        )
-        val expected = Url("https://api.mypurecloud.com/api/v2/webdeployments/token/refresh")
-
-        val result = configuration.refreshAuthTokenUrl
-
-        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
     }
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
@@ -54,7 +54,7 @@ class UrlsTest {
 
         val result = subject.logoutUrl
 
-        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
+        assertThat(result, "logoutUrl URL").isEqualTo(expected)
     }
 
     @Test
@@ -63,6 +63,16 @@ class UrlsTest {
 
         val result = subject.refreshAuthTokenUrl
 
-        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
+        assertThat(result, "refreshAuthToken URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get registerDeviceToken`() {
+        val expected =
+            Url("https://api.${TestValues.Domain}/api/v2/webmessaging/deployments/${TestValues.DeploymentId}/pushdevices/${TestValues.Token}")
+
+        val result = subject.registerDeviceToken(TestValues.DeploymentId, TestValues.Token)
+
+        assertThat(result, "registerDeviceToken URL").isEqualTo(expected)
     }
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
@@ -22,21 +22,21 @@ class UrlsTest {
     }
 
     @Test
-    fun `it should get apiBaseUrl`() {
-        val expected = Url("https://api.${TestValues.Domain}")
-
-        val result = subject.apiBaseUrl
-
-        assertThat(result, "API Base URL").isEqualTo(expected)
-    }
-
-    @Test
     fun `it should get deploymentConfigUrl`() {
         val expected = Url("https://api-cdn.${TestValues.Domain}/webdeployments/v1/deployments/${TestValues.DeploymentId}/config.json")
 
         val result = subject.deploymentConfigUrl
 
         assertThat(result, "Deployment config URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get history`() {
+        val expected = Url("https://api.${TestValues.Domain}/api/v2/webmessaging/messages")
+
+        val result = subject.history
+
+        assertThat(result, "history URL").isEqualTo(expected)
     }
 
     @Test

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/UrlsTest.kt
@@ -1,0 +1,68 @@
+package com.genesys.cloud.messenger.transport
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.genesys.cloud.messenger.transport.core.MessengerTransportSDK
+import com.genesys.cloud.messenger.transport.util.Urls
+import com.genesys.cloud.messenger.transport.utility.TestValues
+import io.ktor.http.Url
+import kotlin.test.Test
+
+class UrlsTest {
+
+    private val subject = Urls(TestValues.Domain, TestValues.DeploymentId)
+
+    @Test
+    fun `it should get webSocketUrl`() {
+        val expected = Url("wss://webmessaging.${TestValues.Domain}/v1?deploymentId=${TestValues.DeploymentId}&application=TransportSDK-${MessengerTransportSDK.sdkVersion}")
+
+        val result = subject.webSocketUrl
+
+        assertThat(result, "WebSocket URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get apiBaseUrl`() {
+        val expected = Url("https://api.${TestValues.Domain}")
+
+        val result = subject.apiBaseUrl
+
+        assertThat(result, "API Base URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get deploymentConfigUrl`() {
+        val expected = Url("https://api-cdn.${TestValues.Domain}/webdeployments/v1/deployments/${TestValues.DeploymentId}/config.json")
+
+        val result = subject.deploymentConfigUrl
+
+        assertThat(result, "Deployment config URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get jwtAuthUrl`() {
+        val expected = Url("https://api.${TestValues.Domain}/api/v2/webdeployments/token/oauthcodegrantjwtexchange")
+
+        val result = subject.jwtAuthUrl
+
+        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get logoutUrl`() {
+        val expected = Url("https://api.${TestValues.Domain}/api/v2/webdeployments/token/revoke")
+
+        val result = subject.logoutUrl
+
+        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
+    }
+
+    @Test
+    fun `it should get refreshAuthTokenUrl`() {
+        val expected = Url("https://api.${TestValues.Domain}/api/v2/webdeployments/token/refresh")
+
+        val result = subject.refreshAuthTokenUrl
+
+        assertThat(result, "jwtAuth config URL").isEqualTo(expected)
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/RequestSerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/RequestSerializationTest.kt
@@ -6,6 +6,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
+import com.genesys.cloud.messenger.transport.push.RegisterDeviceTokenRequestBody
 import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresenceEvent.Presence
@@ -37,7 +38,6 @@ import com.genesys.cloud.messenger.transport.utility.AttachmentValues
 import com.genesys.cloud.messenger.transport.utility.AuthTest
 import com.genesys.cloud.messenger.transport.utility.Journey
 import com.genesys.cloud.messenger.transport.utility.TestValues
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 
@@ -53,7 +53,7 @@ class RequestSerializationTest {
         val expectedMessage = EventMessage(expectedEvents)
         val expectedRequest = AutoStartRequest(TestValues.Token, null)
         val expectedJson =
-            """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],"type":"Event"}}"""
+            """{"token":"token","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],"type":"Event"}}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<AutoStartRequest>(expectedJson)
@@ -94,7 +94,7 @@ class RequestSerializationTest {
         val expectedMessage = EventMessage(expectedEvents)
         val expectedRequest = ClearConversationRequest(TestValues.Token)
         val expectedJson =
-            """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Clear"}}],"type":"Event"}}"""
+            """{"token":"token","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Clear"}}],"type":"Event"}}"""
         val expectedPresenceJson = """{"type":"Clear"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
@@ -120,7 +120,7 @@ class RequestSerializationTest {
             closeAllConnections = true,
         )
         val expectedJson =
-            """{"token":"<token>","closeAllConnections":true,"action":"closeSession"}"""
+            """{"token":"token","closeAllConnections":true,"action":"closeSession"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<CloseSessionRequest>(expectedJson)
@@ -143,7 +143,7 @@ class RequestSerializationTest {
             data = expectedData
         )
         val expectedJson =
-            """{"token":"<token>","deploymentId":"deploymentId","startNew":false,"data":{"code":"jwt_Token"},"action":"configureAuthenticatedSession"}"""
+            """{"token":"token","deploymentId":"deploymentId","startNew":false,"data":{"code":"jwt_Token"},"action":"configureAuthenticatedSession"}"""
         val expectedDataJson = """{"code":"jwt_Token"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
@@ -180,7 +180,7 @@ class RequestSerializationTest {
             startNew = true,
         )
         val expectedJson =
-            """{"token":"<token>","deploymentId":"deploymentId","startNew":true,"action":"configureSession"}"""
+            """{"token":"token","deploymentId":"deploymentId","startNew":true,"action":"configureSession"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<ConfigureSessionRequest>(expectedJson)
@@ -202,7 +202,7 @@ class RequestSerializationTest {
             attachmentId = AttachmentValues.Id
         )
         val expectedJson =
-            """{"token":"<token>","attachmentId":"test_attachment_id","action":"deleteAttachment"}"""
+            """{"token":"token","attachmentId":"test_attachment_id","action":"deleteAttachment"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<DeleteAttachmentRequest>(expectedJson)
@@ -222,7 +222,7 @@ class RequestSerializationTest {
             token = TestValues.Token,
         )
         val expectedJson =
-            """{"token":"<token>","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
+            """{"token":"token","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<EchoRequest>(expectedJson)
@@ -271,7 +271,7 @@ class RequestSerializationTest {
             attachmentId = AttachmentValues.Id
         )
         val expectedJson =
-            """{"token":"<token>","attachmentId":"test_attachment_id","action":"getAttachment"}"""
+            """{"token":"token","attachmentId":"test_attachment_id","action":"getAttachment"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<GetAttachmentRequest>(expectedJson)
@@ -448,7 +448,7 @@ class RequestSerializationTest {
         val expectedMessage = EventMessage(expectedEventList)
         val expectedRequest = UserTypingRequest(token = TestValues.Token)
         val expectedJson =
-            """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
+            """{"token":"token","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<UserTypingRequest>(expectedJson)
@@ -461,6 +461,29 @@ class RequestSerializationTest {
             message.run {
                 assertThat(events).containsExactly(*expectedEventList.toTypedArray())
             }
+        }
+    }
+
+    @Test
+    fun `validate RegisterDeviceTokenRequestBody serialization`() {
+        val expectedRequest = RegisterDeviceTokenRequestBody(
+            deviceToken = TestValues.DEVICE_TOKEN,
+            notificationProvider = TestValues.PUSH_PROVIDER,
+            language = TestValues.PREFERRED_LANGUAGE,
+            deviceType = TestValues.DEVICE_TYPE
+        )
+        val expectedJson =
+            """{"deviceToken":"${TestValues.DEVICE_TOKEN}","notificationProvider":"${TestValues.PUSH_PROVIDER}","language":"${TestValues.PREFERRED_LANGUAGE}","deviceType":"${TestValues.DEVICE_TYPE}"}"""
+
+        val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
+        val decoded = WebMessagingJson.json.decodeFromString<RegisterDeviceTokenRequestBody>(expectedJson)
+
+        assertThat(encodedString, "encoded RegisterDeviceTokenRequestBody").isEqualTo(expectedJson)
+        decoded.run {
+            assertThat(deviceToken).isEqualTo(TestValues.DEVICE_TOKEN)
+            assertThat(notificationProvider).isEqualTo(TestValues.PUSH_PROVIDER)
+            assertThat(language).isEqualTo(TestValues.PREFERRED_LANGUAGE)
+            assertThat(deviceType).isEqualTo(TestValues.DEVICE_TYPE)
         }
     }
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
@@ -15,6 +15,7 @@ import com.genesys.cloud.messenger.transport.network.test_engines.historyEngine
 import com.genesys.cloud.messenger.transport.network.test_engines.invalidHeaders
 import com.genesys.cloud.messenger.transport.network.test_engines.logoutEngine
 import com.genesys.cloud.messenger.transport.network.test_engines.refreshTokenEngine
+import com.genesys.cloud.messenger.transport.network.test_engines.registerDeviceTokenEngine
 import com.genesys.cloud.messenger.transport.network.test_engines.uploadFileEngine
 import com.genesys.cloud.messenger.transport.network.test_engines.validHeaders
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
@@ -23,6 +24,7 @@ import com.genesys.cloud.messenger.transport.utility.AuthTest
 import com.genesys.cloud.messenger.transport.utility.DEFAULT_TIMEOUT
 import com.genesys.cloud.messenger.transport.utility.ErrorTest
 import com.genesys.cloud.messenger.transport.utility.InvalidValues
+import com.genesys.cloud.messenger.transport.utility.PushTestValues
 import com.genesys.cloud.messenger.transport.utility.TestValues
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.mock.MockEngineConfig
@@ -315,6 +317,16 @@ class WebMessagingApiTest {
             runBlocking { subject.refreshAuthJwt(InvalidValues.UnknownException) }
 
         assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `when registerDeviceToken with valid userConfig data`() {
+        subject = buildWebMessagingApiWith { registerDeviceTokenEngine() }
+        val givenUserPushConfig = PushTestValues.CONFIG
+
+        val result = runBlocking { subject.registerDeviceToken(givenUserPushConfig) }
+
+        assertTrue(result is Result.Success<Empty>)
     }
 }
 

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
@@ -18,6 +18,7 @@ import com.genesys.cloud.messenger.transport.network.test_engines.refreshTokenEn
 import com.genesys.cloud.messenger.transport.network.test_engines.uploadFileEngine
 import com.genesys.cloud.messenger.transport.network.test_engines.validHeaders
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
+import com.genesys.cloud.messenger.transport.util.Urls
 import com.genesys.cloud.messenger.transport.utility.AuthTest
 import com.genesys.cloud.messenger.transport.utility.DEFAULT_TIMEOUT
 import com.genesys.cloud.messenger.transport.utility.ErrorTest
@@ -322,6 +323,7 @@ private fun buildWebMessagingApiWith(
     engine: HttpClientConfig<MockEngineConfig>.() -> Unit,
 ): WebMessagingApi {
     return WebMessagingApi(
+        urls = Urls(configuration.domain, configuration.deploymentId),
         configuration = configuration,
         client = mockHttpClientWith { engine() }
     )

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/RegisterDeviceToken.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/RegisterDeviceToken.kt
@@ -1,0 +1,60 @@
+package com.genesys.cloud.messenger.transport.network.test_engines
+
+import com.genesys.cloud.messenger.transport.network.toRegisterDeviceTokenRequestBody
+import com.genesys.cloud.messenger.transport.push.RegisterDeviceTokenRequestBody
+import com.genesys.cloud.messenger.transport.respondNotFound
+import com.genesys.cloud.messenger.transport.utility.MockEngineValues
+import com.genesys.cloud.messenger.transport.utility.PushTestValues
+import com.genesys.cloud.messenger.transport.utility.TestValues
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondBadRequest
+import io.ktor.content.TextContent
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.fullPath
+import io.ktor.http.headersOf
+import kotlinx.serialization.json.Json
+
+private const val BASIC_REGISTER_DEVICE_TOKEN_PATH =
+    "/api/v2/webmessaging/deployments/${TestValues.DeploymentId}/pushdevices/${TestValues.Token}"
+
+internal fun HttpClientConfig<MockEngineConfig>.registerDeviceTokenEngine() {
+    engine {
+        addHandler { request ->
+            when (request.url.fullPath) {
+                BASIC_REGISTER_DEVICE_TOKEN_PATH -> {
+                    if (request.method == HttpMethod.Post && request.body is TextContent) {
+                        val requestBody = Json.decodeFromString(
+                            RegisterDeviceTokenRequestBody.serializer(),
+                            (request.body as TextContent).text
+                        )
+                        if (requestBody == PushTestValues.CONFIG.toRegisterDeviceTokenRequestBody()) {
+                            respond(
+                                status = HttpStatusCode.NoContent,
+                                headers = headersOf(
+                                    HttpHeaders.ContentType,
+                                    MockEngineValues.CONTENT_TYPE_JSON
+                                ),
+                                content = MockEngineValues.NO_CONTENT
+                            )
+                        } else {
+                            TODO("Not yet implemented: MTSDK-416")
+                            respondBadRequest()
+                        }
+                    } else {
+                        TODO("Not yet implemented: MTSDK-416")
+                        respondBadRequest()
+                    }
+                }
+
+                else -> {
+                    TODO("Not yet implemented: MTSDK-416")
+                    respondNotFound()
+                }
+            }
+        }
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -23,7 +23,7 @@ object TestValues {
     internal const val MaxCustomDataBytes = 100
     internal const val DefaultNumber = 1
     internal const val Timestamp = "2022-08-22T19:24:26.704Z"
-    internal const val Token = "<token>"
+    internal const val Token = "token"
     internal const val SecondaryToken = "<secondary_token>"
     internal const val ReconnectionTimeout = 5000L
     internal const val NoReconnectionAttempts = 0L
@@ -193,4 +193,9 @@ object PushTestValues {
         deviceType = TestValues.DEVICE_TYPE,
         pushProvider = TestValues.PUSH_PROVIDER,
     )
+}
+
+object MockEngineValues {
+    const val NO_CONTENT = "No Content"
+    const val CONTENT_TYPE_JSON = "application/json"
 }


### PR DESCRIPTION
- Implement registerDeviceToken api call
- Move urls from Configuration.kt into separate Urls.kt file.
- Update dependencies to use Urls.kt instead of Configuration.kt
- Add log message to print the actual diff when comparing 2 PushConfig objects
- Add RegisterDeviceTokenRequestBody.kt to simplify serialization of deviceToken json body needed for registerDeviceToken request
- Update the DEVICE_TOKEN_EXPIRATION_IN_SECONDS to 30 days
- Add/Update unit tests