### PR TITLE
MTSDK-553 txt file upload failed

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -121,6 +121,42 @@ internal class AttachmentHandlerImplTest {
     }
 
     @Test
+    fun `when prepare() txt file`() {
+        val expectedAttachment = Attachment(
+            AttachmentValues.Id,
+            AttachmentValues.TXT_FILE_NAME,
+            null,
+            State.Presigning
+        )
+        val expectedProcessedAttachment = ProcessedAttachment(expectedAttachment, ByteArray(AttachmentValues.FileSize))
+        val expectedOnAttachmentRequest = OnAttachmentRequest(
+            token = TestValues.Token,
+            attachmentId = AttachmentValues.Id,
+            fileName = AttachmentValues.TXT_FILE_NAME,
+            fileType = "text/plain",
+            fileSize = AttachmentValues.FileSize,
+            null,
+            true,
+        )
+
+        val onAttachmentRequest =
+            subject.prepare(TestValues.Token, AttachmentValues.Id, ByteArray(AttachmentValues.FileSize), AttachmentValues.TXT_FILE_NAME)
+
+        verify {
+            mockLogger.i(capture(logSlot))
+            mockAttachmentListener.invoke(capture(attachmentSlot))
+        }
+        assertThat(onAttachmentRequest).isEqualTo(expectedOnAttachmentRequest)
+        assertThat(processedAttachments).containsOnly(AttachmentValues.Id to expectedProcessedAttachment)
+        assertThat(attachmentSlot.captured).isEqualTo(expectedAttachment)
+        assertThat(logSlot[0].invoke()).isEqualTo(
+            LogMessages.presigningAttachment(
+                expectedAttachment
+            )
+        )
+    }
+
+    @Test
     fun `when upload() processed attachment`() {
         val expectedProgress = 25f
         val expectedAttachment =

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -54,7 +54,7 @@ internal class AttachmentHandlerImpl(
             token,
             attachmentId = attachmentId,
             fileName = fileName,
-            fileType = ContentType.defaultForFilePath(fileName).toString(),
+            fileType = ContentType.defaultForFilePath(fileName).withoutParameters().toString(),
             fileSize = byteArray.size,
             errorsAsJson = true,
         )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -71,7 +71,7 @@ internal class WebMessagingApi(
                 header(it.key, it.value)
             }
             presignedUrlResponse.fileName?.let {
-                contentType(ContentType.defaultForFilePath(it))
+                contentType(ContentType.defaultForFilePath(it).withoutParameters())
             }
             onUpload { bytesSendTotal: Long, contentLength: Long ->
                 progressCallback?.let { it((bytesSendTotal / contentLength.toFloat()) * 100) }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -89,6 +89,7 @@ object AttachmentValues {
     internal const val PresignedHeaderKey = "x-amz-tagging"
     internal const val PresignedHeaderValue = "abc"
     internal const val FileName = "fileName.png"
+    internal const val TXT_FILE_NAME = "fileName.txt"
     internal const val FileSize = 100
     internal const val FileMD5 = "file_md5"
     internal const val FileType = "png"


### PR DESCRIPTION
- Ignore parameters when converting file path to ContentType.