### PR TITLE
techdebt/MTSDK-555_Flaky_whenUploadFile_fails_with_ResponseError

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -34,9 +34,9 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.newSingleThreadContext
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.encodeToString
@@ -62,8 +62,7 @@ internal class AttachmentHandlerImplTest {
     private val givenUploadSuccessEvent = uploadSuccessEvent()
 
     @ExperimentalCoroutinesApi
-    private val threadSurrogate = newSingleThreadContext("main thread")
-
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
     private val subject = AttachmentHandlerImpl(
         mockApi,
         mockLogger,
@@ -74,14 +73,13 @@ internal class AttachmentHandlerImplTest {
     @ExperimentalCoroutinesApi
     @Before
     fun setup() {
-        Dispatchers.setMain(threadSurrogate)
+        Dispatchers.setMain(dispatcher)
     }
 
     @ExperimentalCoroutinesApi
     @After
     fun tearDown() {
         Dispatchers.resetMain()
-        threadSurrogate.close()
     }
 
     @Test

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerImplTest.kt
@@ -37,6 +37,7 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import kotlinx.serialization.encodeToString
@@ -62,7 +63,7 @@ internal class AttachmentHandlerImplTest {
     private val givenUploadSuccessEvent = uploadSuccessEvent()
 
     @ExperimentalCoroutinesApi
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Unconfined
+    private val dispatcher: CoroutineDispatcher = UnconfinedTestDispatcher()
     private val subject = AttachmentHandlerImpl(
         mockApi,
         mockLogger,


### PR DESCRIPTION
- Replaced newSingleThreadContext with Dispatchers.Unconfined for stability