### PR TITLE
bug/MTSDK-673 Attachment is sent after ConversationClear

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
@@ -560,6 +560,19 @@ internal class MessageStoreTest {
         assertThat(subject.pendingMessage.attachments).contains(givenAttachment.id to givenAttachment)
     }
 
+    @Test
+    fun `when clear() after attachment was updated with uploaded attachment`() {
+        subject.updateAttachmentStateWith(
+            attachment(
+                state = Attachment.State.Uploaded("http://someurl.com")
+            )
+        )
+
+        subject.clear()
+
+        assertThat(subject.pendingMessage.attachments).isEmpty()
+    }
+
     private fun outboundMessage(messageId: Int = 0): Message = Message(
         id = "$messageId",
         direction = Direction.Outbound,

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/BaseMessagingClientTest.kt
@@ -280,6 +280,7 @@ open class BaseMessagingClientTest {
 
     protected fun verifyCleanUp() {
         mockMessageStore.invalidateConversationCache()
+        mockMessageStore.clear()
         mockAttachmentHandler.clearAll()
         mockReconnectionHandler.clear()
         mockJwtHandler.clear()

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessageStore.kt
@@ -118,6 +118,10 @@ internal class MessageStore(private val log: Log) {
         startOfConversation = false
     }
 
+    fun clear() {
+        pendingMessage = Message()
+    }
+
     private fun findAndPublish(message: Message) {
         activeConversation.find { it.id == message.id }?.let {
             activeConversation[it.getIndex()] = message

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -571,6 +571,7 @@ internal class MessagingClientImpl(
 
     private fun cleanUp() {
         invalidateConversationCache()
+        messageStore.clear()
         userTypingProvider.clear()
         healthCheckProvider.clear()
         attachmentHandler.clearAll()


### PR DESCRIPTION
- Reset pendingMessage upon MessagingClient.cleanUp()
- Add unit tests.