### PR TITLE
techdebt/MTSDK-76_Sending_opus_file_with_SCP_config

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/AttachmentHandlerImpl.kt
@@ -8,14 +8,13 @@ import com.genesys.cloud.messenger.transport.core.Attachment.State.Sending
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Uploaded
 import com.genesys.cloud.messenger.transport.core.Attachment.State.Uploading
 import com.genesys.cloud.messenger.transport.network.WebMessagingApi
+import com.genesys.cloud.messenger.transport.network.resolveContentType
 import com.genesys.cloud.messenger.transport.shyrka.receive.PresignedUrlResponse
 import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.send.DeleteAttachmentRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.OnAttachmentRequest
 import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogMessages
-import io.ktor.http.ContentType
-import io.ktor.http.defaultForFilePath
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -54,7 +53,7 @@ internal class AttachmentHandlerImpl(
             token,
             attachmentId = attachmentId,
             fileName = fileName,
-            fileType = ContentType.defaultForFilePath(fileName).withoutParameters().toString(),
+            fileType = resolveContentType(fileName).toString(),
             fileSize = byteArray.size,
             errorsAsJson = true,
         )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -71,7 +71,8 @@ internal class WebMessagingApi(
                 header(it.key, it.value)
             }
             presignedUrlResponse.fileName?.let {
-                contentType(ContentType.defaultForFilePath(it).withoutParameters())
+                val resolvedType = resolveContentType(it)
+                contentType(resolvedType)
             }
             onUpload { bytesSendTotal: Long, contentLength: Long ->
                 progressCallback?.let { it((bytesSendTotal / contentLength.toFloat()) * 100) }
@@ -157,3 +158,11 @@ private fun HttpRequestBuilder.headerAuthorizationBearer(jwt: String) =
 
 private fun HttpRequestBuilder.headerOrigin(origin: String) =
     header(HttpHeaders.Origin, origin)
+
+fun resolveContentType(fileName: String): ContentType {
+    val result = when {
+        fileName.endsWith(".opus", ignoreCase = true) -> ContentType("audio", "ogg")
+        else -> ContentType.defaultForFilePath(fileName).withoutParameters()
+    }
+    return result
+}


### PR DESCRIPTION
-fix: ensure .opus attachments upload with audio/ogg content type

 Transport SDK now converts .opus files to use audio/ogg MIME type for successful upload.