### PR TITLE
techdebt/MTSDK-554-cover-log-messages-file-with-unit-tests

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
@@ -54,30 +54,30 @@ class AuthHandlerTest {
     private val mockWebMessagingApi: WebMessagingApi = mockk {
         coEvery {
             fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier,
+                AuthTest.AUTH_CODE,
+                AuthTest.REDIRECT_URI,
+                AuthTest.CODE_VERIFIER,
             )
-        } returns Result.Success(AuthJwt(AuthTest.JwtToken, AuthTest.RefreshToken))
+        } returns Result.Success(AuthJwt(AuthTest.JWT_TOKEN, AuthTest.REFRESH_TOKEN))
 
         coEvery {
-            logoutFromAuthenticatedSession(AuthTest.JwtToken)
+            logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
         } returns Result.Success(Empty())
 
         coEvery {
             logoutFromAuthenticatedSession(NO_JWT)
         } returns Result.Failure(
             ErrorCode.AuthLogoutFailed,
-            ErrorTest.Message,
+            ErrorTest.MESSAGE,
         )
 
-        coEvery { refreshAuthJwt(AuthTest.RefreshToken) } returns Result.Success(
-            AuthJwt(AuthTest.RefreshedJWTToken, null)
+        coEvery { refreshAuthJwt(AuthTest.REFRESH_TOKEN) } returns Result.Success(
+            AuthJwt(AuthTest.REFRESHED_JWT_TOKEN, null)
         )
 
         coEvery { refreshAuthJwt(NO_REFRESH_TOKEN) } returns Result.Failure(
             ErrorCode.RefreshAuthTokenFailure,
-            ErrorTest.Message,
+            ErrorTest.MESSAGE,
         )
     }
 
@@ -101,15 +101,15 @@ class AuthHandlerTest {
 
     @Test
     fun `when authorize() success and autoRefreshTokenWhenExpired is enabled`() {
-        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, AuthTest.RefreshToken)
+        val expectedAuthJwt = AuthJwt(AuthTest.JWT_TOKEN, AuthTest.REFRESH_TOKEN)
 
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
 
         coVerify {
             mockWebMessagingApi.fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier
+                AuthTest.AUTH_CODE,
+                AuthTest.REDIRECT_URI,
+                AuthTest.CODE_VERIFIER
             )
         }
         verify { mockEventHandler.onEvent(Event.Authorized) }
@@ -122,15 +122,15 @@ class AuthHandlerTest {
     fun `when authorize() success and autoRefreshTokenWhenExpired is disabled`() {
         subject = buildAuthHandler(false)
 
-        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
+        val expectedAuthJwt = AuthJwt(AuthTest.JWT_TOKEN, NO_REFRESH_TOKEN)
 
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
 
         coVerify {
             mockWebMessagingApi.fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier
+                AuthTest.AUTH_CODE,
+                AuthTest.REDIRECT_URI,
+                AuthTest.CODE_VERIFIER
             )
         }
         verify { mockEventHandler.onEvent(Event.Authorized) }
@@ -141,18 +141,18 @@ class AuthHandlerTest {
     @Test
     fun `when authorize() success but refreshToken is null`() {
         coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns
-            Result.Success(AuthJwt(AuthTest.JwtToken, null))
+            Result.Success(AuthJwt(AuthTest.JWT_TOKEN, null))
         subject = buildAuthHandler()
 
-        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
+        val expectedAuthJwt = AuthJwt(AuthTest.JWT_TOKEN, NO_REFRESH_TOKEN)
 
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
 
         coVerify {
             mockWebMessagingApi.fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier
+                AuthTest.AUTH_CODE,
+                AuthTest.REDIRECT_URI,
+                AuthTest.CODE_VERIFIER
             )
         }
         verify { mockEventHandler.onEvent(Event.Authorized) }
@@ -163,23 +163,23 @@ class AuthHandlerTest {
     @Test
     fun `when authorize() failure`() {
         val expectedErrorCode = ErrorCode.AuthFailed
-        val expectedErrorMessage = ErrorTest.Message
+        val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
         coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns Result.Failure(
             ErrorCode.AuthFailed,
-            ErrorTest.Message
+            ErrorTest.MESSAGE
         )
 
         val expectedAuthJwt = AuthJwt(NO_JWT, NO_REFRESH_TOKEN)
 
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
 
         coVerify {
             mockWebMessagingApi.fetchAuthJwt(
-                AuthTest.AuthCode,
-                AuthTest.RedirectUri,
-                AuthTest.CodeVerifier
+                AuthTest.AUTH_CODE,
+                AuthTest.REDIRECT_URI,
+                AuthTest.CODE_VERIFIER
             )
         }
         verify {
@@ -201,17 +201,17 @@ class AuthHandlerTest {
     fun `when authorize() failure with CancellationException`() {
         coEvery { mockWebMessagingApi.fetchAuthJwt(any(), any(), any()) } returns Result.Failure(
             ErrorCode.CancellationError,
-            ErrorTest.Message
+            ErrorTest.MESSAGE
         )
 
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
 
         verify { mockLogger.w(capture(logSlot)) }
         verify(exactly = 0) {
             mockEventHandler.onEvent(
                 Event.Error(
                     ErrorCode.CancellationError,
-                    ErrorTest.Message,
+                    ErrorTest.MESSAGE,
                     CorrectiveAction.ReAuthenticate
                 )
             )
@@ -226,14 +226,14 @@ class AuthHandlerTest {
         subject.logout()
 
         coVerify {
-            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken)
+            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
         }
     }
 
     @Test
     fun `when logout() failed because of invalid jwt`() {
         val expectedErrorCode = ErrorCode.AuthLogoutFailed
-        val expectedErrorMessage = ErrorTest.Message
+        val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
         subject.logout()
@@ -258,18 +258,18 @@ class AuthHandlerTest {
     fun `when authorized and logout() failed because of 401 but autoRefreshTokenWhenExpired is disabled`() {
         subject = buildAuthHandler(givenAutoRefreshTokenWhenExpired = false)
         authorize()
-        coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken) } returns Result.Failure(
+        coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN) } returns Result.Failure(
             ErrorCode.ClientResponseError(401),
-            ErrorTest.Message
+            ErrorTest.MESSAGE
         )
         val expectedErrorCode = ErrorCode.ClientResponseError(401)
-        val expectedErrorMessage = ErrorTest.Message
+        val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
         subject.logout()
 
         coVerify {
-            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken)
+            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
         }
         verify {
             mockLogger.e(capture(logSlot))
@@ -289,20 +289,20 @@ class AuthHandlerTest {
         authorize()
         coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(any()) } returns Result.Failure(
             ErrorCode.ClientResponseError(401),
-            ErrorTest.Message
+            ErrorTest.MESSAGE
         )
         val expectedErrorCode = ErrorCode.ClientResponseError(401)
-        val expectedErrorMessage = ErrorTest.Message
+        val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
         subject.logout()
 
         coVerify(exactly = 1) {
-            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken)
+            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
         }
         coVerify(exactly = MAX_LOGOUT_ATTEMPTS) {
-            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.RefreshedJWTToken)
-            mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken)
+            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.REFRESHED_JWT_TOKEN)
+            mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
         }
         verify(exactly = 1) {
             mockLogger.e(capture(logSlot))
@@ -320,24 +320,24 @@ class AuthHandlerTest {
     @Test
     fun `when authorized and logout() failed because of 401 and autoRefreshTokenWhenExpired is enabled but refreshToken() fails`() {
         authorize()
-        coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken) } returns Result.Failure(
+        coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN) } returns Result.Failure(
             ErrorCode.ClientResponseError(401),
-            ErrorTest.Message
+            ErrorTest.MESSAGE
         )
-        coEvery { mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken) } returns Result.Failure(
+        coEvery { mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN) } returns Result.Failure(
             ErrorCode.RefreshAuthTokenFailure,
-            ErrorTest.Message,
+            ErrorTest.MESSAGE,
         )
         val expectedAuthJwt = AuthJwt(NO_JWT, NO_REFRESH_TOKEN)
         val expectedErrorCode = ErrorCode.RefreshAuthTokenFailure
-        val expectedErrorMessage = ErrorTest.Message
+        val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
         subject.logout()
 
         coVerify(exactly = 1) {
-            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JwtToken)
-            mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken)
+            mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
+            mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
             mockEventHandler.onEvent(
                 Event.Error(
                     expectedErrorCode,
@@ -360,7 +360,7 @@ class AuthHandlerTest {
         subject.refreshToken { result -> mockCallback.captured = result }
 
         verify { mockLogger.e(capture(logSlot)) }
-        coVerify(exactly = 0) { mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken) }
+        coVerify(exactly = 0) { mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN) }
         assertThat(mockCallback.captured).isEqualTo(Result.Failure(expectedErrorCode, expectedErrorMessage))
         assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
         assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
@@ -372,14 +372,14 @@ class AuthHandlerTest {
         subject = buildAuthHandler(givenAutoRefreshTokenWhenExpired = false)
         authorize()
         val mockCallback = slot<Result<Empty>>()
-        val expectedAuthJwt = AuthJwt(AuthTest.JwtToken, NO_REFRESH_TOKEN)
+        val expectedAuthJwt = AuthJwt(AuthTest.JWT_TOKEN, NO_REFRESH_TOKEN)
         val expectedErrorCode = ErrorCode.RefreshAuthTokenFailure
         val expectedErrorMessage = ErrorMessage.AutoRefreshTokenDisabled
 
         subject.refreshToken { result -> mockCallback.captured = result }
 
         verify { mockLogger.e(capture(logSlot)) }
-        coVerify(exactly = 0) { mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken) }
+        coVerify(exactly = 0) { mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN) }
         assertThat(mockCallback.captured).isEqualTo(Result.Failure(expectedErrorCode, expectedErrorMessage))
         assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
         assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
@@ -390,12 +390,12 @@ class AuthHandlerTest {
     fun `when authorized and refreshToken() success`() {
         authorize()
         val mockCallback = slot<Result<Empty>>()
-        val expectedAuthJwt = AuthJwt(AuthTest.RefreshedJWTToken, AuthTest.RefreshToken)
+        val expectedAuthJwt = AuthJwt(AuthTest.REFRESHED_JWT_TOKEN, AuthTest.REFRESH_TOKEN)
 
         subject.refreshToken { result -> mockCallback.captured = result }
 
         coVerify {
-            mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken)
+            mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
             mockLogger.i(capture(logSlot))
         }
         assertThat(mockCallback.captured).isInstanceOf(Result.Success::class.java)
@@ -410,7 +410,7 @@ class AuthHandlerTest {
         authorize()
         coEvery { mockWebMessagingApi.refreshAuthJwt(any()) } returns Result.Failure(
             ErrorCode.RefreshAuthTokenFailure,
-            ErrorTest.Message,
+            ErrorTest.MESSAGE,
         )
         val mockCallback = slot<Result<Empty>>()
         val expectedAuthJwt = AuthJwt(NO_JWT, NO_REFRESH_TOKEN)
@@ -418,13 +418,13 @@ class AuthHandlerTest {
         subject.refreshToken { result -> mockCallback.captured = result }
 
         coVerify {
-            mockWebMessagingApi.refreshAuthJwt(AuthTest.RefreshToken)
+            mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
             mockLogger.e(capture(logSlot))
         }
-        assertThat(mockCallback.captured).isEqualTo(Result.Failure(ErrorCode.RefreshAuthTokenFailure, ErrorTest.Message))
+        assertThat(mockCallback.captured).isEqualTo(Result.Failure(ErrorCode.RefreshAuthTokenFailure, ErrorTest.MESSAGE))
         assertThat(subject.jwt).isEqualTo(expectedAuthJwt.jwt)
         assertThat(fakeVault.authRefreshToken).isEqualTo(expectedAuthJwt.refreshToken)
-        assertThat(logSlot.captured.invoke()).isEqualTo(LogMessages.couldNotRefreshAuthToken(ErrorTest.Message))
+        assertThat(logSlot.captured.invoke()).isEqualTo(LogMessages.couldNotRefreshAuthToken(ErrorTest.MESSAGE))
     }
 
     @Test
@@ -440,8 +440,8 @@ class AuthHandlerTest {
 
     @Test
     fun `when serialize AuthJwt`() {
-        val givenAuthJwt = AuthJwt(AuthTest.JwtToken, AuthTest.RefreshToken)
-        val givenAuthJwtWithoutRefreshToken = AuthJwt(AuthTest.JwtToken)
+        val givenAuthJwt = AuthJwt(AuthTest.JWT_TOKEN, AuthTest.REFRESH_TOKEN)
+        val givenAuthJwtWithoutRefreshToken = AuthJwt(AuthTest.JWT_TOKEN)
         val expectedAuthJwtAsJson = """{"jwt":"jwt_Token","refreshToken":"refresh_token"}"""
         val expectedAuthJwtWithoutRefreshTokenAsJson = """{"jwt":"jwt_Token"}"""
 
@@ -454,8 +454,8 @@ class AuthHandlerTest {
 
     @Test
     fun `when serialize RefreshToken`() {
-        val refreshToken = RefreshToken(AuthTest.RefreshToken)
-        val expectedRefreshTokenAsJson = """{"refreshToken":"${AuthTest.RefreshToken}"}"""
+        val refreshToken = RefreshToken(AuthTest.REFRESH_TOKEN)
+        val expectedRefreshTokenAsJson = """{"refreshToken":"${AuthTest.REFRESH_TOKEN}"}"""
 
         val encoded = WebMessagingJson.json.encodeToString(refreshToken)
         val decoded = WebMessagingJson.json.decodeFromString<RefreshToken>(expectedRefreshTokenAsJson)
@@ -466,10 +466,10 @@ class AuthHandlerTest {
 
     @Test
     fun `validate default constructor of AuthJwt`() {
-        val authJwt = AuthJwt(jwt = AuthTest.JwtAuthUrl)
+        val authJwt = AuthJwt(jwt = AuthTest.JWT_AUTH_URL)
 
         authJwt.run {
-            assertThat(jwt).isEqualTo(AuthTest.JwtAuthUrl)
+            assertThat(jwt).isEqualTo(AuthTest.JWT_AUTH_URL)
             assertThat(refreshToken).isNull()
         }
     }
@@ -485,6 +485,6 @@ class AuthHandlerTest {
     }
 
     private fun authorize() {
-        subject.authorize(AuthTest.AuthCode, AuthTest.RedirectUri, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.REDIRECT_URI, AuthTest.CODE_VERIFIER)
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -87,31 +87,31 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when prepare()`() {
         val expectedAttachment = Attachment(
-            AttachmentValues.Id,
-            AttachmentValues.FileName,
+            AttachmentValues.ID,
+            AttachmentValues.FILE_NAME,
             null,
             State.Presigning
         )
-        val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(AttachmentValues.FileSize))
+        val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(AttachmentValues.FILE_SIZE))
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             fileType = "image/png",
-            fileSize = AttachmentValues.FileSize,
+            fileSize = AttachmentValues.FILE_SIZE,
             null,
             true,
         )
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, ByteArray(AttachmentValues.FileSize), AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, ByteArray(AttachmentValues.FILE_SIZE), AttachmentValues.FILE_NAME)
 
         verify {
             mockLogger.i(capture(logSlot))
             mockAttachmentListener.invoke(capture(attachmentSlot))
         }
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
-        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.ID to expectedProcessedAttachment)
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.presigningAttachment(
@@ -124,11 +124,11 @@ internal class AttachmentHandlerImplTest {
     fun `when upload() processed attachment`() {
         val expectedProgress = 25f
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, null, State.Uploading)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, null, State.Uploading)
         val mockUploadProgress: ((Float) -> Unit) = spyk()
         val progressSlot = slot<Float>()
         givenPrepareCalled(uploadProgress = mockUploadProgress)
-        val expectedPresignedUrlResponse = givenPresignedUrlResponse.copy(fileName = AttachmentValues.FileName)
+        val expectedPresignedUrlResponse = givenPresignedUrlResponse.copy(fileName = AttachmentValues.FILE_NAME)
 
         subject.upload(givenPresignedUrlResponse)
 
@@ -167,7 +167,7 @@ internal class AttachmentHandlerImplTest {
             "something went wrong"
         )
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
+            id = AttachmentValues.ID,
             state = expectedState,
         )
         givenPrepareCalled()
@@ -181,7 +181,7 @@ internal class AttachmentHandlerImplTest {
             mockAttachmentListener.invoke(capture(attachmentSlotList))
         }
         assertThat(attachmentSlotList[1]).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.attachmentError(
                 expectedAttachment.id,
@@ -199,8 +199,8 @@ internal class AttachmentHandlerImplTest {
             "upload was cancelled."
         )
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            id = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             state = State.Uploading,
         )
         givenPrepareCalled()
@@ -213,7 +213,7 @@ internal class AttachmentHandlerImplTest {
             mockAttachmentListener.invoke(capture(attachmentSlotList))
         }
         assertThat(attachmentSlotList[1]).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isTrue()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isTrue()
     }
 
     @Test
@@ -221,7 +221,7 @@ internal class AttachmentHandlerImplTest {
         val expectedDownloadUrl = "http://somedownloadurl.com"
         val expectedState = State.Uploaded(expectedDownloadUrl)
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, null, expectedState)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, null, expectedState)
         val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(1))
         givenPrepareCalled()
 
@@ -236,7 +236,7 @@ internal class AttachmentHandlerImplTest {
             assertThat(state).isEqualTo(expectedState)
             assertThat((state as State.Uploaded).downloadUrl).isEqualTo(expectedDownloadUrl)
         }
-        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.ID to expectedProcessedAttachment)
         assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.attachmentUploaded(expectedAttachment))
     }
 
@@ -254,14 +254,14 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when detach() on uploaded attachment`() {
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, null, State.Detaching)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, null, State.Detaching)
         val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(1))
         val expectedDeleteAttachmentRequest =
-            DeleteAttachmentRequest(TestValues.Token, AttachmentValues.Id)
+            DeleteAttachmentRequest(TestValues.TOKEN, AttachmentValues.ID)
         givenPrepareCalled()
         givenUploadSuccessCalled()
 
-        val result = subject.detach(TestValues.Token, AttachmentValues.Id)
+        val result = subject.detach(TestValues.TOKEN, AttachmentValues.ID)
 
         verify {
             mockLogger.i(capture(logSlot))
@@ -269,18 +269,18 @@ internal class AttachmentHandlerImplTest {
         }
         assertThat(result).isEqualTo(expectedDeleteAttachmentRequest)
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.ID to expectedProcessedAttachment)
         assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.detachingAttachment(expectedAttachment.id))
     }
 
     @Test
     fun `when detach() on not uploaded attachment`() {
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, null, State.Detached)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, null, State.Detached)
 
         givenPrepareCalled()
 
-        val result = subject.detach(TestValues.Token, AttachmentValues.Id)
+        val result = subject.detach(TestValues.TOKEN, AttachmentValues.ID)
 
         verify {
             mockLogger.i(capture(logSlot))
@@ -288,7 +288,7 @@ internal class AttachmentHandlerImplTest {
         }
         assertThat(result).isNull()
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.detachingAttachment(expectedAttachment.id))
     }
 
@@ -297,7 +297,7 @@ internal class AttachmentHandlerImplTest {
         val givenAttachmentId = TestValues.DEFAULT_STRING
 
         val exception = assertFailsWith<IllegalArgumentException> {
-            subject.detach(TestValues.Token, givenAttachmentId)
+            subject.detach(TestValues.TOKEN, givenAttachmentId)
         }
         assertThat(exception.message).isEqualTo(ErrorMessage.detachFailed(givenAttachmentId))
 
@@ -307,18 +307,18 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when OnDetached()`() {
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, null, State.Detached)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, null, State.Detached)
         givenPrepareCalled()
         givenUploadSuccessCalled()
 
-        subject.onDetached(AttachmentValues.Id)
+        subject.onDetached(AttachmentValues.ID)
 
         verify {
             mockLogger.i(capture(logSlot))
             mockAttachmentListener.invoke(capture(attachmentSlot))
         }
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.attachmentDetached(expectedAttachment.id))
     }
 
@@ -326,12 +326,12 @@ internal class AttachmentHandlerImplTest {
     fun `when OnError()`() {
         val expectedState = State.Error(ErrorCode.FileTypeInvalid, "something went wrong")
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
+            id = AttachmentValues.ID,
             state = expectedState,
         )
         givenPrepareCalled()
 
-        subject.onError(AttachmentValues.Id, ErrorCode.mapFrom(4001), "something went wrong")
+        subject.onError(AttachmentValues.ID, ErrorCode.mapFrom(4001), "something went wrong")
 
         verify {
             mockLogger.e(capture(logSlot))
@@ -344,7 +344,7 @@ internal class AttachmentHandlerImplTest {
             assertThat((state as State.Error).errorCode).isEqualTo(expectedState.errorCode)
             assertThat((state as State.Error).errorMessage).isEqualTo(expectedState.errorMessage)
         }
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.attachmentError(
                 expectedAttachment.id,
@@ -358,7 +358,7 @@ internal class AttachmentHandlerImplTest {
     fun `when OnMessageError() while has sending attachment`() {
         val expectedState = State.Error(ErrorCode.MessageTooLong, "Message too long")
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
+            id = AttachmentValues.ID,
             state = expectedState,
         )
         givenPrepareCalled()
@@ -378,7 +378,7 @@ internal class AttachmentHandlerImplTest {
             assertThat((state as State.Error).errorCode).isEqualTo(expectedState.errorCode)
             assertThat((state as State.Error).errorMessage).isEqualTo(expectedState.errorMessage)
         }
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.attachmentError(
                 expectedAttachment.id,
@@ -392,7 +392,7 @@ internal class AttachmentHandlerImplTest {
     fun whenOnMessageErrorWithNullErrorMessage() {
         val expectedState = State.Error(ErrorCode.MessageTooLong, "")
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
+            id = AttachmentValues.ID,
             state = expectedState,
         )
         givenPrepareCalled()
@@ -412,7 +412,7 @@ internal class AttachmentHandlerImplTest {
             assertThat((state as State.Error).errorCode).isEqualTo(expectedState.errorCode)
             assertThat((state as State.Error).errorMessage).isEqualTo(expectedState.errorMessage)
         }
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.attachmentError(
                 expectedAttachment.id,
@@ -432,8 +432,8 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when onSending() has uploaded attachment`() {
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            id = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             state = State.Sending
         )
         val expectedProcessedAttachment =
@@ -448,7 +448,7 @@ internal class AttachmentHandlerImplTest {
             mockAttachmentListener.invoke(capture(attachmentSlot))
         }
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
-        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.ID to expectedProcessedAttachment)
         assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.sendingAttachment(expectedAttachment.id))
     }
 
@@ -466,17 +466,17 @@ internal class AttachmentHandlerImplTest {
         val expectedDownloadUrl = "http://somedownloadurl.com"
         val expectedState = State.Sent(expectedDownloadUrl)
         val expectedAttachment =
-            Attachment(AttachmentValues.Id, AttachmentValues.FileName, AttachmentValues.FileSize, expectedState)
+            Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME, AttachmentValues.FILE_SIZE, expectedState)
         givenPrepareCalled()
         givenUploadSuccessCalled()
         givenOnSendingCalled()
 
         subject.onSent(
             mapOf(
-                AttachmentValues.Id to Attachment(
-                    AttachmentValues.Id,
-                    AttachmentValues.FileName,
-                    AttachmentValues.FileSize,
+                AttachmentValues.ID to Attachment(
+                    AttachmentValues.ID,
+                    AttachmentValues.FILE_NAME,
+                    AttachmentValues.FILE_SIZE,
                     State.Sent("http://somedownloadurl.com")
                 )
             )
@@ -491,7 +491,7 @@ internal class AttachmentHandlerImplTest {
             assertThat(state).isEqualTo(expectedState)
             assertThat((state as State.Sent).downloadUrl).isEqualTo(expectedDownloadUrl)
         }
-        assertThat(processedAttachments.containsKey(AttachmentValues.Id)).isFalse()
+        assertThat(processedAttachments.containsKey(AttachmentValues.ID)).isFalse()
         assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.attachmentSent(
                 mapOf(
@@ -505,10 +505,10 @@ internal class AttachmentHandlerImplTest {
     fun `when onSent() on not processed Attachment`() {
         subject.onSent(
             mapOf(
-                AttachmentValues.Id to Attachment(
-                    AttachmentValues.Id,
-                    AttachmentValues.FileName,
-                    AttachmentValues.FileSize,
+                AttachmentValues.ID to Attachment(
+                    AttachmentValues.ID,
+                    AttachmentValues.FILE_NAME,
+                    AttachmentValues.FILE_SIZE,
                     State.Sent("http://somedownloadurl.com")
                 )
             )
@@ -530,9 +530,9 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when prepare() but fileAttachmentProfile is not set`() {
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             fileType = "image/png",
             2000,
             null,
@@ -542,7 +542,7 @@ internal class AttachmentHandlerImplTest {
         val givenByteArray = ByteArray(2000)
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
 
         assertThat(subject.fileAttachmentProfile).isNull()
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -555,7 +555,7 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 1)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
         }
     }
 
@@ -565,9 +565,9 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 2)
         val expectedFileSizeInKB = 2L
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             fileType = "image/png",
             2000,
             null,
@@ -575,7 +575,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
 
         assertThat(subject.fileAttachmentProfile?.maxFileSizeKB).isEqualTo(expectedFileSizeInKB)
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -588,7 +588,7 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 2)
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
         }
     }
 
@@ -598,9 +598,9 @@ internal class AttachmentHandlerImplTest {
         subject.fileAttachmentProfile = FileAttachmentProfile(enabled = true, maxFileSizeKB = 100)
         val expectedFileSizeInKB = 100L
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             fileType = "image/png",
             2000,
             null,
@@ -608,7 +608,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
 
         assertThat(subject.fileAttachmentProfile?.maxFileSizeKB).isEqualTo(expectedFileSizeInKB)
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
@@ -626,7 +626,7 @@ internal class AttachmentHandlerImplTest {
             )
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, "foo.exe")
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, "foo.exe")
         }
     }
 
@@ -640,9 +640,9 @@ internal class AttachmentHandlerImplTest {
                 blockedFileTypes = listOf(".exe")
             )
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             fileType = "image/png",
             1,
             null,
@@ -650,7 +650,7 @@ internal class AttachmentHandlerImplTest {
         )
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
 
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
     }
@@ -662,21 +662,21 @@ internal class AttachmentHandlerImplTest {
         val expectedExceptionMessage = ErrorMessage.FileAttachmentIsDisabled
 
         assertFailsWith<IllegalArgumentException>(expectedExceptionMessage) {
-            subject.prepare(TestValues.Token, AttachmentValues.Id, givenByteArray, AttachmentValues.FileName)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, givenByteArray, AttachmentValues.FILE_NAME)
         }
     }
 
     @Test
     fun `when onAttachmentRefreshed()`() {
         val givenPresignedUrlResponse = PresignedUrlResponse(
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             url = "https://refreshedUrl.com",
             headers = emptyMap(),
         )
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
+            id = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
             state = State.Refreshed("https://refreshedUrl.com")
         )
 
@@ -688,20 +688,20 @@ internal class AttachmentHandlerImplTest {
 
     @Test
     fun whenSerializeAttachment() {
-        val expectedAttachmentJson = """{"id":"${AttachmentValues.Id}"}"""
-        val givenAttachment = Attachment(AttachmentValues.Id, AttachmentValues.FileName)
+        val expectedAttachmentJson = """{"id":"${AttachmentValues.ID}"}"""
+        val givenAttachment = Attachment(AttachmentValues.ID, AttachmentValues.FILE_NAME)
 
         val attachmentJson = WebMessagingJson.json.encodeToString(givenAttachment)
 
         assertThat(attachmentJson).isEqualTo(expectedAttachmentJson)
     }
 
-    private fun presignedUrlResponse(id: String = AttachmentValues.Id): PresignedUrlResponse =
+    private fun presignedUrlResponse(id: String = AttachmentValues.ID): PresignedUrlResponse =
         PresignedUrlResponse(
             id, mapOf("header" to "given header"), "http://someuploadurl.com",
         )
 
-    private fun uploadSuccessEvent(id: String = AttachmentValues.Id): UploadSuccessEvent =
+    private fun uploadSuccessEvent(id: String = AttachmentValues.ID): UploadSuccessEvent =
         UploadSuccessEvent(
             id, "http://somedownloadurl.com", "2021-08-17T17:00:08.746Z",
         )
@@ -711,13 +711,13 @@ internal class AttachmentHandlerImplTest {
      * Executes the subject.prepare() call with given values and clearMocks related to this call.
      */
     private fun givenPrepareCalled(
-        attachmentId: String = AttachmentValues.Id,
+        attachmentId: String = AttachmentValues.ID,
         byteArray: ByteArray = ByteArray(1),
-        fileName: String = AttachmentValues.FileName,
+        fileName: String = AttachmentValues.FILE_NAME,
         uploadProgress: ((Float) -> Unit)? = null,
     ) {
         subject.prepare(
-            token = TestValues.Token,
+            token = TestValues.TOKEN,
             attachmentId = attachmentId,
             byteArray = byteArray,
             fileName = fileName,

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -123,31 +123,31 @@ internal class AttachmentHandlerImplTest {
     @Test
     fun `when prepare() txt file`() {
         val expectedAttachment = Attachment(
-            AttachmentValues.Id,
+            AttachmentValues.ID,
             AttachmentValues.TXT_FILE_NAME,
             null,
             State.Presigning
         )
-        val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(AttachmentValues.FileSize))
+        val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(AttachmentValues.FILE_SIZE))
         val expectedOnAttachmentRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
             fileName = AttachmentValues.TXT_FILE_NAME,
             fileType = "text/plain",
-            fileSize = AttachmentValues.FileSize,
+            fileSize = AttachmentValues.FILE_SIZE,
             null,
             true,
         )
 
         val onAttachmentRequest =
-            subject.prepare(TestValues.Token, AttachmentValues.Id, ByteArray(AttachmentValues.FileSize), AttachmentValues.TXT_FILE_NAME)
+            subject.prepare(TestValues.TOKEN, AttachmentValues.ID, ByteArray(AttachmentValues.FILE_SIZE), AttachmentValues.TXT_FILE_NAME)
 
         verify {
             mockLogger.i(capture(logSlot))
             mockAttachmentListener.invoke(capture(attachmentSlot))
         }
         assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
-        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.ID to expectedProcessedAttachment)
         assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
         assertThat(logSlot[0].invoke()).isEqualTo(
             LogMessages.presigningAttachment(

--- a/transport/src/androidUnitTest/kotlin/transport/core/CustomAttributesStoreTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/CustomAttributesStoreTest.kt
@@ -29,7 +29,7 @@ class CustomAttributesStoreTest {
     private val logSlot = mutableListOf<() -> String>()
     private val mockEventHandler = mockk<EventHandler>(relaxed = true)
     private var subject: CustomAttributesStoreImpl =
-        CustomAttributesStoreImpl(mockLogger, mockEventHandler).also { it.maxCustomDataBytes = TestValues.MaxCustomDataBytes }
+        CustomAttributesStoreImpl(mockLogger, mockEventHandler).also { it.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES }
 
     @Test
     fun `when add a new customAttribute`() {
@@ -252,7 +252,7 @@ class CustomAttributesStoreTest {
 
     @Test
     fun `when maxCustomDataBytes is set`() {
-        val expectedMaxCustomDataBytes = TestValues.MaxCustomDataBytes
+        val expectedMaxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
 
         subject.maxCustomDataBytes = expectedMaxCustomDataBytes
 
@@ -298,7 +298,7 @@ class CustomAttributesStoreTest {
     fun `when maxCustomDataBytes is updated with valid size and ca are already added`() {
         // Given
         subject = CustomAttributesStoreImpl(mockLogger, mockEventHandler)
-        val givenMaxCustomDataBytes = TestValues.MaxCustomDataBytes
+        val givenMaxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
         val givenCustomAttributes = TestValues.defaultMap
         val expectedCustomAttributes = TestValues.defaultMap
         val result = subject.add(givenCustomAttributes)
@@ -317,7 +317,7 @@ class CustomAttributesStoreTest {
     fun `when custom attributes are already added but are bigger than updated maxCustomDataBytes`() {
         // Given
         subject = CustomAttributesStoreImpl(mockLogger, mockEventHandler)
-        val givenMaxCustomDataBytes = TestValues.DefaultNumber
+        val givenMaxCustomDataBytes = TestValues.DEFAULT_NUMBER
         val givenCustomAttributes = TestValues.defaultMap
         val result = subject.add(givenCustomAttributes)
         assertThat(subject.maxCustomDataBytes).isEqualTo(MAX_CUSTOM_DATA_BYTES_UNSET)

--- a/transport/src/androidUnitTest/kotlin/transport/core/JwtHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/JwtHandlerTest.kt
@@ -50,36 +50,36 @@ class JwtHandlerTest {
     @Test
     fun `when withJwt() and jwtResponse is valid`() = runBlocking {
         val givenExpiry = Platform().epochMillis()
-        val givenJwtResponse = JwtResponse(AuthTest.JwtToken, givenExpiry)
+        val givenJwtResponse = JwtResponse(AuthTest.JWT_TOKEN, givenExpiry)
         subject.jwtResponse = givenJwtResponse
 
         subject.withJwt(Request.token, mockJwtFn)
 
-        coVerify { mockJwtFn(AuthTest.JwtToken) }
+        coVerify { mockJwtFn(AuthTest.JWT_TOKEN) }
         coVerify(exactly = 0) { mockWebSocket.sendMessage(Request.jwt) }
-        assertThat(slot.captured).isEqualTo(AuthTest.JwtToken)
+        assertThat(slot.captured).isEqualTo(AuthTest.JWT_TOKEN)
         subject.jwtResponse.run {
             assertThat(this).isEqualTo(givenJwtResponse)
-            assertThat(jwt).isEqualTo(AuthTest.JwtToken)
+            assertThat(jwt).isEqualTo(AuthTest.JWT_TOKEN)
             assertThat(exp).isEqualTo(givenExpiry)
         }
     }
 
     @Test
     fun `when withJwt() and jwtResponse is invalid`() = runBlocking {
-        val givenJwtResponse = JwtResponse(AuthTest.JwtToken, 0)
+        val givenJwtResponse = JwtResponse(AuthTest.JWT_TOKEN, 0)
         subject.jwtResponse = givenJwtResponse
 
         subject.withJwt(Request.token, mockJwtFn)
 
         coVerify {
-            mockJwtFn(AuthTest.JwtToken)
+            mockJwtFn(AuthTest.JWT_TOKEN)
             mockWebSocket.sendMessage(Request.jwt)
         }
-        assertThat(slot.captured).isEqualTo(AuthTest.JwtToken)
+        assertThat(slot.captured).isEqualTo(AuthTest.JWT_TOKEN)
         subject.jwtResponse.run {
             assertThat(this).isEqualTo(givenJwtResponse)
-            assertThat(jwt).isEqualTo(AuthTest.JwtToken)
+            assertThat(jwt).isEqualTo(AuthTest.JWT_TOKEN)
             assertThat(exp).isEqualTo(0)
         }
     }
@@ -87,7 +87,7 @@ class JwtHandlerTest {
     @Test
     fun `when clear() after jwt was set`() {
         val expectedJwtResponse = JwtResponse()
-        subject.jwtResponse = JwtResponse(AuthTest.JwtToken, Platform().epochMillis())
+        subject.jwtResponse = JwtResponse(AuthTest.JWT_TOKEN, Platform().epochMillis())
 
         subject.clear()
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
@@ -103,8 +103,8 @@ internal class MessageExtensionTest {
                 time = isoTestTimestamp,
                 from = StructuredMessage.Participant(
                     nickname = "Bob",
-                    firstName = MessageValues.ParticipantName,
-                    lastName = MessageValues.ParticipantLastName,
+                    firstName = MessageValues.PARTICIPANT_NAME,
+                    lastName = MessageValues.PARTICIPANT_LAST_NAME,
                     image = "http://image.png",
                 )
             ),
@@ -149,7 +149,7 @@ internal class MessageExtensionTest {
                         state = Attachment.State.Sent("http://test.com")
                     )
                 ),
-                events = listOf(Event.ConversationAutostart, Event.SignedIn(MessageValues.ParticipantName, MessageValues.ParticipantLastName)),
+                events = listOf(Event.ConversationAutostart, Event.SignedIn(MessageValues.PARTICIPANT_NAME, MessageValues.PARTICIPANT_LAST_NAME)),
                 from = Participant(
                     name = "Bob",
                     imageUrl = "http://image.png",
@@ -184,7 +184,7 @@ internal class MessageExtensionTest {
                     "first test attachment id" to Attachment(
                         id = "first test attachment id",
                         fileName = "test.png",
-                        fileSizeInBytes = AttachmentValues.FileSize,
+                        fileSizeInBytes = AttachmentValues.FILE_SIZE,
                         Attachment.State.Uploaded("http://test.com")
                     ),
                     "second test attachment id" to Attachment(
@@ -200,7 +200,7 @@ internal class MessageExtensionTest {
             attachment = Attachment(
                 id = "first test attachment id",
                 fileName = "test.png",
-                fileSizeInBytes = AttachmentValues.FileSize,
+                fileSizeInBytes = AttachmentValues.FILE_SIZE,
                 state = Attachment.State.Uploaded("http://test.com")
             )
         )
@@ -400,12 +400,12 @@ internal class MessageExtensionTest {
             content = listOf(QuickReplyTestValues.createQuickReplyContentForTesting())
         )
         val expectedButtonResponse = ButtonResponse(
-            text = QuickReplyTestValues.Text_A,
-            payload = QuickReplyTestValues.Payload_A,
-            type = QuickReplyTestValues.QuickReply
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.QUICK_REPLY
         )
         val expectedMessage = Message(
-            id = MessageValues.Id,
+            id = MessageValues.ID,
             state = State.Sent,
             type = Type.QuickReply.name,
             messageType = Type.QuickReply,
@@ -424,12 +424,12 @@ internal class MessageExtensionTest {
             content = listOf(QuickReplyTestValues.createButtonResponseContentForTesting())
         )
         val expectedButtonResponse = ButtonResponse(
-            text = QuickReplyTestValues.Text_A,
-            payload = QuickReplyTestValues.Payload_A,
-            type = QuickReplyTestValues.QuickReply
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.QUICK_REPLY
         )
         val expectedMessage = Message(
-            id = MessageValues.Id,
+            id = MessageValues.ID,
             state = State.Sent,
             type = Type.QuickReply.name,
             messageType = Type.QuickReply,
@@ -451,12 +451,12 @@ internal class MessageExtensionTest {
             )
         )
         val expectedButtonResponse = ButtonResponse(
-            text = QuickReplyTestValues.Text_A,
-            payload = QuickReplyTestValues.Payload_A,
-            type = QuickReplyTestValues.QuickReply
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.QUICK_REPLY
         )
         val expectedMessage = Message(
-            id = MessageValues.Id,
+            id = MessageValues.ID,
             state = State.Sent,
             type = Type.QuickReply.name,
             messageType = Type.QuickReply,
@@ -475,7 +475,7 @@ internal class MessageExtensionTest {
         )
 
         val expectedMessage = Message(
-            id = MessageValues.Id,
+            id = MessageValues.ID,
             state = State.Sent,
             type = Type.Unknown.name,
             messageType = Type.Unknown,
@@ -508,10 +508,10 @@ internal class MessageExtensionTest {
         )
         val givenMessageEntityList = MessageEntityList(
             entities = listOf(givenStructuredMessage),
-            pageSize = MessageValues.PageSize,
-            pageNumber = MessageValues.PageNumber,
-            total = MessageValues.Total,
-            pageCount = MessageValues.PageCount,
+            pageSize = MessageValues.PAGE_SIZE,
+            pageNumber = MessageValues.PAGE_NUMBER,
+            total = MessageValues.TOTAL,
+            pageCount = MessageValues.PAGE_COUNT,
         )
 
         val expectedMessageEntityListAsJson =
@@ -533,10 +533,10 @@ internal class MessageExtensionTest {
         )
         val expectedMessageEntityList = MessageEntityList(
             entities = listOf(expectedStructuredMessage),
-            pageSize = MessageValues.PageSize,
-            pageNumber = MessageValues.PageNumber,
-            total = MessageValues.Total,
-            pageCount = MessageValues.PageCount,
+            pageSize = MessageValues.PAGE_SIZE,
+            pageNumber = MessageValues.PAGE_NUMBER,
+            total = MessageValues.TOTAL,
+            pageCount = MessageValues.PAGE_COUNT,
         )
 
         val result =
@@ -555,10 +555,10 @@ internal class MessageExtensionTest {
     @Test
     fun `validate default constructor of MessageEntityList`() {
         val givenMessageEntityList = MessageEntityList(
-            pageSize = MessageValues.PageSize,
-            pageNumber = MessageValues.PageNumber,
-            total = MessageValues.Total,
-            pageCount = MessageValues.PageCount,
+            pageSize = MessageValues.PAGE_SIZE,
+            pageNumber = MessageValues.PAGE_NUMBER,
+            total = MessageValues.TOTAL,
+            pageCount = MessageValues.PAGE_COUNT,
         )
 
         assertThat(givenMessageEntityList.entities).isEmpty()
@@ -567,9 +567,9 @@ internal class MessageExtensionTest {
     @Test
     fun `when PreIdentifiedWebMessagingMessage serialized`() {
         val givenMPreIdentifiedWebMessagingMessage = PreIdentifiedWebMessagingMessage(
-            type = MessageValues.PreIdentifiedMessageType,
-            code = MessageValues.PreIdentifiedMessageCode,
-            className = MessageValues.PreIdentifiedMessageClass,
+            type = MessageValues.PRE_IDENTIFIED_MESSAGE_TYPE,
+            code = MessageValues.PRE_IDENTIFIED_MESSAGE_CODE,
+            className = MessageValues.PRE_IDENTIFIED_MESSAGE_CLASS,
         )
 
         val expectedPreIdentifiedWebMessagingMessageAsJson =
@@ -590,23 +590,23 @@ internal class MessageExtensionTest {
         )
 
         result.run {
-            assertThat(type).isEqualTo(MessageValues.PreIdentifiedMessageType)
-            assertThat(code).isEqualTo(MessageValues.PreIdentifiedMessageCode)
-            assertThat(className).isEqualTo(MessageValues.PreIdentifiedMessageClass)
+            assertThat(type).isEqualTo(MessageValues.PRE_IDENTIFIED_MESSAGE_TYPE)
+            assertThat(code).isEqualTo(MessageValues.PRE_IDENTIFIED_MESSAGE_CODE)
+            assertThat(className).isEqualTo(MessageValues.PRE_IDENTIFIED_MESSAGE_CLASS)
         }
     }
 
     @Test
     fun `when Channel serialized`() {
         val givenChannel = StructuredMessage.Channel(
-            time = TestValues.Timestamp,
-            messageId = MessageValues.Id,
-            type = MessageValues.Type,
+            time = TestValues.TIME_STAMP,
+            messageId = MessageValues.ID,
+            type = MessageValues.TYPE,
             to = StructuredMessage.Participant(
-                firstName = MessageValues.ParticipantName,
-                lastName = MessageValues.ParticipantLastName,
-                nickname = MessageValues.ParticipantNickname,
-                image = MessageValues.ParticipantImageUrl,
+                firstName = MessageValues.PARTICIPANT_NAME,
+                lastName = MessageValues.PARTICIPANT_LAST_NAME,
+                nickname = MessageValues.PARTICIPANT_NICKNAME,
+                image = MessageValues.PARTICIPANT_IMAGE_URL,
             ),
             from = StructuredMessage.Participant(),
         )
@@ -625,14 +625,14 @@ internal class MessageExtensionTest {
         val givenChannelAsJson =
             """{"time":"2022-08-22T19:24:26.704Z","messageId":"test_message_id","type":"Text","to":{"firstName":"participant_name","lastName":"participant_last_name","nickname":"participant_nickname","image":"http://participant.image"},"from":{}}"""
         val expectedChannel = StructuredMessage.Channel(
-            time = TestValues.Timestamp,
-            messageId = MessageValues.Id,
-            type = MessageValues.Type,
+            time = TestValues.TIME_STAMP,
+            messageId = MessageValues.ID,
+            type = MessageValues.TYPE,
             to = StructuredMessage.Participant(
-                firstName = MessageValues.ParticipantName,
-                lastName = MessageValues.ParticipantLastName,
-                nickname = MessageValues.ParticipantNickname,
-                image = MessageValues.ParticipantImageUrl,
+                firstName = MessageValues.PARTICIPANT_NAME,
+                lastName = MessageValues.PARTICIPANT_LAST_NAME,
+                nickname = MessageValues.PARTICIPANT_NICKNAME,
+                image = MessageValues.PARTICIPANT_IMAGE_URL,
             ),
             from = StructuredMessage.Participant(),
         )

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
@@ -39,7 +39,7 @@ import io.mockk.verify
 import org.junit.Test
 
 internal class MessageStoreTest {
-    private val givenToken = TestValues.Token
+    private val givenToken = TestValues.TOKEN
     private val messageSlot = slot<MessageEvent>()
     private val mockLogger: Log = mockk(relaxed = true)
     private val logSlot = mutableListOf<() -> String>()
@@ -61,7 +61,7 @@ internal class MessageStoreTest {
             ),
         )
 
-        subject.prepareMessage(TestValues.Token, "test message").run {
+        subject.prepareMessage(TestValues.TOKEN, "test message").run {
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(time).isNull()
@@ -84,8 +84,8 @@ internal class MessageStoreTest {
     @Test
     fun `when prepareMessage() is called twice`() {
 
-        subject.prepareMessage(TestValues.Token, "message 1")
-        subject.prepareMessage(TestValues.Token, "message 2")
+        subject.prepareMessage(TestValues.TOKEN, "message 1")
+        subject.prepareMessage(TestValues.TOKEN, "message 2")
 
         assertThat(subject.getConversation().size).isEqualTo(2)
     }
@@ -98,7 +98,7 @@ internal class MessageStoreTest {
             )
         )
 
-        subject.prepareMessage(TestValues.Token, "test message").run {
+        subject.prepareMessage(TestValues.TOKEN, "test message").run {
             assertThat(this.message.content).containsOnly(
                 Content(
                     contentType = Content.Type.Attachment,
@@ -113,7 +113,7 @@ internal class MessageStoreTest {
     fun `when prepareMessage() with NOT uploaded attachment`() {
         subject.updateAttachmentStateWith(attachment())
 
-        subject.prepareMessage(TestValues.Token, "test message").run {
+        subject.prepareMessage(TestValues.TOKEN, "test message").run {
             assertThat(message.content).isNotNull()
             assertThat(message.content).isEmpty()
         }
@@ -122,7 +122,7 @@ internal class MessageStoreTest {
     @Test
     fun `when update() inbound message`() {
         val sentMessageId =
-            subject.prepareMessage(TestValues.Token, "test message").message.metadata?.get("customMessageId")
+            subject.prepareMessage(TestValues.TOKEN, "test message").message.metadata?.get("customMessageId")
                 ?: "empty"
         val givenMessage =
             Message(id = sentMessageId, state = State.Sent, text = "test message")
@@ -158,7 +158,7 @@ internal class MessageStoreTest {
     @Test
     fun `when update() inbound and then outbound messages`() {
         val sentMessageId =
-            subject.prepareMessage(TestValues.Token, "test message").message.metadata?.get("customMessageId")
+            subject.prepareMessage(TestValues.TOKEN, "test message").message.metadata?.get("customMessageId")
                 ?: "empty"
         val expectedConversationSize = 2
         val givenMessage =
@@ -340,7 +340,7 @@ internal class MessageStoreTest {
                 state = expectedState,
                 text = testMessage
             )
-        subject.prepareMessage(TestValues.Token, testMessage)
+        subject.prepareMessage(TestValues.TOKEN, testMessage)
         clearMocks(mockMessageListener)
 
         subject.onMessageError(ErrorCode.MessageTooLong, errorMessage)
@@ -358,7 +358,7 @@ internal class MessageStoreTest {
     fun `when messageListener not set`() {
         subject.messageListener = null
 
-        subject.prepareMessage(TestValues.Token, "test message")
+        subject.prepareMessage(TestValues.TOKEN, "test message")
 
         verify { mockMessageListener wasNot Called }
         assertThat(subject.messageListener).isNull()
@@ -392,7 +392,7 @@ internal class MessageStoreTest {
         )
 
         val onMessageRequest =
-            subject.prepareMessage(TestValues.Token, "test message", Channel(Channel.Metadata(mapOf("A" to "B"))))
+            subject.prepareMessage(TestValues.TOKEN, "test message", Channel(Channel.Metadata(mapOf("A" to "B"))))
 
         verify { mockMessageListener.invoke(capture(messageSlot)) }
         onMessageRequest.run {
@@ -487,7 +487,7 @@ internal class MessageStoreTest {
             ),
         )
 
-        subject.prepareMessageWith(TestValues.Token, givenButtonResponse, givenChannel).run {
+        subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse, givenChannel).run {
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(message.content).isEqualTo(expectedOnMessageRequest.message.content)
@@ -524,7 +524,7 @@ internal class MessageStoreTest {
             ),
         )
 
-        subject.prepareMessageWith(TestValues.Token, givenButtonResponse).run {
+        subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse).run {
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(message.content).isEqualTo(expectedOnMessageRequest.message.content)
@@ -553,7 +553,7 @@ internal class MessageStoreTest {
         )
         subject.updateAttachmentStateWith(givenAttachment)
 
-        val result = subject.prepareMessageWith(TestValues.Token, givenButtonResponse)
+        val result = subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse)
 
         assertThat(result.message.content).containsOnly(*expectedContent.toTypedArray())
         assertThat(subject.pendingMessage.attachments).isNotEmpty()
@@ -571,7 +571,7 @@ internal class MessageStoreTest {
     private fun attachment(
         id: String = "given id",
         state: Attachment.State = Attachment.State.Presigning,
-    ) = Attachment(id, "file.png", AttachmentValues.FileSize, state)
+    ) = Attachment(id, "file.png", AttachmentValues.FILE_SIZE, state)
 
     private fun messageList(size: Int = 5): List<Message> {
         val messageList = mutableListOf<Message>()

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageTest.kt
@@ -26,7 +26,7 @@ class MessageTest {
     fun `validate default constructor`() {
         val expectedDirection = Direction.Inbound
         val expectedState = State.Idle
-        val expectedType = MessageValues.Type
+        val expectedType = MessageValues.TYPE
         val expectedMessageType = Message.Type.Text
         val expectedParticipant =
             Participant(originatingEntity = Participant.OriginatingEntity.Human)
@@ -56,36 +56,36 @@ class MessageTest {
 
     @Test
     fun `validate custom constructor`() {
-        val expectedId = MessageValues.Id
+        val expectedId = MessageValues.ID
         val expectedDirection = Direction.Outbound
         val expectedState = State.Sending
         val expectedType = "QuickReply"
         val expectedMessageType = Message.Type.QuickReply
-        val expectedText = MessageValues.Text
-        val expectedTimestamp = MessageValues.TimeStamp
-        val expectedAttachments = mapOf(AttachmentValues.Id to Attachment(AttachmentValues.Id))
+        val expectedText = MessageValues.TEXT
+        val expectedTimestamp = MessageValues.TIME_STAMP
+        val expectedAttachments = mapOf(AttachmentValues.ID to Attachment(AttachmentValues.ID))
         val expectedEvents = listOf(Event.ConversationAutostart)
         val expectedQuickReplies = listOf(QuickReplyTestValues.buttonResponse_a)
         val expectedParticipant = Participant(
-            name = MessageValues.ParticipantName,
-            imageUrl = MessageValues.ParticipantImageUrl,
+            name = MessageValues.PARTICIPANT_NAME,
+            imageUrl = MessageValues.PARTICIPANT_IMAGE_URL,
             originatingEntity = Participant.OriginatingEntity.Bot
         )
 
         val message = Message(
-            id = MessageValues.Id,
+            id = MessageValues.ID,
             direction = Direction.Outbound,
             state = State.Sending,
             type = "QuickReply",
             messageType = Message.Type.QuickReply,
-            text = MessageValues.Text,
-            timeStamp = MessageValues.TimeStamp,
-            attachments = mapOf(AttachmentValues.Id to Attachment(AttachmentValues.Id)),
+            text = MessageValues.TEXT,
+            timeStamp = MessageValues.TIME_STAMP,
+            attachments = mapOf(AttachmentValues.ID to Attachment(AttachmentValues.ID)),
             events = listOf(Event.ConversationAutostart),
             quickReplies = listOf(QuickReplyTestValues.buttonResponse_a),
             from = Participant(
-                name = MessageValues.ParticipantName,
-                imageUrl = MessageValues.ParticipantImageUrl,
+                name = MessageValues.PARTICIPANT_NAME,
+                imageUrl = MessageValues.PARTICIPANT_IMAGE_URL,
                 originatingEntity = Participant.OriginatingEntity.Bot,
             ),
             authenticated = true
@@ -110,13 +110,13 @@ class MessageTest {
     @Test
     fun `validate Content with Attachment serialization`() {
         val expectedAttachment = Attachment(
-            id = AttachmentValues.Id,
+            id = AttachmentValues.ID,
             fileName = null,
             state = Attachment.State.Presigning
         )
         val expectedRequest = Message.Content(
             contentType = Message.Content.Type.Attachment,
-            attachment = Attachment(AttachmentValues.Id)
+            attachment = Attachment(AttachmentValues.ID)
         )
         val expectedJson =
             """{"contentType":"Attachment","attachment":{"id":"test_attachment_id"}}"""
@@ -180,8 +180,8 @@ class MessageTest {
     @Test
     fun `validate Participant serialization`() {
         val expectedRequest = Participant(
-            name = MessageValues.ParticipantName,
-            imageUrl = MessageValues.ParticipantImageUrl,
+            name = MessageValues.PARTICIPANT_NAME,
+            imageUrl = MessageValues.PARTICIPANT_IMAGE_URL,
             originatingEntity = Participant.OriginatingEntity.Human
         )
         val expectedJson =

--- a/transport/src/androidUnitTest/kotlin/transport/core/events/EventHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/events/EventHandlerTest.kt
@@ -58,7 +58,7 @@ class EventHandlerTest {
             Authorized,
             Logout,
             ConversationCleared,
-            SignedIn(MessageValues.ParticipantName, MessageValues.ParticipantLastName),
+            SignedIn(MessageValues.PARTICIPANT_NAME, MessageValues.PARTICIPANT_LAST_NAME),
             ExistingAuthSessionCleared,
         )
 
@@ -148,11 +148,11 @@ class EventHandlerTest {
     @Test
     fun `when PresenceEvent SignIn with Participant data toTransportEvent()`() {
         val givenParticipantData = StructuredMessage.Participant(
-            firstName = MessageValues.ParticipantName,
-            lastName = MessageValues.ParticipantLastName,
+            firstName = MessageValues.PARTICIPANT_NAME,
+            lastName = MessageValues.PARTICIPANT_LAST_NAME,
         )
         val expectedEvent =
-            SignedIn(MessageValues.ParticipantName, MessageValues.ParticipantLastName)
+            SignedIn(MessageValues.PARTICIPANT_NAME, MessageValues.PARTICIPANT_LAST_NAME)
 
         val result = PresenceEvent(
             StructuredMessageEvent.Type.Presence,
@@ -181,7 +181,7 @@ class EventHandlerTest {
     @Test
     fun `validate event Error payload`() {
         val expectedErrorCodePayload = ErrorCode.UnexpectedError
-        val expectedErrorMessagePayload = ErrorTest.Message
+        val expectedErrorMessagePayload = ErrorTest.MESSAGE
         val expectedCorrectiveActionPayload = CorrectiveAction.Unknown
         val expectedErrorEvent = Error(
             expectedErrorCodePayload,
@@ -189,7 +189,7 @@ class EventHandlerTest {
             expectedCorrectiveActionPayload
         )
         val givenErrorEvent =
-            Error(ErrorCode.UnexpectedError, ErrorTest.Message, CorrectiveAction.Unknown)
+            Error(ErrorCode.UnexpectedError, ErrorTest.MESSAGE, CorrectiveAction.Unknown)
 
         subject.onEvent(givenErrorEvent)
 
@@ -226,7 +226,7 @@ class EventHandlerTest {
 
     @Test
     fun `validate event SignedIn payload`() {
-        val givenSignedInEvent = SignedIn(MessageValues.ParticipantName, MessageValues.ParticipantLastName)
+        val givenSignedInEvent = SignedIn(MessageValues.PARTICIPANT_NAME, MessageValues.PARTICIPANT_LAST_NAME)
 
         subject.onEvent(givenSignedInEvent)
 
@@ -235,8 +235,8 @@ class EventHandlerTest {
             mockEventListener.invoke(capture(eventSlot))
         }
         (eventSlot[0] as SignedIn).run {
-            assertThat(firstName).isEqualTo(MessageValues.ParticipantName)
-            assertThat(lastName).isEqualTo(MessageValues.ParticipantLastName)
+            assertThat(firstName).isEqualTo(MessageValues.PARTICIPANT_NAME)
+            assertThat(lastName).isEqualTo(MessageValues.PARTICIPANT_LAST_NAME)
         }
         assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.onEvent(givenSignedInEvent))
     }

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -145,7 +145,7 @@ open class BaseMessagingClientTest {
         getCurrentTimestamp = mockTimestampFunction,
     )
     internal val mockAuthHandler: AuthHandler = mockk(relaxed = true) {
-        every { jwt } returns AuthTest.JwtToken
+        every { jwt } returns AuthTest.JWT_TOKEN
         every { refreshToken(captureLambda<(Result<Any>) -> Unit>()) } answers {
             lambda<(Result<Any>) -> Unit>().invoke(Result.Success(Empty()))
         }
@@ -161,7 +161,7 @@ open class BaseMessagingClientTest {
     internal val mockVault: DefaultVault = mockk {
         every { fetch(TOKEN_KEY) } returns testToken
         every { token } returns testToken
-        every { remove(TOKEN_KEY) } answers { testToken = TestValues.SecondaryToken }
+        every { remove(TOKEN_KEY) } answers { testToken = TestValues.SECONDARY_TOKEN }
         every { keys } returns TestValues.vaultKeys
         justRun { wasAuthenticated = any() }
     }
@@ -222,7 +222,7 @@ open class BaseMessagingClientTest {
         mockAttachmentHandler.fileAttachmentProfile = any()
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()
-        mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+        mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
     }
 
     protected fun MockKVerificationScope.connectToReadOnlySequence() {
@@ -232,7 +232,7 @@ open class BaseMessagingClientTest {
         mockAttachmentHandler.fileAttachmentProfile = any()
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()
-        mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+        mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
         mockStateChangedListener(fromConnectedToReadOnly)
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAttachmentTests.kt
@@ -144,7 +144,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
         val expectedAttachment = Attachment(
             "attachment_id",
             "image.png",
-            AttachmentValues.FileSize,
+            AttachmentValues.FILE_SIZE,
             Attachment.State.Sent("https://downloadurl.com")
         )
         val expectedMessage = Message(
@@ -394,7 +394,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
         val expectedAttachment = Attachment(
             "attachment_id",
             "image.png",
-            AttachmentValues.FileSize,
+            AttachmentValues.FILE_SIZE,
             Attachment.State.Sent("https://downloadurl.com")
         )
         val expectedMessage = Message(
@@ -426,9 +426,9 @@ class MCAttachmentTests : BaseMessagingClientTest() {
     @Test
     fun `when SocketListener invoke OnMessage with UploadSuccessEvent response`() {
         val expectedEvent = UploadSuccessEvent(
-            attachmentId = AttachmentValues.Id,
-            downloadUrl = AttachmentValues.DownloadUrl,
-            timestamp = TestValues.Timestamp,
+            attachmentId = AttachmentValues.ID,
+            downloadUrl = AttachmentValues.DOWNLOAD_URL,
+            timestamp = TestValues.TIME_STAMP,
         )
 
         subject.connect()
@@ -444,9 +444,9 @@ class MCAttachmentTests : BaseMessagingClientTest() {
     @Test
     fun `when SocketListener invoke OnMessage with PresignedUrlResponse response`() {
         val expectedEvent = PresignedUrlResponse(
-            attachmentId = AttachmentValues.Id,
-            headers = mapOf(AttachmentValues.PresignedHeaderKey to AttachmentValues.PresignedHeaderValue),
-            url = AttachmentValues.DownloadUrl,
+            attachmentId = AttachmentValues.ID,
+            headers = mapOf(AttachmentValues.PRESIGNED_HEADER_KEY to AttachmentValues.PRESIGNED_HEADER_VALUE),
+            url = AttachmentValues.DOWNLOAD_URL,
         )
 
         subject.connect()
@@ -467,7 +467,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence()
-            mockAttachmentHandler.onError(AttachmentValues.Id, ErrorCode.FileTypeInvalid, ErrorTest.Message)
+            mockAttachmentHandler.onError(AttachmentValues.ID, ErrorCode.FileTypeInvalid, ErrorTest.MESSAGE)
         }
     }
 
@@ -479,7 +479,7 @@ class MCAttachmentTests : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence()
-            mockAttachmentHandler.onError(AttachmentValues.Id, ErrorCode.FileTypeInvalid, ErrorTest.Message)
+            mockAttachmentHandler.onError(AttachmentValues.ID, ErrorCode.FileTypeInvalid, ErrorTest.MESSAGE)
         }
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAuthTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCAuthTests.kt
@@ -40,10 +40,10 @@ class MCAuthTests : BaseMessagingClientTest() {
 
     @Test
     fun `when authorize is called`() {
-        subject.authorize(AuthTest.AuthCode, AuthTest.JwtAuthUrl, AuthTest.CodeVerifier)
+        subject.authorize(AuthTest.AUTH_CODE, AuthTest.JWT_AUTH_URL, AuthTest.CODE_VERIFIER)
 
         verify {
-            mockAuthHandler.authorize(AuthTest.AuthCode, AuthTest.JwtAuthUrl, AuthTest.CodeVerifier)
+            mockAuthHandler.authorize(AuthTest.AUTH_CODE, AuthTest.JWT_AUTH_URL, AuthTest.CODE_VERIFIER)
         }
     }
 
@@ -61,7 +61,7 @@ class MCAuthTests : BaseMessagingClientTest() {
     fun `when connectAuthenticatedSession and AuthHandler has no Jwt and refreshToken was successful`() {
         every { mockAuthHandler.jwt } returns NO_JWT
         every { mockAuthHandler.refreshToken(captureLambda()) } answers {
-            every { mockAuthHandler.jwt } returns AuthTest.JwtToken
+            every { mockAuthHandler.jwt } returns AuthTest.JWT_TOKEN
             lambda<(Result<Empty>) -> Unit>().invoke(Result.Success(Empty()))
         }
 
@@ -84,14 +84,14 @@ class MCAuthTests : BaseMessagingClientTest() {
 
     @Test
     fun `when connectAuthenticatedSession and AuthHandler has no Jwt and refreshToken fails`() {
-        val givenResult = Result.Failure(ErrorCode.AuthFailed, ErrorTest.Message)
+        val givenResult = Result.Failure(ErrorCode.AuthFailed, ErrorTest.MESSAGE)
         every { mockAuthHandler.refreshToken(captureLambda()) } answers {
             lambda<(Result<Empty>) -> Unit>().invoke(givenResult)
         }
         every { mockAuthHandler.jwt } returns NO_JWT
 
         val expectedErrorState =
-            MessagingClient.State.Error(ErrorCode.AuthFailed, ErrorTest.Message)
+            MessagingClient.State.Error(ErrorCode.AuthFailed, ErrorTest.MESSAGE)
 
         subject.connectAuthenticatedSession()
 
@@ -269,7 +269,7 @@ class MCAuthTests : BaseMessagingClientTest() {
             slot.captured.onMessage(Response.configureSuccess(connected = false, readOnly = true))
         }
         every { mockAuthHandler.refreshToken(captureLambda()) } answers {
-            every { mockAuthHandler.jwt } returns AuthTest.JwtToken
+            every { mockAuthHandler.jwt } returns AuthTest.JWT_TOKEN
             lambda<(Result<Empty>) -> Unit>().invoke(Result.Success(Empty()))
         }
         subject.connectAuthenticatedSession()

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConnectionTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConnectionTests.kt
@@ -334,7 +334,7 @@ class MCConnectionTests : BaseMessagingClientTest() {
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(Request.configureRequest())
             invalidateSessionTokenSequence()
-            mockStateChangedListener(fromConnectedToError(MessagingClient.State.Error(ErrorCode.CannotDowngradeToUnauthenticated, ErrorTest.Message)))
+            mockStateChangedListener(fromConnectedToError(MessagingClient.State.Error(ErrorCode.CannotDowngradeToUnauthenticated, ErrorTest.MESSAGE)))
         }
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConversationDisconnectTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCConversationDisconnectTests.kt
@@ -242,7 +242,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()
-            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
             mockLogger.i(capture(logSlot))
             verifyCleanUp()
             mockLogger.i(capture(logSlot))
@@ -270,7 +270,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()
-            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
         }
         verify(exactly = 0) {
             mockMessageStore.invalidateConversationCache()
@@ -292,7 +292,7 @@ class MCConversationDisconnectTests : BaseMessagingClientTest() {
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()
-            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
             mockStateChangedListener(fromConfiguredToReadOnly())
         }
         verify(exactly = 0) {

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCHealthCheckTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCHealthCheckTests.kt
@@ -98,7 +98,7 @@ class MCHealthCheckTests : BaseMessagingClientTest() {
             mockAttachmentHandler.fileAttachmentProfile = any()
             mockReconnectionHandler.clear()
             mockJwtHandler.clear()
-            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MaxCustomDataBytes
+            mockCustomAttributesStore.maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES
             mockStateChangedListener(fromConnectedToConfigured)
             mockLogger.i(capture(logSlot))
             mockLogger.i(capture(logSlot))

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCMessageTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCMessageTests.kt
@@ -56,13 +56,13 @@ class MCMessageTests : BaseMessagingClientTest() {
             slot.captured.onMessage(Response.onMessage())
         }
         val expectedMessageRequest =
-            """{"token":"${Request.token}","message":{"text":"${MessageValues.Text}","type":"Text"},"action":"onMessage"}"""
+            """{"token":"${Request.token}","message":{"text":"${MessageValues.TEXT}","type":"Text"},"action":"onMessage"}"""
         val expectedMessage = Message(
             id = "some_custom_message_id",
             state = State.Sent,
             messageType = Type.Text,
             type = "Text",
-            text = MessageValues.Text,
+            text = MessageValues.TEXT,
             timeStamp = 1661196266704,
         )
         subject.connect()
@@ -74,7 +74,7 @@ class MCMessageTests : BaseMessagingClientTest() {
             mockLogger.i(capture(logSlot))
             mockCustomAttributesStore.add(emptyMap())
             mockCustomAttributesStore.getCustomAttributesToSend()
-            mockMessageStore.prepareMessage(Request.token, MessageValues.Text)
+            mockMessageStore.prepareMessage(Request.token, MessageValues.TEXT)
             mockAttachmentHandler.onSending()
             mockLogger.i(capture(logSlot))
             mockPlatformSocket.sendMessage(expectedMessageRequest)
@@ -89,7 +89,7 @@ class MCMessageTests : BaseMessagingClientTest() {
         }
         assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.CONNECT)
         assertThat(logSlot[1].invoke()).isEqualTo(LogMessages.configureSession(Request.token, false))
-        assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.sendMessage(MessageValues.Text))
+        assertThat(logSlot[2].invoke()).isEqualTo(LogMessages.sendMessage(MessageValues.TEXT))
         assertThat(logSlot[3].invoke()).isEqualTo(LogMessages.WILL_SEND_MESSAGE)
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/network/ReconnectionHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/network/ReconnectionHandlerTest.kt
@@ -30,7 +30,7 @@ class ReconnectionHandlerTest {
     private val mockReconnectFunction: () -> Unit = spyk()
     private val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
 
-    private var subject = ReconnectionHandlerImpl(TestValues.ReconnectionTimeout, mockLogger)
+    private var subject = ReconnectionHandlerImpl(TestValues.RECONNECTION_TIMEOUT, mockLogger)
 
     @ExperimentalCoroutinesApi
     @Before
@@ -62,7 +62,7 @@ class ReconnectionHandlerTest {
 
     @Test
     fun `when reconnect() and there is NO reconnection attempts left`() {
-        subject = ReconnectionHandlerImpl(TestValues.NoReconnectionAttempts, mockLogger)
+        subject = ReconnectionHandlerImpl(TestValues.NO_RECONNECTION_ATTEMPTS, mockLogger)
 
         subject.reconnect(mockReconnectFunction)
 

--- a/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/DeploymentConfigTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/DeploymentConfigTest.kt
@@ -43,17 +43,17 @@ class DeploymentConfigTest {
         val expectedJourneyEvents = JourneyEvents(enabled = false)
         val expectedConversationClear = Conversations.ConversationClear(enabled = true)
         val expectedConversations = Conversations(
-            messagingEndpoint = DeploymentConfigValues.MessagingEndpoint,
+            messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
             conversationClear = expectedConversationClear
         )
         val expectedApps = Apps(conversations = expectedConversations)
-        val expectedStyles = Styles(primaryColor = DeploymentConfigValues.PrimaryColor)
+        val expectedStyles = Styles(primaryColor = DeploymentConfigValues.PRIMARY_COLOR)
         val expectedMode = Mode(
-            fileTypes = listOf(DeploymentConfigValues.FileType),
-            maxFileSizeKB = DeploymentConfigValues.MaxFileSize
+            fileTypes = listOf(DeploymentConfigValues.FILE_TYPE),
+            maxFileSizeKB = DeploymentConfigValues.MAX_FILE_SIZE
         )
         val expectedLauncherButton =
-            LauncherButton(visibility = DeploymentConfigValues.LauncherButtonVisibility)
+            LauncherButton(visibility = DeploymentConfigValues.LAUNCHER_BUTTON_VISIBILITY)
         val expectedFileUpload = FileUpload(enableAttachments = false, modes = listOf(expectedMode))
         val expectedMessenger = Messenger(
             enabled = true,
@@ -63,17 +63,17 @@ class DeploymentConfigTest {
             fileUpload = expectedFileUpload,
         )
         val expectedLanguages =
-            listOf(DeploymentConfigValues.DefaultLanguage, DeploymentConfigValues.SecondaryLanguage)
+            listOf(DeploymentConfigValues.DEFAULT_LANGUAGE, DeploymentConfigValues.SECONDARY_LANGUAGE)
 
         val result =
             WebMessagingJson.json.decodeFromString<DeploymentConfig>(givenDeploymentConfigAsJson)
 
         assertThat(result).isEqualTo(expectedDeploymentConfig)
         result.run {
-            assertThat(apiEndpoint).isEqualTo(DeploymentConfigValues.ApiEndPoint)
+            assertThat(apiEndpoint).isEqualTo(DeploymentConfigValues.API_ENDPOINT)
             assertThat(auth).isEqualTo(expectedAuth)
-            assertThat(defaultLanguage).isEqualTo(DeploymentConfigValues.DefaultLanguage)
-            assertThat(id).isEqualTo(DeploymentConfigValues.Id)
+            assertThat(defaultLanguage).isEqualTo(DeploymentConfigValues.DEFAULT_LANGUAGE)
+            assertThat(id).isEqualTo(DeploymentConfigValues.ID)
             assertThat(journeyEvents).isEqualTo(expectedJourneyEvents)
             assertThat(journeyEvents.enabled).isFalse()
             assertThat(languages).containsExactly(*expectedLanguages.toTypedArray())
@@ -86,7 +86,7 @@ class DeploymentConfigTest {
                 assertThat(fileUpload).isEqualTo(expectedFileUpload)
             }
             assertThat(status).isEqualTo(DeploymentConfigValues.Status)
-            assertThat(version).isEqualTo(DeploymentConfigValues.Version)
+            assertThat(version).isEqualTo(DeploymentConfigValues.VERSION)
         }
     }
 
@@ -114,7 +114,7 @@ class DeploymentConfigTest {
     @Test
     fun `when Conversations serialized`() {
         val givenConversations = Conversations(
-            messagingEndpoint = DeploymentConfigValues.MessagingEndpoint,
+            messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
             showAgentTypingIndicator = true,
             showUserTypingIndicator = true,
             autoStart = Conversations.AutoStart(enabled = true),
@@ -143,7 +143,7 @@ class DeploymentConfigTest {
             Conversations.ConversationDisconnect.Type.ReadOnly
         )
         val expectedConversations = Conversations(
-            messagingEndpoint = DeploymentConfigValues.MessagingEndpoint,
+            messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
             showAgentTypingIndicator = true,
             showUserTypingIndicator = true,
             autoStart = expectedAutoStart,
@@ -155,7 +155,7 @@ class DeploymentConfigTest {
 
         assertThat(result).isEqualTo(expectedConversations)
         result.run {
-            assertThat(messagingEndpoint).isEqualTo(DeploymentConfigValues.MessagingEndpoint)
+            assertThat(messagingEndpoint).isEqualTo(DeploymentConfigValues.MESSAGING_ENDPOINT)
             assertThat(showAgentTypingIndicator).isTrue()
             assertThat(showUserTypingIndicator).isTrue()
             assertThat(autoStart).isEqualTo(expectedAutoStart)
@@ -246,8 +246,8 @@ class DeploymentConfigTest {
     @Test
     fun `when FileUpload serialized`() {
         val givenMode = Mode(
-            fileTypes = listOf(DeploymentConfigValues.FileType),
-            maxFileSizeKB = DeploymentConfigValues.MaxFileSize
+            fileTypes = listOf(DeploymentConfigValues.FILE_TYPE),
+            maxFileSizeKB = DeploymentConfigValues.MAX_FILE_SIZE
         )
         val givenFileUpload = FileUpload(modes = listOf(givenMode))
         val expectedFileUploadAsJson = """{"modes":[{"fileTypes":["png"],"maxFileSizeKB":100}]}"""
@@ -260,12 +260,12 @@ class DeploymentConfigTest {
     @Test
     fun `when FileUpload deserialized`() {
         val givenFileUploadAsJson = """{"modes":[{"fileTypes":["png"],"maxFileSizeKB":100}]}"""
-        val expectedFileType = DeploymentConfigValues.FileType
+        val expectedFileType = DeploymentConfigValues.FILE_TYPE
         val expectedFileTypes = listOf(expectedFileType)
         val expectedModes = listOf(
             Mode(
                 fileTypes = expectedFileTypes,
-                maxFileSizeKB = DeploymentConfigValues.MaxFileSize
+                maxFileSizeKB = DeploymentConfigValues.MAX_FILE_SIZE
             )
         )
         val expectedFileUpload = FileUpload(modes = expectedModes)
@@ -273,8 +273,8 @@ class DeploymentConfigTest {
         val result = WebMessagingJson.json.decodeFromString<FileUpload>(givenFileUploadAsJson)
 
         assertThat(result).isEqualTo(expectedFileUpload)
-        assertThat(result.modes[0].fileTypes[0]).isEqualTo(DeploymentConfigValues.FileType)
-        assertThat(result.modes[0].maxFileSizeKB).isEqualTo(DeploymentConfigValues.MaxFileSize)
+        assertThat(result.modes[0].fileTypes[0]).isEqualTo(DeploymentConfigValues.FILE_TYPE)
+        assertThat(result.modes[0].maxFileSizeKB).isEqualTo(DeploymentConfigValues.MAX_FILE_SIZE)
         assertThat(result.modes).containsExactly(*expectedModes.toTypedArray())
         assertThat(result.modes[0].fileTypes).containsExactly(*expectedFileTypes.toTypedArray())
     }
@@ -302,7 +302,7 @@ class DeploymentConfigTest {
 
     @Test
     fun `when LauncherButton serialized`() {
-        val givenLauncherButton = LauncherButton(DeploymentConfigValues.LauncherButtonVisibility)
+        val givenLauncherButton = LauncherButton(DeploymentConfigValues.LAUNCHER_BUTTON_VISIBILITY)
         val expectedLauncherButtonAsJson = """{"visibility":"On"}"""
 
         val result = WebMessagingJson.json.encodeToString(givenLauncherButton)
@@ -313,19 +313,19 @@ class DeploymentConfigTest {
     @Test
     fun `when LauncherButton deserialized`() {
         val givenLauncherButtonAsJson = """{"visibility":"On"}"""
-        val expectedLauncherButton = LauncherButton(DeploymentConfigValues.LauncherButtonVisibility)
+        val expectedLauncherButton = LauncherButton(DeploymentConfigValues.LAUNCHER_BUTTON_VISIBILITY)
 
         val result =
             WebMessagingJson.json.decodeFromString<LauncherButton>(givenLauncherButtonAsJson)
 
         assertThat(result).isEqualTo(expectedLauncherButton)
-        assertThat(result.visibility).isEqualTo(DeploymentConfigValues.LauncherButtonVisibility)
+        assertThat(result.visibility).isEqualTo(DeploymentConfigValues.LAUNCHER_BUTTON_VISIBILITY)
     }
 
     @Test
     fun `when Mode serialized`() {
-        val givenFileTypes = listOf(DeploymentConfigValues.FileType)
-        val givenMode = Mode(givenFileTypes, DeploymentConfigValues.MaxFileSize)
+        val givenFileTypes = listOf(DeploymentConfigValues.FILE_TYPE)
+        val givenMode = Mode(givenFileTypes, DeploymentConfigValues.MAX_FILE_SIZE)
         val expectedModeAsJson = """{"fileTypes":["png"],"maxFileSizeKB":100}"""
 
         val result = WebMessagingJson.json.encodeToString(givenMode)
@@ -336,9 +336,9 @@ class DeploymentConfigTest {
     @Test
     fun `when Mode deserialized`() {
         val givenModeAsJson = """{"fileTypes":["png"],"maxFileSizeKB":100}"""
-        val expectedFileTypes = listOf(DeploymentConfigValues.FileType)
+        val expectedFileTypes = listOf(DeploymentConfigValues.FILE_TYPE)
         val expectedMode =
-            Mode(listOf(DeploymentConfigValues.FileType), DeploymentConfigValues.MaxFileSize)
+            Mode(listOf(DeploymentConfigValues.FILE_TYPE), DeploymentConfigValues.MAX_FILE_SIZE)
 
         val result = WebMessagingJson.json.decodeFromString<Mode>(givenModeAsJson)
 
@@ -348,13 +348,13 @@ class DeploymentConfigTest {
 
     @Test
     fun `when Styles serialized`() {
-        val expectedRequest = Styles(primaryColor = DeploymentConfigValues.PrimaryColor)
+        val expectedRequest = Styles(primaryColor = DeploymentConfigValues.PRIMARY_COLOR)
         val expectedJson = """{"primaryColor":"red"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<Styles>(expectedJson)
 
         assertThat(encodedString, "encoded Styles").isEqualTo(expectedJson)
-        assertThat(decoded.primaryColor).isEqualTo(DeploymentConfigValues.PrimaryColor)
+        assertThat(decoded.primaryColor).isEqualTo(DeploymentConfigValues.PRIMARY_COLOR)
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/ResponsesTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/ResponsesTests.kt
@@ -32,24 +32,24 @@ class ResponsesTests {
 
     @Test
     fun `when AttachmentDeleteResponse serialized`() {
-        val expectedRequest = AttachmentDeletedResponse(AttachmentValues.Id)
-        val expectedJson = """{"attachmentId":"${AttachmentValues.Id}"}"""
+        val expectedRequest = AttachmentDeletedResponse(AttachmentValues.ID)
+        val expectedJson = """{"attachmentId":"${AttachmentValues.ID}"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<AttachmentDeletedResponse>(expectedJson)
 
         assertThat(encodedString, "encoded AttachmentDeletedResponse").isEqualTo(expectedJson)
-        assertThat(decoded.attachmentId).isEqualTo(AttachmentValues.Id)
+        assertThat(decoded.attachmentId).isEqualTo(AttachmentValues.ID)
     }
 
     @Test
     fun `when GenerateUrlError serialized`() {
         val expectedRequest = GenerateUrlError(
-            attachmentId = AttachmentValues.Id,
+            attachmentId = AttachmentValues.ID,
             errorCode = ErrorCode.FileNameInvalid.code,
-            errorMessage = ErrorTest.Message
+            errorMessage = ErrorTest.MESSAGE
         )
-        val expectedJson = """{"attachmentId":"${AttachmentValues.Id}","errorCode":4004,"errorMessage":"${ErrorTest.Message}"}"""
+        val expectedJson = """{"attachmentId":"${AttachmentValues.ID}","errorCode":4004,"errorMessage":"${ErrorTest.MESSAGE}"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<GenerateUrlError>(expectedJson)
@@ -57,15 +57,15 @@ class ResponsesTests {
         assertThat(encodedString, "encoded GenerateUrlError").isEqualTo(expectedJson)
         decoded.run {
             assertThat(this).isEqualTo(expectedRequest)
-            assertThat(attachmentId).isEqualTo(AttachmentValues.Id)
+            assertThat(attachmentId).isEqualTo(AttachmentValues.ID)
             assertThat(errorCode).isEqualTo(ErrorCode.FileNameInvalid.code)
-            assertThat(errorMessage).isEqualTo(ErrorTest.Message)
+            assertThat(errorMessage).isEqualTo(ErrorTest.MESSAGE)
         }
     }
 
     @Test
     fun `when JwtResponse serialized`() {
-        val expectedRequest = JwtResponse(AuthTest.JwtToken, AuthTest.JwtExpiry)
+        val expectedRequest = JwtResponse(AuthTest.JWT_TOKEN, AuthTest.JWT_EXPIRY)
         val expectedJson = """{"jwt":"jwt_Token","exp":100}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
@@ -74,20 +74,20 @@ class ResponsesTests {
         assertThat(encodedString, "encoded JwtResponse").isEqualTo(expectedJson)
         decoded.run {
             assertThat(this).isEqualTo(expectedRequest)
-            assertThat(jwt).isEqualTo(AuthTest.JwtToken)
-            assertThat(exp).isEqualTo(AuthTest.JwtExpiry)
+            assertThat(jwt).isEqualTo(AuthTest.JWT_TOKEN)
+            assertThat(exp).isEqualTo(AuthTest.JWT_EXPIRY)
         }
     }
 
     @Test
     fun `when PresignedUrlResponse serialized`() {
         val expectedRequest = PresignedUrlResponse(
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
-            headers = mapOf(AttachmentValues.PresignedHeaderKey to AttachmentValues.PresignedHeaderValue),
-            url = AttachmentValues.DownloadUrl,
-            fileSize = AttachmentValues.FileSize,
-            fileType = AttachmentValues.FileType,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
+            headers = mapOf(AttachmentValues.PRESIGNED_HEADER_KEY to AttachmentValues.PRESIGNED_HEADER_VALUE),
+            url = AttachmentValues.DOWNLOAD_URL,
+            fileSize = AttachmentValues.FILE_SIZE,
+            fileType = AttachmentValues.FILE_TYPE,
         )
         val expectedJson = """{"attachmentId":"test_attachment_id","headers":{"x-amz-tagging":"abc"},"url":"https://downloadurl.png","fileName":"fileName.png","fileSize":100,"fileType":"png"}"""
 
@@ -99,8 +99,8 @@ class ResponsesTests {
             assertThat(this).isEqualTo(expectedRequest)
             assertThat(attachmentId).isEqualTo(expectedRequest.attachmentId)
             assertThat(fileName).isEqualTo(expectedRequest.fileName)
-            assertThat(headers[AttachmentValues.PresignedHeaderKey]).isEqualTo(
-                expectedRequest.headers[AttachmentValues.PresignedHeaderKey]
+            assertThat(headers[AttachmentValues.PRESIGNED_HEADER_KEY]).isEqualTo(
+                expectedRequest.headers[AttachmentValues.PRESIGNED_HEADER_KEY]
             )
             assertThat(url).isEqualTo(expectedRequest.url)
             assertThat(fileSize).isEqualTo(expectedRequest.fileSize)
@@ -149,12 +149,12 @@ class ResponsesTests {
     @Test
     fun `validate StructuredMessage_Attachment serialization`() {
         val expectedRequest = StructuredMessage.Content.AttachmentContent(
-            contentType = AttachmentValues.AttachmentContentType,
+            contentType = AttachmentValues.ATTACHMENT_CONTENT_TYPE,
             attachment = StructuredMessage.Content.AttachmentContent.Attachment(
-                id = AttachmentValues.Id,
-                url = AttachmentValues.DownloadUrl,
-                filename = AttachmentValues.FileName,
-                mediaType = AttachmentValues.MediaType,
+                id = AttachmentValues.ID,
+                url = AttachmentValues.DOWNLOAD_URL,
+                filename = AttachmentValues.FILE_NAME,
+                mediaType = AttachmentValues.MEDIA_TYPE,
             )
         )
         val expectedJson =
@@ -165,12 +165,12 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded StructuredMessage.Content.AttachmentContent").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(contentType).isEqualTo(AttachmentValues.AttachmentContentType)
+            assertThat(contentType).isEqualTo(AttachmentValues.ATTACHMENT_CONTENT_TYPE)
             attachment.run {
-                assertThat(id).isEqualTo(AttachmentValues.Id)
-                assertThat(url).isEqualTo(AttachmentValues.DownloadUrl)
-                assertThat(filename).isEqualTo(AttachmentValues.FileName)
-                assertThat(mediaType).isEqualTo(AttachmentValues.MediaType)
+                assertThat(id).isEqualTo(AttachmentValues.ID)
+                assertThat(url).isEqualTo(AttachmentValues.DOWNLOAD_URL)
+                assertThat(filename).isEqualTo(AttachmentValues.FILE_NAME)
+                assertThat(mediaType).isEqualTo(AttachmentValues.MEDIA_TYPE)
                 assertThat(fileSize).isNull()
                 assertThat(mime).isNull()
                 assertThat(sha256).isNull()
@@ -182,9 +182,9 @@ class ResponsesTests {
     @Test
     fun `validate TooManyRequestsErrorMessage serialization`() {
         val expectedRequest = TooManyRequestsErrorMessage(
-            retryAfter = ErrorTest.RetryAfter,
+            retryAfter = ErrorTest.RETRY_AFTER,
             errorCode = ErrorCode.UnexpectedError.code,
-            errorMessage = ErrorTest.Message
+            errorMessage = ErrorTest.MESSAGE
         )
         val expectedJson =
             """{"retryAfter":1,"errorCode":5000,"errorMessage":"This is a generic error message for testing."}"""
@@ -194,19 +194,19 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded TooManyRequestsErrorMessage").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(retryAfter).isEqualTo(ErrorTest.RetryAfter)
+            assertThat(retryAfter).isEqualTo(ErrorTest.RETRY_AFTER)
             assertThat(errorCode).isEqualTo(ErrorCode.UnexpectedError.code)
-            assertThat(errorMessage).isEqualTo(ErrorTest.Message)
+            assertThat(errorMessage).isEqualTo(ErrorTest.MESSAGE)
         }
     }
 
     @Test
     fun `validate UploadFailureEvent serialization`() {
         val expectedRequest = UploadFailureEvent(
-            attachmentId = AttachmentValues.Id,
+            attachmentId = AttachmentValues.ID,
             errorCode = ErrorCode.UnexpectedError.code,
-            errorMessage = ErrorTest.Message,
-            timestamp = TestValues.Timestamp
+            errorMessage = ErrorTest.MESSAGE,
+            timestamp = TestValues.TIME_STAMP
         )
         val expectedJson =
             """{"attachmentId":"test_attachment_id","errorCode":5000,"errorMessage":"This is a generic error message for testing.","timestamp":"2022-08-22T19:24:26.704Z"}"""
@@ -216,19 +216,19 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded UploadFailureEvent").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(attachmentId).isEqualTo(AttachmentValues.Id)
+            assertThat(attachmentId).isEqualTo(AttachmentValues.ID)
             assertThat(errorCode).isEqualTo(ErrorCode.UnexpectedError.code)
-            assertThat(errorMessage).isEqualTo(ErrorTest.Message)
-            assertThat(timestamp).isEqualTo(TestValues.Timestamp)
+            assertThat(errorMessage).isEqualTo(ErrorTest.MESSAGE)
+            assertThat(timestamp).isEqualTo(TestValues.TIME_STAMP)
         }
     }
 
     @Test
     fun `validate UploadSuccessEvent serialization`() {
         val expectedRequest = UploadSuccessEvent(
-            attachmentId = AttachmentValues.Id,
-            downloadUrl = AttachmentValues.DownloadUrl,
-            timestamp = TestValues.Timestamp
+            attachmentId = AttachmentValues.ID,
+            downloadUrl = AttachmentValues.DOWNLOAD_URL,
+            timestamp = TestValues.TIME_STAMP
         )
         val expectedJson =
             """{"attachmentId":"test_attachment_id","downloadUrl":"https://downloadurl.png","timestamp":"2022-08-22T19:24:26.704Z"}"""
@@ -238,9 +238,9 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded UploadSuccessEvent").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(attachmentId).isEqualTo(AttachmentValues.Id)
-            assertThat(downloadUrl).isEqualTo(AttachmentValues.DownloadUrl)
-            assertThat(timestamp).isEqualTo(TestValues.Timestamp)
+            assertThat(attachmentId).isEqualTo(AttachmentValues.ID)
+            assertThat(downloadUrl).isEqualTo(AttachmentValues.DOWNLOAD_URL)
+            assertThat(timestamp).isEqualTo(TestValues.TIME_STAMP)
         }
     }
 
@@ -256,8 +256,8 @@ class ResponsesTests {
         decoded.run {
             assertThat(this).isEqualTo(expectedRequest)
             assertThat(text).isEqualTo("text_a")
-            assertThat(payload).isEqualTo(QuickReplyTestValues.Payload_A)
-            assertThat(type).isEqualTo(QuickReplyTestValues.QuickReply)
+            assertThat(payload).isEqualTo(QuickReplyTestValues.PAYLOAD_A)
+            assertThat(type).isEqualTo(QuickReplyTestValues.QUICK_REPLY)
         }
     }
 
@@ -272,11 +272,11 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded StructuredMessage.Content.ButtonResponse").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(contentType).isEqualTo(QuickReplyTestValues.ButtonResponse)
+            assertThat(contentType).isEqualTo(QuickReplyTestValues.BUTTON_RESPONSE)
             buttonResponse.run {
-                assertThat(text).isEqualTo(QuickReplyTestValues.Text_A)
-                assertThat(payload).isEqualTo(QuickReplyTestValues.Payload_A)
-                assertThat(type).isEqualTo(QuickReplyTestValues.QuickReply)
+                assertThat(text).isEqualTo(QuickReplyTestValues.TEXT_A)
+                assertThat(payload).isEqualTo(QuickReplyTestValues.PAYLOAD_A)
+                assertThat(type).isEqualTo(QuickReplyTestValues.QUICK_REPLY)
             }
         }
     }
@@ -292,10 +292,10 @@ class ResponsesTests {
 
         assertThat(encodedString, "encoded StructuredMessage.Content.QuickReply").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(contentType).isEqualTo(QuickReplyTestValues.QuickReply)
+            assertThat(contentType).isEqualTo(QuickReplyTestValues.QUICK_REPLY)
             quickReply.run {
-                assertThat(text).isEqualTo(QuickReplyTestValues.Text_A)
-                assertThat(payload).isEqualTo(QuickReplyTestValues.Payload_A)
+                assertThat(text).isEqualTo(QuickReplyTestValues.TEXT_A)
+                assertThat(payload).isEqualTo(QuickReplyTestValues.PAYLOAD_A)
                 assertThat(action).isEqualTo("action")
             }
         }

--- a/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/AndroidPlatformTest.kt
@@ -46,17 +46,17 @@ class AndroidPlatformTest {
     @Test
     fun `test Vault Keys`() {
         val result = Vault.Keys(
-            vaultKey = TestValues.VaultKey,
-            tokenKey = TestValues.TokenKey,
-            authRefreshTokenKey = TestValues.AuthRefreshTokenKey,
-            wasAuthenticated = TestValues.WasAuthenticated,
+            vaultKey = TestValues.VAULT_KEY,
+            tokenKey = TestValues.TOKEN_KEY,
+            authRefreshTokenKey = TestValues.AUTH_REFRESH_TOKEN_KEY,
+            wasAuthenticated = TestValues.WAS_AUTHENTICATED,
         )
 
         result.run {
-            assertThat(vaultKey).isEqualTo(TestValues.VaultKey)
-            assertThat(tokenKey).isEqualTo(TestValues.TokenKey)
-            assertThat(authRefreshTokenKey).isEqualTo(TestValues.AuthRefreshTokenKey)
-            assertThat(wasAuthenticated).isEqualTo(TestValues.WasAuthenticated)
+            assertThat(vaultKey).isEqualTo(TestValues.VAULT_KEY)
+            assertThat(tokenKey).isEqualTo(TestValues.TOKEN_KEY)
+            assertThat(authRefreshTokenKey).isEqualTo(TestValues.AUTH_REFRESH_TOKEN_KEY)
+            assertThat(wasAuthenticated).isEqualTo(TestValues.WAS_AUTHENTICATED)
         }
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/util/LogsTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/LogsTest.kt
@@ -20,17 +20,17 @@ import org.junit.Test
 
 class LogsTest {
     private val mockKermit: Logger = mockk(relaxed = true) {
-        every { tag } returns TestValues.LogTag
+        every { tag } returns TestValues.LOG_TAG
     }
 
-    internal var subject = Log(true, TestValues.LogTag, mockKermit)
+    internal var subject = Log(true, TestValues.LOG_TAG, mockKermit)
 
     @Test
     fun `when log i and enabledLogs=true`() {
         subject.i { LogMessages.CONNECT }
 
         verify {
-            mockKermit.log(Severity.Info, TestValues.LogTag, null, LogMessages.CONNECT)
+            mockKermit.log(Severity.Info, TestValues.LOG_TAG, null, LogMessages.CONNECT)
         }
     }
 
@@ -39,7 +39,7 @@ class LogsTest {
         subject.w { LogMessages.CONNECT }
 
         verify {
-            mockKermit.log(Severity.Warn, TestValues.LogTag, null, LogMessages.CONNECT)
+            mockKermit.log(Severity.Warn, TestValues.LOG_TAG, null, LogMessages.CONNECT)
         }
     }
 
@@ -48,26 +48,26 @@ class LogsTest {
         subject.e { LogMessages.CONNECT }
 
         verify {
-            mockKermit.log(Severity.Error, TestValues.LogTag, null, LogMessages.CONNECT)
+            mockKermit.log(Severity.Error, TestValues.LOG_TAG, null, LogMessages.CONNECT)
         }
     }
 
     @Test
     fun `when log e with throwable and enabledLogs=true`() {
-        val givenThrowable = Exception(ErrorTest.Message)
+        val givenThrowable = Exception(ErrorTest.MESSAGE)
 
         subject.e(givenThrowable) { LogMessages.CONNECT }
 
         verify {
-            mockKermit.log(Severity.Error, TestValues.LogTag, givenThrowable, LogMessages.CONNECT)
+            mockKermit.log(Severity.Error, TestValues.LOG_TAG, givenThrowable, LogMessages.CONNECT)
         }
     }
 
     @Test
     fun `when enableLogs=false`() {
-        subject = Log(enableLogs = false, TestValues.LogTag)
+        subject = Log(enableLogs = false, TestValues.LOG_TAG)
 
-        assertThat(subject.kermit.tag).isEqualTo(TestValues.LogTag)
+        assertThat(subject.kermit.tag).isEqualTo(TestValues.LOG_TAG)
         assertThat(subject.kermit.config.minSeverity).isEqualTo(Severity.Assert)
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/util/Request.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/Request.kt
@@ -9,7 +9,7 @@ internal object Request {
     fun configureRequest(startNew: Boolean = false) =
         """{"token":"$token","deploymentId":"deploymentId","startNew":$startNew,"journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"action":"configureSession"}"""
     fun configureAuthenticatedRequest(startNew: Boolean = false) =
-        """{"token":"$token","deploymentId":"deploymentId","startNew":$startNew,"journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"data":{"code":"${AuthTest.JwtToken}"},"action":"configureAuthenticatedSession"}"""
+        """{"token":"$token","deploymentId":"deploymentId","startNew":$startNew,"journeyContext":{"customer":{"id":"00000000-0000-0000-0000-000000000000","idType":"cookie"},"customerSession":{"id":"","type":"web"}},"data":{"code":"${AuthTest.JWT_TOKEN}"},"action":"configureAuthenticatedSession"}"""
     const val userTypingRequest =
         """{"token":"$token","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
     const val echo =
@@ -20,7 +20,7 @@ internal object Request {
         content: String = """"content":[{"contentType":"ButtonResponse","buttonResponse":{"text":"text_a","payload":"payload_a","type":"QuickReply"}}]""",
         channel: String = ""
     ) = """{"token":"$token","message":{"text":"",$content,$channel"type":"Text"},"action":"onMessage"}"""
-    fun textMessage(text: String = MessageValues.Text) =
+    fun textMessage(text: String = MessageValues.TEXT) =
         """{"token":"$token","message":{"text":"$text","type":"Text"},"action":"onMessage"}"""
     const val closeAllConnections =
         """{"token":"$token","closeAllConnections":true,"action":"closeSession"}"""

--- a/transport/src/androidUnitTest/kotlin/transport/util/Response.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/util/Response.kt
@@ -12,7 +12,7 @@ internal object Response {
     fun configureSuccess(
         connected: Boolean = true,
         readOnly: Boolean = false,
-        maxCustomDataBytes: Int = TestValues.MaxCustomDataBytes,
+        maxCustomDataBytes: Int = TestValues.MAX_CUSTOM_DATA_BYTES,
         allowedMedia: String = AllowedMedia.empty,
         blockedExtensions: String = AllowedMedia.emptyBlockedExtensions,
         clearedExistingSession: Boolean = false,
@@ -26,7 +26,7 @@ internal object Response {
     fun onMessage(direction: Message.Direction = Message.Direction.Inbound) =
         """{"type":"message","class":"StructuredMessage","code":200,"body":{"text":"Hello world!","direction":"${direction.name}","id":"test_id","channel":{"time":"2022-08-22T19:24:26.704Z","messageId":"message_id"},"type":"Text","metadata":{"customMessageId":"some_custom_message_id"}}}"""
     fun onMessageWithAttachment(direction: Message.Direction = Message.Direction.Outbound) =
-        """{"type":"message","class":"StructuredMessage","code":200,"body":{"direction":"${direction.name}","id":"msg_id","channel":{"time":"some_time","type":"Private"},"type":"Text","text":"Hi","content":[{"attachment":{"id":"attachment_id","filename":"image.png","mediaType":"Image","fileSize":${AttachmentValues.FileSize},"mime":"image/png","url":"https://downloadurl.com"},"contentType":"Attachment"}],"originatingEntity":"Human"}}"""
+        """{"type":"message","class":"StructuredMessage","code":200,"body":{"direction":"${direction.name}","id":"msg_id","channel":{"time":"some_time","type":"Private"},"type":"Text","text":"Hi","content":[{"attachment":{"id":"attachment_id","filename":"image.png","mediaType":"Image","fileSize":${AttachmentValues.FILE_SIZE},"mime":"image/png","url":"https://downloadurl.com"},"contentType":"Attachment"}],"originatingEntity":"Human"}}"""
     const val onMessageWithQuickReplies =
         """{"type":"message","class":"StructuredMessage","code":200,"body":{"direction":"Outbound","id":"msg_id","channel":{"time":"some_time","type":"Private"},"type":"Structured","text":"Hi","content":[{"contentType":"QuickReply","quickReply":{"text":"text_a","payload":"payload_a","action":"action_a"}},{"contentType":"QuickReply","quickReply":{"text":"text_b","payload":"payload_b","action":"action_b"}}],"originatingEntity":"Bot"}}"""
     const val onMessageWithoutQuickReplies =
@@ -40,7 +40,7 @@ internal object Response {
     const val sessionExpired =
         """{"type": "response","class": "string","code": 4006,"body": "session expired error message"}"""
     const val cannotDowngradeToUnauthenticated =
-        """{"type": "response","class": "string","code": 4017,"body": "${ErrorTest.Message}"}"""
+        """{"type": "response","class": "string","code": 4017,"body": "${ErrorTest.MESSAGE}"}"""
     const val sessionExpiredEvent =
         """{"type": "response","class": "SessionExpiredEvent","code": 200,"body": {}}"""
     const val messageTooLong =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -24,7 +24,6 @@ internal object LogMessages {
     fun attachmentError(attachmentId: String, errorCode: ErrorCode, errorMessage: String) =
         "Attachment error with id: $attachmentId. ErrorCode: $errorCode, errorMessage: $errorMessage"
     fun invalidAttachmentId(attachmentId: String) = "Invalid attachment ID: $attachmentId. Detach failed."
-
     // Authentication
     const val REFRESH_AUTH_TOKEN_SUCCESS = "refreshAuthToken success."
     fun configureAuthenticatedSession(token: String, startNew: Boolean) =

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
@@ -14,12 +14,12 @@ class ConfigurationTest {
 
     @Test
     fun `validate default constructor`() {
-        val expectedDeploymentId = TestValues.DeploymentId
+        val expectedDeploymentId = TestValues.DEPLOYMENT_ID
         val expectedReconnectionTimeout = 300L
 
         val configuration = Configuration(
-            deploymentId = TestValues.DeploymentId,
-            domain = TestValues.Domain
+            deploymentId = TestValues.DEPLOYMENT_ID,
+            domain = TestValues.DOMAIN
         )
 
         configuration.run {
@@ -32,12 +32,12 @@ class ConfigurationTest {
 
     @Test
     fun `validate secondary constructor`() {
-        val expectedDeploymentId = TestValues.DeploymentId
+        val expectedDeploymentId = TestValues.DEPLOYMENT_ID
         val expectedReconnectionTimeout = 1L
 
         val configuration = Configuration(
-            deploymentId = TestValues.DeploymentId,
-            domain = TestValues.Domain,
+            deploymentId = TestValues.DEPLOYMENT_ID,
+            domain = TestValues.DOMAIN,
             logging = true,
             reconnectionTimeoutInSeconds = 1L
         )

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/RequestSerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/RequestSerializationTest.kt
@@ -37,7 +37,6 @@ import com.genesys.cloud.messenger.transport.utility.AttachmentValues
 import com.genesys.cloud.messenger.transport.utility.AuthTest
 import com.genesys.cloud.messenger.transport.utility.Journey
 import com.genesys.cloud.messenger.transport.utility.TestValues
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 
@@ -51,7 +50,7 @@ class RequestSerializationTest {
         )
         val expectedEvents = listOf(expectedPresenceEvent)
         val expectedMessage = EventMessage(expectedEvents)
-        val expectedRequest = AutoStartRequest(TestValues.Token, null)
+        val expectedRequest = AutoStartRequest(TestValues.TOKEN, null)
         val expectedJson =
             """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Join"}}],"type":"Event"}}"""
 
@@ -61,7 +60,7 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded AutoStartRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.ON_MESSAGE.value)
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(message).isEqualTo(expectedMessage)
             assertThat(message.events).containsExactly(*expectedEvents.toTypedArray())
         }
@@ -92,7 +91,7 @@ class RequestSerializationTest {
         )
         val expectedEvents = listOf(expectedPresenceEvent)
         val expectedMessage = EventMessage(expectedEvents)
-        val expectedRequest = ClearConversationRequest(TestValues.Token)
+        val expectedRequest = ClearConversationRequest(TestValues.TOKEN)
         val expectedJson =
             """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Presence","presence":{"type":"Clear"}}],"type":"Event"}}"""
         val expectedPresenceJson = """{"type":"Clear"}"""
@@ -106,7 +105,7 @@ class RequestSerializationTest {
         assertThat(encodedPresenceString, "encoded Presence").isEqualTo(expectedPresenceJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.ON_MESSAGE.value)
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(message).isEqualTo(expectedMessage)
             assertThat(message.events).containsExactly(*expectedEvents.toTypedArray())
         }
@@ -116,7 +115,7 @@ class RequestSerializationTest {
     @Test
     fun `validate CloseSessionRequest serialization`() {
         val expectedRequest = CloseSessionRequest(
-            token = TestValues.Token,
+            token = TestValues.TOKEN,
             closeAllConnections = true,
         )
         val expectedJson =
@@ -128,17 +127,17 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded CloseSessionRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.CLOSE_SESSION.value)
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(closeAllConnections).isTrue()
         }
     }
 
     @Test
     fun `validate ConfigureAuthenticatedSessionRequest serialization`() {
-        val expectedData = ConfigureAuthenticatedSessionRequest.Data(AuthTest.JwtToken)
+        val expectedData = ConfigureAuthenticatedSessionRequest.Data(AuthTest.JWT_TOKEN)
         val expectedRequest = ConfigureAuthenticatedSessionRequest(
-            token = TestValues.Token,
-            deploymentId = TestValues.DeploymentId,
+            token = TestValues.TOKEN,
+            deploymentId = TestValues.DEPLOYMENT_ID,
             startNew = false,
             data = expectedData
         )
@@ -162,21 +161,21 @@ class RequestSerializationTest {
         assertThat(encodedDataString, "encoded Data").isEqualTo(expectedDataJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.CONFIGURE_AUTHENTICATED_SESSION.value)
-            assertThat(token).isEqualTo(TestValues.Token)
-            assertThat(deploymentId).isEqualTo(TestValues.DeploymentId)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
+            assertThat(deploymentId).isEqualTo(TestValues.DEPLOYMENT_ID)
             assertThat(startNew).isFalse()
             assertThat(journeyContext).isNull()
             assertThat(data).isEqualTo(expectedData)
         }
         assertThat(decodedData).isEqualTo(expectedData)
-        assertThat(decodedData.code).isEqualTo(AuthTest.JwtToken)
+        assertThat(decodedData.code).isEqualTo(AuthTest.JWT_TOKEN)
     }
 
     @Test
     fun `validate ConfigureSessionRequest serialization`() {
         val expectedRequest = ConfigureSessionRequest(
-            token = TestValues.Token,
-            deploymentId = TestValues.DeploymentId,
+            token = TestValues.TOKEN,
+            deploymentId = TestValues.DEPLOYMENT_ID,
             startNew = true,
         )
         val expectedJson =
@@ -188,8 +187,8 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded ConfigureSessionRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.CONFIGURE_SESSION.value)
-            assertThat(token).isEqualTo(TestValues.Token)
-            assertThat(deploymentId).isEqualTo(TestValues.DeploymentId)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
+            assertThat(deploymentId).isEqualTo(TestValues.DEPLOYMENT_ID)
             assertThat(startNew).isTrue()
             assertThat(journeyContext).isNull()
         }
@@ -198,8 +197,8 @@ class RequestSerializationTest {
     @Test
     fun `validate DeleteAttachmentRequest serialization`() {
         val expectedRequest = DeleteAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID
         )
         val expectedJson =
             """{"token":"<token>","attachmentId":"test_attachment_id","action":"deleteAttachment"}"""
@@ -210,8 +209,8 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded DeleteAttachmentRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.DELETE_ATTACHMENT.value)
-            assertThat(token).isEqualTo(TestValues.Token)
-            assertThat(attachmentId).isEqualTo(AttachmentValues.Id)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
+            assertThat(attachmentId).isEqualTo(AttachmentValues.ID)
         }
     }
 
@@ -219,7 +218,7 @@ class RequestSerializationTest {
     fun `validate EchoRequest serialization`() {
         val expectedTextMessage = TextMessage("ping", mapOf("customMessageId" to HealthCheckID))
         val expectedRequest = EchoRequest(
-            token = TestValues.Token,
+            token = TestValues.TOKEN,
         )
         val expectedJson =
             """{"token":"<token>","action":"echo","message":{"text":"ping","metadata":{"customMessageId":"SGVhbHRoQ2hlY2tNZXNzYWdlSWQ="},"type":"Text"}}"""
@@ -230,7 +229,7 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded EchoRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.ECHO_MESSAGE.value)
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(message).isEqualTo(expectedTextMessage)
             message.run {
                 assertThat(text).isEqualTo(expectedTextMessage.text)
@@ -267,8 +266,8 @@ class RequestSerializationTest {
     @Test
     fun `validate GetAttachmentRequest serialization`() {
         val expectedRequest = GetAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID
         )
         val expectedJson =
             """{"token":"<token>","attachmentId":"test_attachment_id","action":"getAttachment"}"""
@@ -279,23 +278,23 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded GetAttachmentRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.GET_ATTACHMENT.value)
-            assertThat(token).isEqualTo(TestValues.Token)
-            assertThat(attachmentId).isEqualTo(AttachmentValues.Id)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
+            assertThat(attachmentId).isEqualTo(AttachmentValues.ID)
         }
     }
 
     @Test
     fun `validate JourneyContext serialization`() {
         val expectedJourneyCustomer =
-            JourneyCustomer(id = Journey.CustomerId, idType = Journey.CustomerIdType)
+            JourneyCustomer(id = Journey.CUSTOMER_ID, idType = Journey.CUSTOMER_ID_TYPE)
         val expectedCustomerSession = JourneyCustomerSession(
-            id = Journey.CustomerSessionId,
-            type = Journey.CustomerSessionType
+            id = Journey.CUSTOMER_SESSION_ID,
+            type = Journey.CUSTOMER_SESSION_TYPE
         )
         val expectedJourneyActionMap =
-            JourneyActionMap(id = Journey.ActionMapId, version = Journey.ActionMapVersion)
+            JourneyActionMap(id = Journey.ACTION_MAP_ID, version = Journey.ACTION_MAP_VERSION)
         val expectedTriggeringAction =
-            JourneyAction(id = Journey.ActionId, actionMap = expectedJourneyActionMap)
+            JourneyAction(id = Journey.ACTION_ID, actionMap = expectedJourneyActionMap)
         val expectedJourneyContext = JourneyContext(
             customer = expectedJourneyCustomer,
             customerSession = expectedCustomerSession,
@@ -351,19 +350,19 @@ class RequestSerializationTest {
             expectedJourneyContextJson
         )
         decodedJourneyCustomer.run {
-            assertThat(id).isEqualTo(Journey.CustomerId)
-            assertThat(idType).isEqualTo(Journey.CustomerIdType)
+            assertThat(id).isEqualTo(Journey.CUSTOMER_ID)
+            assertThat(idType).isEqualTo(Journey.CUSTOMER_ID_TYPE)
         }
         decodedJourneyCustomerSession.run {
-            assertThat(id).isEqualTo(Journey.CustomerSessionId)
-            assertThat(type).isEqualTo(Journey.CustomerSessionType)
+            assertThat(id).isEqualTo(Journey.CUSTOMER_SESSION_ID)
+            assertThat(type).isEqualTo(Journey.CUSTOMER_SESSION_TYPE)
         }
         decodedJourneyActionMap.run {
-            assertThat(id).isEqualTo(Journey.ActionMapId)
-            assertThat(version).isEqualTo(Journey.ActionMapVersion)
+            assertThat(id).isEqualTo(Journey.ACTION_MAP_ID)
+            assertThat(version).isEqualTo(Journey.ACTION_MAP_VERSION)
         }
         decodedJourneyAction.run {
-            assertThat(id).isEqualTo(Journey.ActionId)
+            assertThat(id).isEqualTo(Journey.ACTION_ID)
             assertThat(actionMap).isEqualTo(expectedJourneyActionMap)
         }
         decodedJourneyContext.run {
@@ -375,8 +374,8 @@ class RequestSerializationTest {
 
     @Test
     fun `validate JwtRequest serialization`() {
-        val expectedRequest = JwtRequest(token = TestValues.Token)
-        val expectedJson = """{"token":"${TestValues.Token}","action":"getJwt"}"""
+        val expectedRequest = JwtRequest(token = TestValues.TOKEN)
+        val expectedJson = """{"token":"${TestValues.TOKEN}","action":"getJwt"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<JwtRequest>(expectedJson)
@@ -384,56 +383,56 @@ class RequestSerializationTest {
         assertThat(encodedString, "encoded JwtRequest").isEqualTo(expectedJson)
         decoded.run {
             assertThat(action).isEqualTo(RequestAction.GET_JWT.value)
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
         }
     }
 
     @Test
     fun `validate OAuth serialization`() {
         val expectedRequest = OAuth(
-            code = AuthTest.AuthCode,
-            redirectUri = AuthTest.RedirectUri,
-            codeVerifier = AuthTest.CodeVerifier,
+            code = AuthTest.AUTH_CODE,
+            redirectUri = AuthTest.REDIRECT_URI,
+            codeVerifier = AuthTest.CODE_VERIFIER,
         )
         val expectedJson =
-            """{"code":"${AuthTest.AuthCode}","redirectUri":"${AuthTest.RedirectUri}","codeVerifier":"${AuthTest.CodeVerifier}"}"""
+            """{"code":"${AuthTest.AUTH_CODE}","redirectUri":"${AuthTest.REDIRECT_URI}","codeVerifier":"${AuthTest.CODE_VERIFIER}"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<OAuth>(expectedJson)
 
         assertThat(encodedString, "encoded OAuth").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(code).isEqualTo(AuthTest.AuthCode)
-            assertThat(redirectUri).isEqualTo(AuthTest.RedirectUri)
-            assertThat(codeVerifier).isEqualTo(AuthTest.CodeVerifier)
+            assertThat(code).isEqualTo(AuthTest.AUTH_CODE)
+            assertThat(redirectUri).isEqualTo(AuthTest.REDIRECT_URI)
+            assertThat(codeVerifier).isEqualTo(AuthTest.CODE_VERIFIER)
         }
     }
 
     @Test
     fun `validate OnAttachmentRequest serialization`() {
         val expectedRequest = OnAttachmentRequest(
-            token = TestValues.Token,
-            attachmentId = AttachmentValues.Id,
-            fileName = AttachmentValues.FileName,
-            fileType = AttachmentValues.FileType,
-            fileSize = AttachmentValues.FileSize,
-            fileMd5 = AttachmentValues.FileMD5,
+            token = TestValues.TOKEN,
+            attachmentId = AttachmentValues.ID,
+            fileName = AttachmentValues.FILE_NAME,
+            fileType = AttachmentValues.FILE_TYPE,
+            fileSize = AttachmentValues.FILE_SIZE,
+            fileMd5 = AttachmentValues.FILE_MD5,
             errorsAsJson = false,
         )
         val expectedJson =
-            """{"token":"${TestValues.Token}","attachmentId":"${AttachmentValues.Id}","fileName":"${AttachmentValues.FileName}","fileType":"${AttachmentValues.FileType}","fileSize":${AttachmentValues.FileSize},"fileMd5":"${AttachmentValues.FileMD5}","errorsAsJson":false,"action":"onAttachment"}"""
+            """{"token":"${TestValues.TOKEN}","attachmentId":"${AttachmentValues.ID}","fileName":"${AttachmentValues.FILE_NAME}","fileType":"${AttachmentValues.FILE_TYPE}","fileSize":${AttachmentValues.FILE_SIZE},"fileMd5":"${AttachmentValues.FILE_MD5}","errorsAsJson":false,"action":"onAttachment"}"""
 
         val encodedString = WebMessagingJson.json.encodeToString(expectedRequest)
         val decoded = WebMessagingJson.json.decodeFromString<OnAttachmentRequest>(expectedJson)
 
         assertThat(encodedString, "encoded OnAttachmentRequest").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(action).isEqualTo(RequestAction.ON_ATTACHMENT.value)
-            assertThat(fileName).isEqualTo(AttachmentValues.FileName)
-            assertThat(fileType).isEqualTo(AttachmentValues.FileType)
-            assertThat(fileSize).isEqualTo(AttachmentValues.FileSize)
-            assertThat(fileMd5).isEqualTo(AttachmentValues.FileMD5)
+            assertThat(fileName).isEqualTo(AttachmentValues.FILE_NAME)
+            assertThat(fileType).isEqualTo(AttachmentValues.FILE_TYPE)
+            assertThat(fileSize).isEqualTo(AttachmentValues.FILE_SIZE)
+            assertThat(fileMd5).isEqualTo(AttachmentValues.FILE_MD5)
             assertThat(errorsAsJson).isFalse()
         }
     }
@@ -446,7 +445,7 @@ class RequestSerializationTest {
         )
         val expectedEventList = listOf(expectedEvent)
         val expectedMessage = EventMessage(expectedEventList)
-        val expectedRequest = UserTypingRequest(token = TestValues.Token)
+        val expectedRequest = UserTypingRequest(token = TestValues.TOKEN)
         val expectedJson =
             """{"token":"<token>","action":"onMessage","message":{"events":[{"eventType":"Typing","typing":{"type":"On"}}],"type":"Event"}}"""
 
@@ -455,7 +454,7 @@ class RequestSerializationTest {
 
         assertThat(encodedString, "encoded UserTypingRequest").isEqualTo(expectedJson)
         decoded.run {
-            assertThat(token).isEqualTo(TestValues.Token)
+            assertThat(token).isEqualTo(TestValues.TOKEN)
             assertThat(action).isEqualTo(RequestAction.ON_MESSAGE.value)
             assertThat(message).isEqualTo(expectedMessage)
             message.run {

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -190,7 +190,7 @@ class SerializationTest {
                 connected = true,
                 newSession = true,
                 readOnly = false,
-                maxCustomDataBytes = TestValues.MaxCustomDataBytes,
+                maxCustomDataBytes = TestValues.MAX_CUSTOM_DATA_BYTES,
                 allowedMedia = AllowedMedia(
                     Inbound(
                         fileTypes = listOf(FileType("*/*"), FileType("video/3gpp")),

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApiTest.kt
@@ -67,7 +67,7 @@ class WebMessagingApiTest {
     @Test
     fun `when fetchHistory results in Unexpected Error`() {
         subject = buildWebMessagingApiWith { historyEngine() }
-        val expectedEntityList = Result.Failure(ErrorCode.UnexpectedError, ErrorTest.Message)
+        val expectedEntityList = Result.Failure(ErrorCode.UnexpectedError, ErrorTest.MESSAGE)
 
         val result = runBlocking {
             withTimeout(DEFAULT_TIMEOUT) {
@@ -81,11 +81,11 @@ class WebMessagingApiTest {
     @Test
     fun `when fetchHistory results in CancellationException`() {
         subject = buildWebMessagingApiWith { historyEngine() }
-        val expectedEntityList = Result.Failure(ErrorCode.CancellationError, ErrorTest.Message)
+        val expectedEntityList = Result.Failure(ErrorCode.CancellationError, ErrorTest.MESSAGE)
 
         val result = runBlocking {
             withTimeout(DEFAULT_TIMEOUT) {
-                subject.getMessages(jwt = InvalidValues.CancellationException, pageNumber = -1)
+                subject.getMessages(jwt = InvalidValues.CANCELLATION_EXCEPTION, pageNumber = -1)
             }
         }
 
@@ -141,13 +141,13 @@ class WebMessagingApiTest {
     @Test
     fun `when fetchAuthJwt is successful`() {
         subject = buildWebMessagingApiWith { authorizeEngine() }
-        val expectedResult = Result.Success(AuthJwt(AuthTest.JwtToken, AuthTest.RefreshToken))
+        val expectedResult = Result.Success(AuthJwt(AuthTest.JWT_TOKEN, AuthTest.REFRESH_TOKEN))
 
         val result = runBlocking {
             subject.fetchAuthJwt(
-                authCode = AuthTest.AuthCode,
-                redirectUri = AuthTest.RedirectUri,
-                codeVerifier = AuthTest.CodeVerifier,
+                authCode = AuthTest.AUTH_CODE,
+                redirectUri = AuthTest.REDIRECT_URI,
+                codeVerifier = AuthTest.CODE_VERIFIER,
             )
         }
 
@@ -157,8 +157,8 @@ class WebMessagingApiTest {
     @Test
     fun `when fetchAuthJwt request body has invalid params`() {
         val brokenConfigurations = Configuration(
-            deploymentId = InvalidValues.DeploymentId,
-            domain = InvalidValues.Domain,
+            deploymentId = InvalidValues.DEPLOYMENT_ID,
+            domain = InvalidValues.DOMAIN,
             logging = false
         )
         subject = buildWebMessagingApiWith(brokenConfigurations) { authorizeEngine() }
@@ -167,9 +167,9 @@ class WebMessagingApiTest {
 
         val result = runBlocking {
             subject.fetchAuthJwt(
-                authCode = AuthTest.AuthCode,
-                redirectUri = AuthTest.RedirectUri,
-                codeVerifier = AuthTest.CodeVerifier,
+                authCode = AuthTest.AUTH_CODE,
+                redirectUri = AuthTest.REDIRECT_URI,
+                codeVerifier = AuthTest.CODE_VERIFIER,
             )
         }
 
@@ -179,19 +179,19 @@ class WebMessagingApiTest {
     @Test
     fun `fetch should return result Failure when CancellationException is thrown`() {
         val brokenConfigurations = Configuration(
-            deploymentId = InvalidValues.CancellationException,
-            domain = InvalidValues.Domain,
+            deploymentId = InvalidValues.CANCELLATION_EXCEPTION,
+            domain = InvalidValues.DOMAIN,
             logging = false
         )
         subject = buildWebMessagingApiWith(brokenConfigurations) { authorizeEngine() }
 
-        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.MESSAGE)
 
         val result = runBlocking {
             subject.fetchAuthJwt(
-                authCode = AuthTest.AuthCode,
-                redirectUri = AuthTest.RedirectUri,
-                codeVerifier = AuthTest.CodeVerifier,
+                authCode = AuthTest.AUTH_CODE,
+                redirectUri = AuthTest.REDIRECT_URI,
+                codeVerifier = AuthTest.CODE_VERIFIER,
             )
         }
 
@@ -201,19 +201,19 @@ class WebMessagingApiTest {
     @Test
     fun `fetch should return result Failure when UnknownException is thrown`() {
         val brokenConfigurations = Configuration(
-            deploymentId = InvalidValues.UnknownException,
-            domain = InvalidValues.Domain,
+            deploymentId = InvalidValues.UNKNOWN_EXCEPTION,
+            domain = InvalidValues.DOMAIN,
             logging = false
         )
         subject = buildWebMessagingApiWith(brokenConfigurations) { authorizeEngine() }
 
-        val expectedResult = Result.Failure(ErrorCode.AuthFailed, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.AuthFailed, ErrorTest.MESSAGE)
 
         val result = runBlocking {
             subject.fetchAuthJwt(
-                authCode = AuthTest.AuthCode,
-                redirectUri = AuthTest.RedirectUri,
-                codeVerifier = AuthTest.CodeVerifier,
+                authCode = AuthTest.AUTH_CODE,
+                redirectUri = AuthTest.REDIRECT_URI,
+                codeVerifier = AuthTest.CODE_VERIFIER,
             )
         }
 
@@ -224,7 +224,7 @@ class WebMessagingApiTest {
     fun `when logoutFromAuthenticatedSession with valid jwt`() {
         subject = buildWebMessagingApiWith { logoutEngine() }
 
-        val result = runBlocking { subject.logoutFromAuthenticatedSession(jwt = AuthTest.JwtToken) }
+        val result = runBlocking { subject.logoutFromAuthenticatedSession(jwt = AuthTest.JWT_TOKEN) }
 
         assertTrue(result is Result.Success)
     }
@@ -235,7 +235,7 @@ class WebMessagingApiTest {
         val expectedResult = Result.Failure(ErrorCode.ClientResponseError(401), "You are not authorized")
 
         val result =
-            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.UnauthorizedJwt) }
+            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.UNAUTHORIZED_JWT) }
 
         assertEquals(expectedResult, result)
     }
@@ -243,10 +243,10 @@ class WebMessagingApiTest {
     @Test
     fun `when logoutFromAuthenticatedSession result in CancellationException`() {
         subject = buildWebMessagingApiWith { logoutEngine() }
-        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.MESSAGE)
 
         val result =
-            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.CancellationException) }
+            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.CANCELLATION_EXCEPTION) }
 
         assertEquals(expectedResult, result)
     }
@@ -254,10 +254,10 @@ class WebMessagingApiTest {
     @Test
     fun `when logoutFromAuthenticatedSession result in UnknownException`() {
         subject = buildWebMessagingApiWith { logoutEngine() }
-        val expectedResult = Result.Failure(ErrorCode.AuthLogoutFailed, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.AuthLogoutFailed, ErrorTest.MESSAGE)
 
         val result =
-            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.UnknownException) }
+            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.UNKNOWN_EXCEPTION) }
 
         assertEquals(expectedResult, result)
     }
@@ -268,7 +268,7 @@ class WebMessagingApiTest {
         val expectedResult = Result.Failure(ErrorCode.AuthLogoutFailed, "Bad Request")
 
         val result =
-            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.InvalidJwt) }
+            runBlocking { subject.logoutFromAuthenticatedSession(InvalidValues.INVALID_JWT) }
 
         assertEquals(expectedResult, result)
     }
@@ -276,9 +276,9 @@ class WebMessagingApiTest {
     @Test
     fun `when refreshToken with valid refreshToken`() {
         subject = buildWebMessagingApiWith { refreshTokenEngine() }
-        val expectedResult = Result.Success(AuthJwt(AuthTest.RefreshedJWTToken, null))
+        val expectedResult = Result.Success(AuthJwt(AuthTest.REFRESHED_JWT_TOKEN, null))
 
-        val result = runBlocking { subject.refreshAuthJwt(AuthTest.RefreshToken) }
+        val result = runBlocking { subject.refreshAuthJwt(AuthTest.REFRESH_TOKEN) }
 
         assertEquals(expectedResult, result)
     }
@@ -289,7 +289,7 @@ class WebMessagingApiTest {
         val expectedResult = Result.Failure(ErrorCode.RefreshAuthTokenFailure, "Bad Request")
 
         val result =
-            runBlocking { subject.refreshAuthJwt(InvalidValues.InvalidRefreshToken) }
+            runBlocking { subject.refreshAuthJwt(InvalidValues.INVALID_REFRESH_TOKEN) }
 
         assertEquals(expectedResult, result)
     }
@@ -297,10 +297,10 @@ class WebMessagingApiTest {
     @Test
     fun `when refreshToken result in CancellationException`() {
         subject = buildWebMessagingApiWith { refreshTokenEngine() }
-        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.CancellationError, ErrorTest.MESSAGE)
 
         val result =
-            runBlocking { subject.refreshAuthJwt(InvalidValues.CancellationException) }
+            runBlocking { subject.refreshAuthJwt(InvalidValues.CANCELLATION_EXCEPTION) }
 
         assertEquals(expectedResult, result)
     }
@@ -308,10 +308,10 @@ class WebMessagingApiTest {
     @Test
     fun `when refreshToken result in UnknownException`() {
         subject = buildWebMessagingApiWith { refreshTokenEngine() }
-        val expectedResult = Result.Failure(ErrorCode.RefreshAuthTokenFailure, ErrorTest.Message)
+        val expectedResult = Result.Failure(ErrorCode.RefreshAuthTokenFailure, ErrorTest.MESSAGE)
 
         val result =
-            runBlocking { subject.refreshAuthJwt(InvalidValues.UnknownException) }
+            runBlocking { subject.refreshAuthJwt(InvalidValues.UNKNOWN_EXCEPTION) }
 
         assertEquals(expectedResult, result)
     }
@@ -328,7 +328,7 @@ private fun buildWebMessagingApiWith(
 }
 
 private fun configuration(): Configuration = Configuration(
-    deploymentId = TestValues.DeploymentId,
-    domain = TestValues.Domain,
+    deploymentId = TestValues.DEPLOYMENT_ID,
+    domain = TestValues.DOMAIN,
     logging = false
 )

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/Authorize.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/Authorize.kt
@@ -33,7 +33,7 @@ internal fun HttpClientConfig<MockEngineConfig>.authorizeEngine() {
                             AuthJwtRequest.serializer(),
                             (request.body as TextContent).text
                         )
-                        if (requestBody.deploymentId == TestValues.DeploymentId && requestBody.oauth.code == AuthTest.AuthCode) {
+                        if (requestBody.deploymentId == TestValues.DEPLOYMENT_ID && requestBody.oauth.code == AuthTest.AUTH_CODE) {
                             respond(
                                 status = HttpStatusCode.OK,
                                 headers = headersOf(
@@ -42,17 +42,17 @@ internal fun HttpClientConfig<MockEngineConfig>.authorizeEngine() {
                                 ),
                                 content = Json.encodeToString(
                                     AuthJwt.serializer(),
-                                    AuthJwt(AuthTest.JwtToken, AuthTest.RefreshToken)
+                                    AuthJwt(AuthTest.JWT_TOKEN, AuthTest.REFRESH_TOKEN)
                                 )
                             )
                         } else {
                             when (requestBody.deploymentId) {
-                                InvalidValues.CancellationException -> {
-                                    throw CancellationException(ErrorTest.Message)
+                                InvalidValues.CANCELLATION_EXCEPTION -> {
+                                    throw CancellationException(ErrorTest.MESSAGE)
                                 }
 
-                                InvalidValues.UnknownException -> {
-                                    error(ErrorTest.Message)
+                                InvalidValues.UNKNOWN_EXCEPTION -> {
+                                    error(ErrorTest.MESSAGE)
                                 }
                                 else -> {
                                     respondBadRequest()

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/History.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/History.kt
@@ -35,10 +35,10 @@ fun HttpClientConfig<MockEngineConfig>.historyEngine() {
                     )
                 }
                 else -> {
-                    if (request.headers["Authorization"].equals("bearer ${InvalidValues.CancellationException}")) {
-                        throw CancellationException(ErrorTest.Message)
+                    if (request.headers["Authorization"].equals("bearer ${InvalidValues.CANCELLATION_EXCEPTION}")) {
+                        throw CancellationException(ErrorTest.MESSAGE)
                     } else {
-                        error(ErrorTest.Message)
+                        error(ErrorTest.MESSAGE)
                     }
                 }
             }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/Logout.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/Logout.kt
@@ -24,20 +24,20 @@ internal fun HttpClientConfig<MockEngineConfig>.logoutEngine() {
                 BASIC_LOGOUT_PATH -> {
                     if (request.method == HttpMethod.Delete) {
                         when (request.headers[HttpHeaders.Authorization]) {
-                            "bearer ${AuthTest.JwtToken}" -> {
+                            "bearer ${AuthTest.JWT_TOKEN}" -> {
                                 respondOk()
                             }
-                            "bearer ${InvalidValues.UnauthorizedJwt}" -> {
+                            "bearer ${InvalidValues.UNAUTHORIZED_JWT}" -> {
                                 respondUnauthorized()
                             }
-                            "bearer ${InvalidValues.InvalidJwt}" -> {
+                            "bearer ${InvalidValues.INVALID_JWT}" -> {
                                 respondBadRequest()
                             }
-                            "bearer ${InvalidValues.CancellationException}" -> {
-                                throw CancellationException(ErrorTest.Message)
+                            "bearer ${InvalidValues.CANCELLATION_EXCEPTION}" -> {
+                                throw CancellationException(ErrorTest.MESSAGE)
                             }
-                            "bearer ${InvalidValues.UnknownException}" -> {
-                                error(ErrorTest.Message)
+                            "bearer ${InvalidValues.UNKNOWN_EXCEPTION}" -> {
+                                error(ErrorTest.MESSAGE)
                             }
                             else -> {
                                 respondBadRequest()

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/RefreshToken.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/test_engines/RefreshToken.kt
@@ -32,7 +32,7 @@ internal fun HttpClientConfig<MockEngineConfig>.refreshTokenEngine() {
                             RefreshToken.serializer(),
                             (request.body as TextContent).text
                         )
-                        if (requestBody.refreshToken == AuthTest.RefreshToken) {
+                        if (requestBody.refreshToken == AuthTest.REFRESH_TOKEN) {
                             respond(
                                 status = HttpStatusCode.OK,
                                 headers = headersOf(
@@ -41,16 +41,16 @@ internal fun HttpClientConfig<MockEngineConfig>.refreshTokenEngine() {
                                 ),
                                 content = Json.encodeToString(
                                     AuthJwt.serializer(),
-                                    AuthJwt(AuthTest.RefreshedJWTToken, null)
+                                    AuthJwt(AuthTest.REFRESHED_JWT_TOKEN, null)
                                 )
                             )
                         } else {
                             when (requestBody.refreshToken) {
-                                InvalidValues.CancellationException -> {
-                                    throw CancellationException(ErrorTest.Message)
+                                InvalidValues.CANCELLATION_EXCEPTION -> {
+                                    throw CancellationException(ErrorTest.MESSAGE)
                                 }
-                                InvalidValues.UnknownException -> {
-                                    error(ErrorTest.Message)
+                                InvalidValues.UNKNOWN_EXCEPTION -> {
+                                    error(ErrorTest.MESSAGE)
                                 }
                                 else -> {
                                     respondBadRequest()

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -5,14 +5,14 @@ import com.genesys.cloud.messenger.transport.utility.DeploymentConfigValues
 fun createDeploymentConfigForTesting(
     messenger: Messenger = createMessengerVOForTesting(),
 ) = DeploymentConfig(
-    id = DeploymentConfigValues.Id,
-    version = DeploymentConfigValues.Version,
+    id = DeploymentConfigValues.ID,
+    version = DeploymentConfigValues.VERSION,
     languages = listOf(
-        DeploymentConfigValues.DefaultLanguage,
-        DeploymentConfigValues.SecondaryLanguage
+        DeploymentConfigValues.DEFAULT_LANGUAGE,
+        DeploymentConfigValues.SECONDARY_LANGUAGE
     ),
-    defaultLanguage = DeploymentConfigValues.DefaultLanguage,
-    apiEndpoint = DeploymentConfigValues.ApiEndPoint,
+    defaultLanguage = DeploymentConfigValues.DEFAULT_LANGUAGE,
+    apiEndpoint = DeploymentConfigValues.API_ENDPOINT,
     messenger = messenger,
     journeyEvents = JourneyEvents(enabled = false),
     status = DeploymentConfigValues.Status,
@@ -28,8 +28,8 @@ fun createMessengerVOForTesting(
 ) = Messenger(
     enabled = true,
     apps = apps,
-    styles = Styles(primaryColor = DeploymentConfigValues.PrimaryColor),
-    launcherButton = LauncherButton(visibility = DeploymentConfigValues.LauncherButtonVisibility),
+    styles = Styles(primaryColor = DeploymentConfigValues.PRIMARY_COLOR),
+    launcherButton = LauncherButton(visibility = DeploymentConfigValues.LAUNCHER_BUTTON_VISIBILITY),
     fileUpload = fileUpload
 )
 
@@ -37,8 +37,8 @@ fun createFileUploadVOForTesting(
     enableAttachments: Boolean? = false,
     modes: List<Mode> = listOf(
         Mode(
-            fileTypes = listOf(DeploymentConfigValues.FileType),
-            maxFileSizeKB = DeploymentConfigValues.MaxFileSize,
+            fileTypes = listOf(DeploymentConfigValues.FILE_TYPE),
+            maxFileSizeKB = DeploymentConfigValues.MAX_FILE_SIZE,
         )
     ),
 ): FileUpload {
@@ -50,7 +50,7 @@ fun createConversationsVOForTesting(
     conversationDisconnect: Conversations.ConversationDisconnect = Conversations.ConversationDisconnect(),
     conversationClear: Conversations.ConversationClear = Conversations.ConversationClear(enabled = true),
 ): Conversations = Conversations(
-    messagingEndpoint = DeploymentConfigValues.MessagingEndpoint,
+    messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
     autoStart = autoStart,
     conversationDisconnect = conversationDisconnect,
     conversationClear = conversationClear,

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/LogMessagesTests.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/LogMessagesTests.kt
@@ -17,7 +17,7 @@ class LogMessagesTests {
     // Attachment
     @Test
     fun `when presigningAttachment is called then it logs correctly`() {
-        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val givenAttachment = Attachment(id = AttachmentValues.ID, fileName = AttachmentValues.FILE_NAME, fileSizeInBytes = AttachmentValues.FILE_SIZE)
         val expectedMessage = "Presigning attachment: $givenAttachment"
 
         val result = LogMessages.presigningAttachment(givenAttachment)
@@ -27,7 +27,7 @@ class LogMessagesTests {
 
     @Test
     fun `when uploadingAttachment is called then it logs correctly`() {
-        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val givenAttachment = Attachment(id = AttachmentValues.ID, fileName = AttachmentValues.FILE_NAME, fileSizeInBytes = AttachmentValues.FILE_SIZE)
         val expectedMessage = "Uploading attachment: $givenAttachment"
 
         val result = LogMessages.uploadingAttachment(givenAttachment)
@@ -37,7 +37,7 @@ class LogMessagesTests {
 
     @Test
     fun `when attachmentUploaded is called then it logs correctly`() {
-        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val givenAttachment = Attachment(id = AttachmentValues.ID, fileName = AttachmentValues.FILE_NAME, fileSizeInBytes = AttachmentValues.FILE_SIZE)
         val expectedMessage = "Attachment uploaded: $givenAttachment"
 
         val result = LogMessages.attachmentUploaded(givenAttachment)
@@ -47,8 +47,8 @@ class LogMessagesTests {
 
     @Test
     fun `when detachingAttachment is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
-        val expectedMessage = "Detaching attachment: ${AttachmentValues.Id}"
+        val givenAttachmentId = AttachmentValues.ID
+        val expectedMessage = "Detaching attachment: ${AttachmentValues.ID}"
 
         val result = LogMessages.detachingAttachment(givenAttachmentId)
 
@@ -57,8 +57,8 @@ class LogMessagesTests {
 
     @Test
     fun `when attachmentDetached is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
-        val expectedMessage = "Attachment detached: ${AttachmentValues.Id}"
+        val givenAttachmentId = AttachmentValues.ID
+        val expectedMessage = "Attachment detached: ${AttachmentValues.ID}"
 
         val result = LogMessages.attachmentDetached(givenAttachmentId)
 
@@ -67,8 +67,8 @@ class LogMessagesTests {
 
     @Test
     fun `when sendingAttachment is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
-        val expectedMessage = "Sending attachment: ${AttachmentValues.Id}"
+        val givenAttachmentId = AttachmentValues.ID
+        val expectedMessage = "Sending attachment: ${AttachmentValues.ID}"
 
         val result = LogMessages.sendingAttachment(givenAttachmentId)
 
@@ -77,7 +77,7 @@ class LogMessagesTests {
 
     @Test
     fun `when attachmentSent is called then it logs correctly`() {
-        val givenAttachments = mapOf(AttachmentValues.Id to Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize))
+        val givenAttachments = mapOf(AttachmentValues.ID to Attachment(id = AttachmentValues.ID, fileName = AttachmentValues.FILE_NAME, fileSizeInBytes = AttachmentValues.FILE_SIZE))
         val expectedMessage = "Attachments sent: $givenAttachments"
 
         val result = LogMessages.attachmentSent(givenAttachments)
@@ -87,7 +87,7 @@ class LogMessagesTests {
 
     @Test
     fun `when attachmentStateUpdated is called then it logs correctly`() {
-        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val givenAttachment = Attachment(id = AttachmentValues.ID, fileName = AttachmentValues.FILE_NAME, fileSizeInBytes = AttachmentValues.FILE_SIZE)
         val expectedMessage = "Attachment state updated: $givenAttachment"
 
         val result = LogMessages.attachmentStateUpdated(givenAttachment)
@@ -97,7 +97,7 @@ class LogMessagesTests {
 
     @Test
     fun `when attach is called then it logs correctly`() {
-        val givenFileName = AttachmentValues.FileName
+        val givenFileName = AttachmentValues.FILE_NAME
         val expectedMessage = "attach(fileName = $givenFileName)"
 
         val result = LogMessages.attach(givenFileName)
@@ -107,7 +107,7 @@ class LogMessagesTests {
 
     @Test
     fun `when detach is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
+        val givenAttachmentId = AttachmentValues.ID
         val expectedMessage = "detach(attachmentId = $givenAttachmentId)"
 
         val result = LogMessages.detach(givenAttachmentId)
@@ -117,9 +117,9 @@ class LogMessagesTests {
 
     @Test
     fun `when attachmentError is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
+        val givenAttachmentId = AttachmentValues.ID
         val givenErrorCode = ErrorCode.AttachmentNotFound
-        val givenErrorMessage = ErrorTest.Message
+        val givenErrorMessage = ErrorTest.MESSAGE
         val expectedMessage = "Attachment error with id: $givenAttachmentId. ErrorCode: $givenErrorCode, errorMessage: $givenErrorMessage"
 
         val result = LogMessages.attachmentError(givenAttachmentId, givenErrorCode, givenErrorMessage)
@@ -129,7 +129,7 @@ class LogMessagesTests {
 
     @Test
     fun `when invalidAttachmentId is called then it logs correctly`() {
-        val givenAttachmentId = AttachmentValues.Id
+        val givenAttachmentId = AttachmentValues.ID
         val expectedMessage = "Invalid attachment ID: $givenAttachmentId. Detach failed."
 
         val result = LogMessages.invalidAttachmentId(givenAttachmentId)
@@ -140,7 +140,7 @@ class LogMessagesTests {
     // Authentication
     @Test
     fun `when configureAuthenticatedSession is called then it logs correctly`() {
-        val givenToken = TestValues.Token
+        val givenToken = TestValues.TOKEN
         val givenStartNew = true
         val expectedMessage = "configureAuthenticatedSession(token = $givenToken, startNew: $givenStartNew)"
 
@@ -151,7 +151,7 @@ class LogMessagesTests {
 
     @Test
     fun `when configureSession is called then it logs correctly`() {
-        val givenToken = TestValues.Token
+        val givenToken = TestValues.TOKEN
         val givenStartNew = false
         val expectedMessage = "configureSession (token = $givenToken, startNew: $givenStartNew)"
 
@@ -193,8 +193,8 @@ class LogMessagesTests {
 
     @Test
     fun `when receiveMessageError is called then it logs correctly`() {
-        val givenCode = ErrorTest.Code
-        val givenLocalizedDescription = ErrorTest.Message
+        val givenCode = ErrorTest.CODE_404
+        val givenLocalizedDescription = ErrorTest.MESSAGE
         val expectedMessage = "receiveMessageWithCompletionHandler error [$givenCode] $givenLocalizedDescription"
 
         val result = LogMessages.receiveMessageError(givenCode, givenLocalizedDescription)
@@ -204,7 +204,7 @@ class LogMessagesTests {
 
     @Test
     fun `when fetchingHistory is called then it logs correctly`() {
-        val givenPageIndex = MessageValues.PageNumber
+        val givenPageIndex = MessageValues.PAGE_NUMBER
         val expectedMessage = "fetching history for page index = $givenPageIndex"
 
         val result = LogMessages.fetchingHistory(givenPageIndex)
@@ -235,7 +235,7 @@ class LogMessagesTests {
 
     @Test
     fun `when unhandledMessage is called then it logs correctly`() {
-        val givenDecoded = WebMessagingMessage(type = MessageValues.Type, code = MessageValues.PreIdentifiedMessageCode, body = MessageValues.Text)
+        val givenDecoded = WebMessagingMessage(type = MessageValues.TYPE, code = MessageValues.PRE_IDENTIFIED_MESSAGE_CODE, body = MessageValues.TEXT)
         val expectedMessage = "Unhandled message received from Shyrka: $givenDecoded"
 
         val result = LogMessages.unhandledMessage(givenDecoded)
@@ -245,7 +245,7 @@ class LogMessagesTests {
 
     @Test
     fun `when historyFetchFailed is called then it logs correctly`() {
-        val givenError = Result.Failure(ErrorCode.UnexpectedError, ErrorTest.Message)
+        val givenError = Result.Failure(ErrorCode.UnexpectedError, ErrorTest.MESSAGE)
         val expectedMessage = "History fetch failed with: $givenError"
 
         val result = LogMessages.historyFetchFailed(givenError)

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/LogMessagesTests.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/LogMessagesTests.kt
@@ -1,0 +1,520 @@
+package com.genesys.cloud.messenger.transport.utility
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.genesys.cloud.messenger.transport.core.Attachment
+import com.genesys.cloud.messenger.transport.core.ErrorCode
+import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.core.MessagingClient
+import com.genesys.cloud.messenger.transport.core.Result
+import com.genesys.cloud.messenger.transport.core.events.Event
+import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
+import com.genesys.cloud.messenger.transport.util.logs.LogMessages
+import kotlin.test.Test
+
+class LogMessagesTests {
+
+    // Attachment
+    @Test
+    fun `when presigningAttachment is called then it logs correctly`() {
+        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val expectedMessage = "Presigning attachment: $givenAttachment"
+
+        val result = LogMessages.presigningAttachment(givenAttachment)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when uploadingAttachment is called then it logs correctly`() {
+        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val expectedMessage = "Uploading attachment: $givenAttachment"
+
+        val result = LogMessages.uploadingAttachment(givenAttachment)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attachmentUploaded is called then it logs correctly`() {
+        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val expectedMessage = "Attachment uploaded: $givenAttachment"
+
+        val result = LogMessages.attachmentUploaded(givenAttachment)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when detachingAttachment is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val expectedMessage = "Detaching attachment: ${AttachmentValues.Id}"
+
+        val result = LogMessages.detachingAttachment(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attachmentDetached is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val expectedMessage = "Attachment detached: ${AttachmentValues.Id}"
+
+        val result = LogMessages.attachmentDetached(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when sendingAttachment is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val expectedMessage = "Sending attachment: ${AttachmentValues.Id}"
+
+        val result = LogMessages.sendingAttachment(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attachmentSent is called then it logs correctly`() {
+        val givenAttachments = mapOf(AttachmentValues.Id to Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize))
+        val expectedMessage = "Attachments sent: $givenAttachments"
+
+        val result = LogMessages.attachmentSent(givenAttachments)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attachmentStateUpdated is called then it logs correctly`() {
+        val givenAttachment = Attachment(id = AttachmentValues.Id, fileName = AttachmentValues.FileName, fileSizeInBytes = AttachmentValues.FileSize)
+        val expectedMessage = "Attachment state updated: $givenAttachment"
+
+        val result = LogMessages.attachmentStateUpdated(givenAttachment)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attach is called then it logs correctly`() {
+        val givenFileName = AttachmentValues.FileName
+        val expectedMessage = "attach(fileName = $givenFileName)"
+
+        val result = LogMessages.attach(givenFileName)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when detach is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val expectedMessage = "detach(attachmentId = $givenAttachmentId)"
+
+        val result = LogMessages.detach(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when attachmentError is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val givenErrorCode = ErrorCode.AttachmentNotFound
+        val givenErrorMessage = ErrorTest.Message
+        val expectedMessage = "Attachment error with id: $givenAttachmentId. ErrorCode: $givenErrorCode, errorMessage: $givenErrorMessage"
+
+        val result = LogMessages.attachmentError(givenAttachmentId, givenErrorCode, givenErrorMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when invalidAttachmentId is called then it logs correctly`() {
+        val givenAttachmentId = AttachmentValues.Id
+        val expectedMessage = "Invalid attachment ID: $givenAttachmentId. Detach failed."
+
+        val result = LogMessages.invalidAttachmentId(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    // Authentication
+    @Test
+    fun `when configureAuthenticatedSession is called then it logs correctly`() {
+        val givenToken = TestValues.Token
+        val givenStartNew = true
+        val expectedMessage = "configureAuthenticatedSession(token = $givenToken, startNew: $givenStartNew)"
+
+        val result = LogMessages.configureAuthenticatedSession(givenToken, givenStartNew)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when configureSession is called then it logs correctly`() {
+        val givenToken = TestValues.Token
+        val givenStartNew = false
+        val expectedMessage = "configureSession (token = $givenToken, startNew: $givenStartNew)"
+
+        val result = LogMessages.configureSession(givenToken, givenStartNew)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    // Message
+    @Test
+    fun `when messagePreparedToSend is called then it logs correctly`() {
+        val givenMessage = Message()
+        val expectedMessage = "Message prepared to send: $givenMessage"
+
+        val result = LogMessages.messagePreparedToSend(givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when messageStateUpdated is called then it logs correctly`() {
+        val givenMessage = Message()
+        val expectedMessage = "Message state updated: $givenMessage"
+
+        val result = LogMessages.messageStateUpdated(givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when messageHistoryUpdated is called then it logs correctly`() {
+        val givenMessages = listOf(Message())
+        val expectedMessage = "Message history updated with: $givenMessages."
+
+        val result = LogMessages.messageHistoryUpdated(givenMessages)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when receiveMessageError is called then it logs correctly`() {
+        val givenCode = ErrorTest.Code
+        val givenLocalizedDescription = ErrorTest.Message
+        val expectedMessage = "receiveMessageWithCompletionHandler error [$givenCode] $givenLocalizedDescription"
+
+        val result = LogMessages.receiveMessageError(givenCode, givenLocalizedDescription)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when fetchingHistory is called then it logs correctly`() {
+        val givenPageIndex = MessageValues.PageNumber
+        val expectedMessage = "fetching history for page index = $givenPageIndex"
+
+        val result = LogMessages.fetchingHistory(givenPageIndex)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when onMessage is called then it logs correctly`() {
+        val givenText = TestValues.DEFAULT_STRING
+        val expectedMessage = "onMessage(text = $givenText)"
+
+        val result = LogMessages.onMessage(givenText)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when sendMessage is called then it logs correctly`() {
+        val givenText = TestValues.DEFAULT_STRING
+        val givenCustomAttributes = TestValues.defaultMap
+        val expectedMessage = "sendMessage(text = $givenText, customAttributes = $givenCustomAttributes)"
+
+        val result = LogMessages.sendMessage(givenText, givenCustomAttributes)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when unhandledMessage is called then it logs correctly`() {
+        val givenDecoded = WebMessagingMessage(type = MessageValues.Type, code = MessageValues.PreIdentifiedMessageCode, body = MessageValues.Text)
+        val expectedMessage = "Unhandled message received from Shyrka: $givenDecoded"
+
+        val result = LogMessages.unhandledMessage(givenDecoded)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when historyFetchFailed is called then it logs correctly`() {
+        val givenError = Result.Failure(ErrorCode.UnexpectedError, ErrorTest.Message)
+        val expectedMessage = "History fetch failed with: $givenError"
+
+        val result = LogMessages.historyFetchFailed(givenError)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when onFailure is called then it logs correctly`() {
+        val givenThrowable = Throwable("Some error")
+        val expectedMessage = "onFailure(message: ${givenThrowable.message})"
+
+        val result = LogMessages.onFailure(givenThrowable)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when unsupportedMessageType is called then it logs correctly`() {
+        val givenMessageType = Message.Type.Text
+        val expectedMessage = "Messages of type: $givenMessageType are not supported."
+
+        val result = LogMessages.unsupportedMessageType(givenMessageType)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when typingIndicatorCoolDown is called then it logs correctly`() {
+        val givenMilliseconds = 5000L
+        val expectedMessage = "Typing event can be sent only once every $givenMilliseconds milliseconds."
+
+        val result = LogMessages.typingIndicatorCoolDown(givenMilliseconds)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    // Session State
+    @Test
+    fun `when onSentState is called then it logs correctly`() {
+        val givenState = "Sent"
+        val expectedMessage = "onSent. state = $givenState"
+
+        val result = LogMessages.onSentState(givenState)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when onClosing is called then it logs correctly`() {
+        val givenCode = 1001
+        val givenReason = "Going away"
+        val expectedMessage = "onClosing(code = $givenCode, reason = $givenReason)"
+
+        val result = LogMessages.onClosing(givenCode, givenReason)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when onClosed is called then it logs correctly`() {
+        val givenCode = 1000
+        val givenReason = "Normal closure"
+        val expectedMessage = "onClosed(code = $givenCode, reason = $givenReason)"
+
+        val result = LogMessages.onClosed(givenCode, givenReason)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when stateChanged is called then it logs correctly`() {
+        val givenOldState = MessagingClient.State.Connecting
+        val givenNewState = MessagingClient.State.Connected
+        val expectedMessage = "State changed from: ${givenOldState::class.simpleName}, to: ${givenNewState::class.simpleName}"
+
+        val result = LogMessages.stateChanged(givenOldState, givenNewState)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when onEvent is called then it logs correctly`() {
+        val givenEvent = Event.Logout
+        val expectedMessage = "on event: $givenEvent"
+
+        val result = LogMessages.onEvent(givenEvent)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when socketDidOpen is called then it logs correctly`() {
+        val givenActive = true
+        val expectedMessage = "Socket did open. Active: $givenActive."
+
+        val result = LogMessages.socketDidOpen(givenActive)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when socketDidClose is called then it logs correctly`() {
+        val givenCode = 1006L
+        val givenReason = "Abnormal closure"
+        val givenActive = false
+        val expectedMessage = "Socket did close (code: $givenCode, reason: $givenReason). Active: $givenActive."
+
+        val result = LogMessages.socketDidClose(givenCode, givenReason, givenActive)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when closeSocket is called then it logs correctly`() {
+        val givenCode = 4000
+        val givenReason = "Manual close"
+        val expectedMessage = "closeSocket(code = $givenCode, reason = $givenReason)"
+
+        val result = LogMessages.closeSocket(givenCode, givenReason)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when failedFetchDeploymentConfig is called then it logs correctly`() {
+        val givenError = Exception("Deployment fetch error")
+        val expectedMessage = "Failed to fetch deployment config: $givenError"
+
+        val result = LogMessages.failedFetchDeploymentConfig(givenError)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when healthCheckCoolDown is called then it logs correctly`() {
+        val givenMilliseconds = 3000L
+        val expectedMessage = "Health check can be sent only once every $givenMilliseconds milliseconds."
+
+        val result = LogMessages.healthCheckCoolDown(givenMilliseconds)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when deactivateWithCloseCode is called then it logs correctly`() {
+        val givenCode = 1000
+        val givenReason = "Session ended"
+        val expectedMessage = "deactivateWithCloseCode(code = $givenCode, reason = $givenReason)"
+
+        val result = LogMessages.deactivateWithCloseCode(givenCode, givenReason)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when tryingToReconnect is called then it logs correctly`() {
+        val givenAttempts = 2
+        val givenMaxAttempts = 5
+        val expectedMessage = "Trying to reconnect. Attempt number: $givenAttempts out of $givenMaxAttempts"
+
+        val result = LogMessages.tryingToReconnect(givenAttempts, givenMaxAttempts)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when cancellationExceptionRequestName is called then it logs correctly`() {
+        val givenRequestName = "Reconnect"
+        val expectedMessage = "Cancellation exception was thrown, while running $givenRequestName request."
+
+        val result = LogMessages.cancellationExceptionRequestName(givenRequestName)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when cancellationExceptionAttachmentUpload is called then it logs correctly`() {
+        val givenAttachmentId = TestValues.DEFAULT_STRING
+        val expectedMessage = "Cancellation exception during attachment upload: $givenAttachmentId"
+
+        val result = LogMessages.cancellationExceptionAttachmentUpload(givenAttachmentId)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when unhandledErrorCode is called then it logs correctly`() {
+        val givenErrorCode = ErrorCode.FeatureUnavailable
+        val givenMessage = "Feature not supported"
+        val expectedMessage = "Unhandled ErrorCode: $givenErrorCode with optional message: $givenMessage"
+
+        val result = LogMessages.unhandledErrorCode(givenErrorCode, givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when unhandledWebSocketError is called then it logs correctly`() {
+        val givenErrorCode = ErrorCode.FileSizeInvalid
+        val expectedMessage = "Unhandled WebSocket errorCode. ErrorCode: $givenErrorCode"
+
+        val result = LogMessages.unhandledWebSocketError(givenErrorCode)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when couldNotRefreshAuthToken is called then it logs correctly`() {
+        val givenMessage = "Invalid token"
+        val expectedMessage = "Could not refreshAuthToken: $givenMessage"
+
+        val result = LogMessages.couldNotRefreshAuthToken(givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when requestError is called then it logs correctly`() {
+        val givenRequestName = "SendMessage"
+        val givenErrorCode = ErrorCode.AuthFailed
+        val givenMessage = "Connection timeout"
+        val expectedMessage = "$givenRequestName responded with error: $givenErrorCode, and message: $givenMessage"
+
+        val result = LogMessages.requestError(givenRequestName, givenErrorCode, givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    // Custom Attributes
+    @Test
+    fun `when addCustomAttribute is called then it logs correctly`() {
+        val givenCustomAttributes = TestValues.defaultMap
+        val givenState = "ACTIVE"
+        val expectedMessage = "add: $givenCustomAttributes | state = $givenState"
+
+        val result = LogMessages.addCustomAttribute(givenCustomAttributes, givenState)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    // Quick Replies
+    @Test
+    fun `when quickReplyPrepareToSend is called then it logs correctly`() {
+        val givenMessage = Message()
+        val expectedMessage = "Message with quick reply prepared to send: $givenMessage"
+
+        val result = LogMessages.quickReplyPrepareToSend(givenMessage)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when sendQuickReply is called then it logs correctly`() {
+        val givenButtonResponse = QuickReplyTestValues.buttonResponse_a
+        val expectedMessage = "sendQuickReply(buttonResponse: $givenButtonResponse)"
+
+        val result = LogMessages.sendQuickReply(givenButtonResponse)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+
+    @Test
+    fun `when ignoreInboundEvent is called then it logs correctly`() {
+        val givenEvent = Event.ConversationDisconnect
+        val expectedMessage = "Ignore inbound event: $givenEvent."
+
+        val result = LogMessages.ignoreInboundEvent(givenEvent)
+
+        assertThat(result).isEqualTo(expectedMessage)
+    }
+}

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -6,144 +6,140 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.ButtonResponseContent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.QuickReplyContent
-import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.VAULT_KEY
 import com.genesys.cloud.messenger.transport.util.Vault
-import com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED
 
 internal const val DEFAULT_TIMEOUT = 10000L
 
 object TestValues {
-    internal const val Domain: String = "inindca.com"
-    internal const val DeploymentId = "deploymentId"
-    internal const val MaxCustomDataBytes = 100
-    internal const val DefaultNumber = 1
-    internal const val Timestamp = "2022-08-22T19:24:26.704Z"
-    internal const val Token = "<token>"
-    internal const val SecondaryToken = "<secondary_token>"
-    internal const val ReconnectionTimeout = 5000L
-    internal const val NoReconnectionAttempts = 0L
-    internal const val VaultKey = "vault_key"
-    internal const val TokenKey = "token_key"
-    internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
-    internal const val WasAuthenticated = "was_authenticated"
-    internal const val LogTag = "TestLogTag"
+    internal const val DOMAIN: String = "inindca.com"
+    internal const val DEPLOYMENT_ID = "deploymentId"
+    internal const val MAX_CUSTOM_DATA_BYTES = 100
+    internal const val DEFAULT_NUMBER = 1
+    internal const val TIME_STAMP = "2022-08-22T19:24:26.704Z"
+    internal const val TOKEN = "<token>"
+    internal const val SECONDARY_TOKEN = "<secondary_token>"
+    internal const val RECONNECTION_TIMEOUT = 5000L
+    internal const val NO_RECONNECTION_ATTEMPTS = 0L
+    internal const val VAULT_KEY = "vault_key"
+    internal const val TOKEN_KEY = "token_key"
+    internal const val AUTH_REFRESH_TOKEN_KEY = "auth_refresh_token_key"
+    internal const val WAS_AUTHENTICATED = "was_authenticated"
+    internal const val LOG_TAG = "TestLogTag"
     internal val defaultMap = mapOf("A" to "B")
     internal const val DEFAULT_STRING = "any string"
     internal val vaultKeys = Vault.Keys(
-        vaultKey = VAULT_KEY,
-        tokenKey = TOKEN_KEY,
-        authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
-        wasAuthenticated = WAS_AUTHENTICATED,
+        vaultKey = com.genesys.cloud.messenger.transport.util.VAULT_KEY,
+        tokenKey = com.genesys.cloud.messenger.transport.util.TOKEN_KEY,
+        authRefreshTokenKey = com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY,
+        wasAuthenticated = com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED,
     )
 }
 
 object AuthTest {
-    internal const val AuthCode = "auth_code"
-    internal const val RedirectUri = "https://example.com/redirect"
-    internal const val JwtAuthUrl = "https://example.com/auth"
-    internal const val CodeVerifier = "code_verifier"
-    internal const val JwtToken = "jwt_Token"
-    internal const val RefreshToken = "refresh_token"
-    internal const val RefreshedJWTToken = "jwt_token_that_was_refreshed"
-    internal const val JwtExpiry = 100L
+    internal const val AUTH_CODE = "auth_code"
+    internal const val REDIRECT_URI = "https://example.com/redirect"
+    internal const val JWT_AUTH_URL = "https://example.com/auth"
+    internal const val CODE_VERIFIER = "code_verifier"
+    internal const val JWT_TOKEN = "jwt_Token"
+    internal const val REFRESH_TOKEN = "refresh_token"
+    internal const val REFRESHED_JWT_TOKEN = "jwt_token_that_was_refreshed"
+    internal const val JWT_EXPIRY = 100L
 }
 
 object ErrorTest {
-    internal const val Message = "This is a generic error message for testing."
-    internal const val RetryAfter = 1
-    internal const val Code = 404L
+    internal const val MESSAGE = "This is a generic error message for testing."
+    internal const val RETRY_AFTER = 1
+    internal const val CODE_404 = 404L
 }
 
 object InvalidValues {
-    internal const val Domain = "invalid_domain"
-    internal const val DeploymentId = "invalid_deploymentId"
-    internal const val InvalidJwt = "invalid_jwt"
-    internal const val UnauthorizedJwt = "unauthorized_jwt"
-    internal const val InvalidRefreshToken = "invalid_refresh_token"
-    internal const val CancellationException = "cancellation_exception"
-    internal const val UnknownException = "unknown_exception"
+    internal const val DOMAIN = "invalid_domain"
+    internal const val DEPLOYMENT_ID = "invalid_deploymentId"
+    internal const val INVALID_JWT = "invalid_jwt"
+    internal const val UNAUTHORIZED_JWT = "unauthorized_jwt"
+    internal const val INVALID_REFRESH_TOKEN = "invalid_refresh_token"
+    internal const val CANCELLATION_EXCEPTION = "cancellation_exception"
+    internal const val UNKNOWN_EXCEPTION = "unknown_exception"
 }
 
 object MessageValues {
-    internal const val Id = "test_message_id"
-    internal const val ParticipantName = "participant_name"
-    internal const val ParticipantLastName = "participant_last_name"
-    internal const val ParticipantNickname = "participant_nickname"
-    internal const val ParticipantImageUrl = "http://participant.image"
-    internal const val Text = "Hello world!"
-    internal const val Type = "Text"
-    internal const val TimeStamp = 1L
-    internal const val PageSize = 25
-    internal const val PageNumber = 1
-    internal const val Total = 25
-    internal const val PageCount = 1
-    internal const val PreIdentifiedMessageType = "type"
-    internal const val PreIdentifiedMessageCode = 200
-    internal const val PreIdentifiedMessageClass = "clazz"
+    internal const val ID = "test_message_id"
+    internal const val PARTICIPANT_NAME = "participant_name"
+    internal const val PARTICIPANT_LAST_NAME = "participant_last_name"
+    internal const val PARTICIPANT_NICKNAME = "participant_nickname"
+    internal const val PARTICIPANT_IMAGE_URL = "http://participant.image"
+    internal const val TEXT = "Hello world!"
+    internal const val TYPE = "Text"
+    internal const val TIME_STAMP = 1L
+    internal const val PAGE_SIZE = 25
+    internal const val PAGE_NUMBER = 1
+    internal const val TOTAL = 25
+    internal const val PAGE_COUNT = 1
+    internal const val PRE_IDENTIFIED_MESSAGE_TYPE = "type"
+    internal const val PRE_IDENTIFIED_MESSAGE_CODE = 200
+    internal const val PRE_IDENTIFIED_MESSAGE_CLASS = "clazz"
 }
 
 object AttachmentValues {
-    internal const val Id = "test_attachment_id"
-    internal const val DownloadUrl = "https://downloadurl.png"
-    internal const val PresignedHeaderKey = "x-amz-tagging"
-    internal const val PresignedHeaderValue = "abc"
-    internal const val FileName = "fileName.png"
-    internal const val FileSize = 100
-    internal const val FileMD5 = "file_md5"
-    internal const val FileType = "png"
-    internal const val MediaType = "png"
-    internal const val AttachmentContentType = "Attachment"
+    internal const val ID = "test_attachment_id"
+    internal const val DOWNLOAD_URL = "https://downloadurl.png"
+    internal const val PRESIGNED_HEADER_KEY = "x-amz-tagging"
+    internal const val PRESIGNED_HEADER_VALUE = "abc"
+    internal const val FILE_NAME = "fileName.png"
+    internal const val FILE_SIZE = 100
+    internal const val FILE_MD5 = "file_md5"
+    internal const val FILE_TYPE = "png"
+    internal const val MEDIA_TYPE = "png"
+    internal const val ATTACHMENT_CONTENT_TYPE = "Attachment"
 }
 
 object DeploymentConfigValues {
-    internal const val ApiEndPoint = "api_endpoint"
-    internal const val DefaultLanguage = "en-us"
-    internal const val SecondaryLanguage = "zh-cn"
-    internal const val Id = "id"
-    internal const val MessagingEndpoint = "messaging_endpoint"
-    internal const val PrimaryColor = "red"
-    internal const val LauncherButtonVisibility = "On"
-    internal const val MaxFileSize = 100L
-    internal const val FileType = "png"
+    internal const val API_ENDPOINT = "api_endpoint"
+    internal const val DEFAULT_LANGUAGE = "en-us"
+    internal const val SECONDARY_LANGUAGE = "zh-cn"
+    internal const val ID = "id"
+    internal const val MESSAGING_ENDPOINT = "messaging_endpoint"
+    internal const val PRIMARY_COLOR = "red"
+    internal const val LAUNCHER_BUTTON_VISIBILITY = "On"
+    internal const val MAX_FILE_SIZE = 100L
+    internal const val FILE_TYPE = "png"
     internal val Status = DeploymentConfig.Status.Active
-    internal const val Version = "1"
+    internal const val VERSION = "1"
 }
 
 object Journey {
-    internal const val CustomerId = "customer_id"
-    internal const val CustomerIdType = "customer_id_type"
-    internal const val CustomerSessionId = "customer_session_id"
-    internal const val CustomerSessionType = "customer_session_type"
-    internal const val ActionId = "action_id"
-    internal const val ActionMapId = "action_map_id"
-    internal const val ActionMapVersion = 1.0f
+    internal const val CUSTOMER_ID = "customer_id"
+    internal const val CUSTOMER_ID_TYPE = "customer_id_type"
+    internal const val CUSTOMER_SESSION_ID = "customer_session_id"
+    internal const val CUSTOMER_SESSION_TYPE = "customer_session_type"
+    internal const val ACTION_ID = "action_id"
+    internal const val ACTION_MAP_ID = "action_map_id"
+    internal const val ACTION_MAP_VERSION = 1.0f
 }
 
 object QuickReplyTestValues {
-    internal const val Text_A = "text_a"
-    internal const val Text_B = "text_b"
-    internal const val Payload_A = "payload_a"
-    internal const val Payload_B = "payload_b"
-    internal const val QuickReply = "QuickReply"
-    internal const val ButtonResponse = "ButtonResponse"
+    internal const val TEXT_A = "text_a"
+    internal const val TEXT_B = "text_b"
+    internal const val PAYLOAD_A = "payload_a"
+    internal const val PAYLOAD_B = "payload_b"
+    internal const val QUICK_REPLY = "QuickReply"
+    internal const val BUTTON_RESPONSE = "ButtonResponse"
 
     internal val buttonResponse_a = ButtonResponse(
-        text = Text_A,
-        payload = Payload_A,
-        type = QuickReply
+        text = TEXT_A,
+        payload = PAYLOAD_A,
+        type = QUICK_REPLY
     )
 
     internal val buttonResponse_b = ButtonResponse(
-        text = Text_B,
-        payload = Payload_B,
-        type = QuickReply
+        text = TEXT_B,
+        payload = PAYLOAD_B,
+        type = QUICK_REPLY
     )
 
     internal fun createQuickReplyContentForTesting(
-        text: String = Text_A,
-        payload: String = Payload_A,
+        text: String = TEXT_A,
+        payload: String = PAYLOAD_A,
     ) = QuickReplyContent(
         contentType = StructuredMessage.Content.Type.QuickReply.name,
         quickReply = QuickReplyContent.QuickReply(
@@ -154,21 +150,21 @@ object QuickReplyTestValues {
     )
 
     internal fun createButtonResponseContentForTesting(
-        text: String = Text_A,
-        payload: String = Payload_A,
+        text: String = TEXT_A,
+        payload: String = PAYLOAD_A,
     ) = ButtonResponseContent(
         contentType = StructuredMessage.Content.Type.ButtonResponse.name,
         buttonResponse = ButtonResponseContent.ButtonResponse(
             text = text,
             payload = payload,
-            type = QuickReply,
+            type = QUICK_REPLY,
         )
     )
 }
 
 object StructuredMessageValues {
     internal fun createStructuredMessageForTesting(
-        id: String = MessageValues.Id,
+        id: String = MessageValues.ID,
         type: StructuredMessage.Type = StructuredMessage.Type.Text,
         direction: String = Message.Direction.Inbound.name,
         content: List<StructuredMessage.Content> = emptyList(),

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -6,144 +6,141 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.DeploymentConfig
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.ButtonResponseContent
 import com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.QuickReplyContent
-import com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.TOKEN_KEY
-import com.genesys.cloud.messenger.transport.util.VAULT_KEY
 import com.genesys.cloud.messenger.transport.util.Vault
-import com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED
 
 internal const val DEFAULT_TIMEOUT = 10000L
 
 object TestValues {
-    internal const val Domain: String = "inindca.com"
-    internal const val DeploymentId = "deploymentId"
-    internal const val MaxCustomDataBytes = 100
-    internal const val DefaultNumber = 1
-    internal const val Timestamp = "2022-08-22T19:24:26.704Z"
-    internal const val Token = "<token>"
-    internal const val SecondaryToken = "<secondary_token>"
-    internal const val ReconnectionTimeout = 5000L
-    internal const val NoReconnectionAttempts = 0L
-    internal const val VaultKey = "vault_key"
-    internal const val TokenKey = "token_key"
-    internal const val AuthRefreshTokenKey = "auth_refresh_token_key"
-    internal const val WasAuthenticated = "was_authenticated"
-    internal const val LogTag = "TestLogTag"
+    internal const val DOMAIN: String = "inindca.com"
+    internal const val DEPLOYMENT_ID = "deploymentId"
+    internal const val MAX_CUSTOM_DATA_BYTES = 100
+    internal const val DEFAULT_NUMBER = 1
+    internal const val TIME_STAMP = "2022-08-22T19:24:26.704Z"
+    internal const val TOKEN = "<token>"
+    internal const val SECONDARY_TOKEN = "<secondary_token>"
+    internal const val RECONNECTION_TIMEOUT = 5000L
+    internal const val NO_RECONNECTION_ATTEMPTS = 0L
+    internal const val VAULT_KEY = "vault_key"
+    internal const val TOKEN_KEY = "token_key"
+    internal const val AUTH_REFRESH_TOKEN_KEY = "auth_refresh_token_key"
+    internal const val WAS_AUTHENTICATED = "was_authenticated"
+    internal const val LOG_TAG = "TestLogTag"
     internal val defaultMap = mapOf("A" to "B")
     internal const val DEFAULT_STRING = "any string"
     internal val vaultKeys = Vault.Keys(
-        vaultKey = VAULT_KEY,
-        tokenKey = TOKEN_KEY,
-        authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
-        wasAuthenticated = WAS_AUTHENTICATED,
+        vaultKey = com.genesys.cloud.messenger.transport.util.VAULT_KEY,
+        tokenKey = com.genesys.cloud.messenger.transport.util.TOKEN_KEY,
+        authRefreshTokenKey = com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY,
+        wasAuthenticated = com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED,
     )
 }
 
 object AuthTest {
-    internal const val AuthCode = "auth_code"
-    internal const val RedirectUri = "https://example.com/redirect"
-    internal const val JwtAuthUrl = "https://example.com/auth"
-    internal const val CodeVerifier = "code_verifier"
-    internal const val JwtToken = "jwt_Token"
-    internal const val RefreshToken = "refresh_token"
-    internal const val RefreshedJWTToken = "jwt_token_that_was_refreshed"
-    internal const val JwtExpiry = 100L
+    internal const val AUTH_CODE = "auth_code"
+    internal const val REDIRECT_URI = "https://example.com/redirect"
+    internal const val JWT_AUTH_URL = "https://example.com/auth"
+    internal const val CODE_VERIFIER = "code_verifier"
+    internal const val JWT_TOKEN = "jwt_Token"
+    internal const val REFRESH_TOKEN = "refresh_token"
+    internal const val REFRESHED_JWT_TOKEN = "jwt_token_that_was_refreshed"
+    internal const val JWT_EXPIRY = 100L
 }
 
 object ErrorTest {
-    internal const val Message = "This is a generic error message for testing."
-    internal const val RetryAfter = 1
+    internal const val MESSAGE = "This is a generic error message for testing."
+    internal const val RETRY_AFTER = 1
+    internal const val CODE_404 = 404L
 }
 
 object InvalidValues {
-    internal const val Domain = "invalid_domain"
-    internal const val DeploymentId = "invalid_deploymentId"
-    internal const val InvalidJwt = "invalid_jwt"
-    internal const val UnauthorizedJwt = "unauthorized_jwt"
-    internal const val InvalidRefreshToken = "invalid_refresh_token"
-    internal const val CancellationException = "cancellation_exception"
-    internal const val UnknownException = "unknown_exception"
+    internal const val DOMAIN = "invalid_domain"
+    internal const val DEPLOYMENT_ID = "invalid_deploymentId"
+    internal const val INVALID_JWT = "invalid_jwt"
+    internal const val UNAUTHORIZED_JWT = "unauthorized_jwt"
+    internal const val INVALID_REFRESH_TOKEN = "invalid_refresh_token"
+    internal const val CANCELLATION_EXCEPTION = "cancellation_exception"
+    internal const val UNKNOWN_EXCEPTION = "unknown_exception"
 }
 
 object MessageValues {
-    internal const val Id = "test_message_id"
-    internal const val ParticipantName = "participant_name"
-    internal const val ParticipantLastName = "participant_last_name"
-    internal const val ParticipantNickname = "participant_nickname"
-    internal const val ParticipantImageUrl = "http://participant.image"
-    internal const val Text = "Hello world!"
-    internal const val Type = "Text"
-    internal const val TimeStamp = 1L
-    internal const val PageSize = 25
-    internal const val PageNumber = 1
-    internal const val Total = 25
-    internal const val PageCount = 1
-    internal const val PreIdentifiedMessageType = "type"
-    internal const val PreIdentifiedMessageCode = 200
-    internal const val PreIdentifiedMessageClass = "clazz"
+    internal const val ID = "test_message_id"
+    internal const val PARTICIPANT_NAME = "participant_name"
+    internal const val PARTICIPANT_LAST_NAME = "participant_last_name"
+    internal const val PARTICIPANT_NICKNAME = "participant_nickname"
+    internal const val PARTICIPANT_IMAGE_URL = "http://participant.image"
+    internal const val TEXT = "Hello world!"
+    internal const val TYPE = "Text"
+    internal const val TIME_STAMP = 1L
+    internal const val PAGE_SIZE = 25
+    internal const val PAGE_NUMBER = 1
+    internal const val TOTAL = 25
+    internal const val PAGE_COUNT = 1
+    internal const val PRE_IDENTIFIED_MESSAGE_TYPE = "type"
+    internal const val PRE_IDENTIFIED_MESSAGE_CODE = 200
+    internal const val PRE_IDENTIFIED_MESSAGE_CLASS = "clazz"
 }
 
 object AttachmentValues {
-    internal const val Id = "test_attachment_id"
-    internal const val DownloadUrl = "https://downloadurl.png"
-    internal const val PresignedHeaderKey = "x-amz-tagging"
-    internal const val PresignedHeaderValue = "abc"
-    internal const val FileName = "fileName.png"
+    internal const val ID = "test_attachment_id"
+    internal const val DOWNLOAD_URL = "https://downloadurl.png"
+    internal const val PRESIGNED_HEADER_KEY = "x-amz-tagging"
+    internal const val PRESIGNED_HEADER_VALUE = "abc"
+    internal const val FILE_NAME = "fileName.png"
+    internal const val FILE_SIZE = 100
+    internal const val FILE_MD5 = "file_md5"
+    internal const val FILE_TYPE = "png"
+    internal const val MEDIA_TYPE = "png"
+    internal const val ATTACHMENT_CONTENT_TYPE = "Attachment"
     internal const val TXT_FILE_NAME = "fileName.txt"
-    internal const val FileSize = 100
-    internal const val FileMD5 = "file_md5"
-    internal const val FileType = "png"
-    internal const val MediaType = "png"
-    internal const val AttachmentContentType = "Attachment"
 }
 
 object DeploymentConfigValues {
-    internal const val ApiEndPoint = "api_endpoint"
-    internal const val DefaultLanguage = "en-us"
-    internal const val SecondaryLanguage = "zh-cn"
-    internal const val Id = "id"
-    internal const val MessagingEndpoint = "messaging_endpoint"
-    internal const val PrimaryColor = "red"
-    internal const val LauncherButtonVisibility = "On"
-    internal const val MaxFileSize = 100L
-    internal const val FileType = "png"
+    internal const val API_ENDPOINT = "api_endpoint"
+    internal const val DEFAULT_LANGUAGE = "en-us"
+    internal const val SECONDARY_LANGUAGE = "zh-cn"
+    internal const val ID = "id"
+    internal const val MESSAGING_ENDPOINT = "messaging_endpoint"
+    internal const val PRIMARY_COLOR = "red"
+    internal const val LAUNCHER_BUTTON_VISIBILITY = "On"
+    internal const val MAX_FILE_SIZE = 100L
+    internal const val FILE_TYPE = "png"
     internal val Status = DeploymentConfig.Status.Active
-    internal const val Version = "1"
+    internal const val VERSION = "1"
 }
 
 object Journey {
-    internal const val CustomerId = "customer_id"
-    internal const val CustomerIdType = "customer_id_type"
-    internal const val CustomerSessionId = "customer_session_id"
-    internal const val CustomerSessionType = "customer_session_type"
-    internal const val ActionId = "action_id"
-    internal const val ActionMapId = "action_map_id"
-    internal const val ActionMapVersion = 1.0f
+    internal const val CUSTOMER_ID = "customer_id"
+    internal const val CUSTOMER_ID_TYPE = "customer_id_type"
+    internal const val CUSTOMER_SESSION_ID = "customer_session_id"
+    internal const val CUSTOMER_SESSION_TYPE = "customer_session_type"
+    internal const val ACTION_ID = "action_id"
+    internal const val ACTION_MAP_ID = "action_map_id"
+    internal const val ACTION_MAP_VERSION = 1.0f
 }
 
 object QuickReplyTestValues {
-    internal const val Text_A = "text_a"
-    internal const val Text_B = "text_b"
-    internal const val Payload_A = "payload_a"
-    internal const val Payload_B = "payload_b"
-    internal const val QuickReply = "QuickReply"
-    internal const val ButtonResponse = "ButtonResponse"
+    internal const val TEXT_A = "text_a"
+    internal const val TEXT_B = "text_b"
+    internal const val PAYLOAD_A = "payload_a"
+    internal const val PAYLOAD_B = "payload_b"
+    internal const val QUICK_REPLY = "QuickReply"
+    internal const val BUTTON_RESPONSE = "ButtonResponse"
 
     internal val buttonResponse_a = ButtonResponse(
-        text = Text_A,
-        payload = Payload_A,
-        type = QuickReply
+        text = TEXT_A,
+        payload = PAYLOAD_A,
+        type = QUICK_REPLY
     )
 
     internal val buttonResponse_b = ButtonResponse(
-        text = Text_B,
-        payload = Payload_B,
-        type = QuickReply
+        text = TEXT_B,
+        payload = PAYLOAD_B,
+        type = QUICK_REPLY
     )
 
     internal fun createQuickReplyContentForTesting(
-        text: String = Text_A,
-        payload: String = Payload_A,
+        text: String = TEXT_A,
+        payload: String = PAYLOAD_A,
     ) = QuickReplyContent(
         contentType = StructuredMessage.Content.Type.QuickReply.name,
         quickReply = QuickReplyContent.QuickReply(
@@ -154,21 +151,21 @@ object QuickReplyTestValues {
     )
 
     internal fun createButtonResponseContentForTesting(
-        text: String = Text_A,
-        payload: String = Payload_A,
+        text: String = TEXT_A,
+        payload: String = PAYLOAD_A,
     ) = ButtonResponseContent(
         contentType = StructuredMessage.Content.Type.ButtonResponse.name,
         buttonResponse = ButtonResponseContent.ButtonResponse(
             text = text,
             payload = payload,
-            type = QuickReply,
+            type = QUICK_REPLY,
         )
     )
 }
 
 object StructuredMessageValues {
     internal fun createStructuredMessageForTesting(
-        id: String = MessageValues.Id,
+        id: String = MessageValues.ID,
         type: StructuredMessage.Type = StructuredMessage.Type.Text,
         direction: String = Message.Direction.Inbound.name,
         content: List<StructuredMessage.Content> = emptyList(),

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -53,6 +53,7 @@ object AuthTest {
 object ErrorTest {
     internal const val Message = "This is a generic error message for testing."
     internal const val RetryAfter = 1
+    internal const val Code = 404L
 }
 
 object InvalidValues {


### PR DESCRIPTION
- Improve overall unit test coverage by adding tests of LogMessages file.

- Add variables to TestValues.kt

- Remove extra space from LogMessages.kt