### PR TITLE
feature/MTSDK-385-Postback-Message-Added-to-Conversation

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
@@ -965,7 +965,7 @@ internal class MessageExtensionTest {
     fun `when StructuredMessage has CardContent then messageType is Carousel and card is mapped`() {
         val givenStructuredMessage = CardTestValues.createStructuredMessageWithCardContent()
 
-        val expectedMessageType = Message.Type.Carousel
+        val expectedMessageType = Message.Type.Cards
         val expectedCardTitle = CardTestValues.title
         val expectedActionText = CardTestValues.text
 
@@ -990,7 +990,7 @@ internal class MessageExtensionTest {
 
         val result = givenStructuredMessage.toMessage()
 
-        assertThat(result.messageType).isEqualTo(Message.Type.Carousel)
+        assertThat(result.messageType).isEqualTo(Message.Type.Cards)
         assertThat(result.cards).size().isEqualTo(givenTitles.size)
         assertThat(result.cards[0].title).isEqualTo(expectedTitles[0])
         assertThat(result.cards[1].title).isEqualTo(expectedTitles[1])

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
@@ -99,6 +99,7 @@ internal class MessageStoreTest {
         )
 
         subject.prepareMessage(TestValues.TOKEN, "test message").run {
+            this.message as TextMessage
             assertThat(this.message.content).containsOnly(
                 Content(
                     contentType = Content.Type.Attachment,
@@ -114,6 +115,7 @@ internal class MessageStoreTest {
         subject.updateAttachmentStateWith(attachment())
 
         subject.prepareMessage(TestValues.TOKEN, "test message").run {
+            this.message as TextMessage
             assertThat(message.content).isNotNull()
             assertThat(message.content).isEmpty()
         }
@@ -121,9 +123,9 @@ internal class MessageStoreTest {
 
     @Test
     fun `when update() inbound message`() {
-        val sentMessageId =
-            subject.prepareMessage(TestValues.TOKEN, "test message").message.metadata?.get("customMessageId")
-                ?: "empty"
+        val messageRequest = subject.prepareMessage(TestValues.TOKEN, "test message")
+        messageRequest.message as TextMessage
+        val sentMessageId = messageRequest.message.metadata?.get("customMessageId") ?: "empty"
         val givenMessage =
             Message(id = sentMessageId, state = State.Sent, text = "test message")
         clearMocks(mockMessageListener)
@@ -157,9 +159,9 @@ internal class MessageStoreTest {
 
     @Test
     fun `when update() inbound and then outbound messages`() {
-        val sentMessageId =
-            subject.prepareMessage(TestValues.TOKEN, "test message").message.metadata?.get("customMessageId")
-                ?: "empty"
+        val messageRequest = subject.prepareMessage(TestValues.TOKEN, "test message")
+        messageRequest.message as TextMessage
+        val sentMessageId = messageRequest.message.metadata?.get("customMessageId") ?: "empty"
         val expectedConversationSize = 2
         val givenMessage =
             Message(id = sentMessageId, state = State.Sent, text = "test message")
@@ -396,6 +398,8 @@ internal class MessageStoreTest {
 
         verify { mockMessageListener.invoke(capture(messageSlot)) }
         onMessageRequest.run {
+            this.message as TextMessage
+            expectedOnMessageRequest.message as TextMessage
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(message.channel).isEqualTo(expectedOnMessageRequest.message.channel)
@@ -488,6 +492,8 @@ internal class MessageStoreTest {
         )
 
         subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse, givenChannel).run {
+            this.message as TextMessage
+            expectedOnMessageRequest.message as TextMessage
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(message.content).isEqualTo(expectedOnMessageRequest.message.content)
@@ -525,6 +531,8 @@ internal class MessageStoreTest {
         )
 
         subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse).run {
+            this.message as TextMessage
+            expectedOnMessageRequest.message as TextMessage
             assertThat(token).isEqualTo(expectedOnMessageRequest.token)
             assertThat(message).isEqualTo(expectedOnMessageRequest.message)
             assertThat(message.content).isEqualTo(expectedOnMessageRequest.message.content)
@@ -555,6 +563,7 @@ internal class MessageStoreTest {
 
         val result = subject.prepareMessageWith(TestValues.TOKEN, givenButtonResponse)
 
+        result.message as TextMessage
         assertThat(result.message.content).containsOnly(*expectedContent.toTypedArray())
         assertThat(subject.pendingMessage.attachments).isNotEmpty()
         assertThat(subject.pendingMessage.attachments).contains(givenAttachment.id to givenAttachment)

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
@@ -1,0 +1,65 @@
+package transport.core.messagingclient
+
+import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.core.MessageStore
+import com.genesys.cloud.messenger.transport.shyrka.send.StructuredMessage
+import com.genesys.cloud.messenger.transport.utility.QuickReplyTestValues
+import io.mockk.every
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+import transport.util.Request
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class MCCardsAndCarouselTests : BaseMessagingClientTest() {
+
+    @Test
+    fun `when preparePostbackMessage is called then returns StructuredMessage with ButtonResponse`() {
+        val json = Json {
+            ignoreUnknownKeys = true
+        }
+
+        val expectedButtonResponse = QuickReplyTestValues.postbackButtonResponse
+
+        every { mockCustomAttributesStore.getCustomAttributesToSend() } returns emptyMap()
+
+        subject.connect()
+
+        val result = MessageStore(mockLogger).preparePostbackMessage(
+            token = Request.token,
+            buttonResponse = expectedButtonResponse,
+            channel = null
+        )
+
+        val structuredMessage = result.message as StructuredMessage
+        val messageId = structuredMessage.metadata?.get("customMessageId")
+        requireNotNull(messageId) { "customMessageId should not be null" }
+
+        val messageJson = json.encodeToJsonElement(
+            StructuredMessage.serializer(),
+            structuredMessage
+        ).jsonObject
+
+        val text = messageJson["text"]?.jsonPrimitive?.content
+        val content = messageJson["content"]?.jsonArray?.firstOrNull()?.jsonObject
+        val buttonResponse = content?.get("buttonResponse")?.jsonObject
+
+        requireNotNull(text)
+        requireNotNull(content)
+        requireNotNull(buttonResponse)
+
+        assertEquals(expectedButtonResponse.text, text)
+        assertEquals(expectedButtonResponse.payload, buttonResponse["payload"]?.jsonPrimitive?.content)
+        assertEquals(expectedButtonResponse.type, buttonResponse["type"]?.jsonPrimitive?.content)
+
+        val contentObj = structuredMessage.content.firstOrNull()
+        assertNotNull(contentObj)
+        assertEquals(Message.Content.Type.ButtonResponse, contentObj.contentType)
+        assertEquals(expectedButtonResponse.payload, contentObj.buttonResponse?.payload)
+        assertEquals(expectedButtonResponse.type, contentObj.buttonResponse?.type)
+        assertEquals(expectedButtonResponse.text, contentObj.buttonResponse?.text)
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Message.kt
@@ -51,7 +51,7 @@ data class Message(
         Text,
         Event,
         QuickReply,
-        Carousel,
+        Cards,
         Unknown,
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/WebMessagingJson.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/WebMessagingJson.kt
@@ -17,14 +17,13 @@ import com.genesys.cloud.messenger.transport.shyrka.receive.UploadFailureEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.UploadSuccessEvent
 import com.genesys.cloud.messenger.transport.shyrka.receive.WebMessagingMessage
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 internal object WebMessagingJson {
 
     val json = Json {
         ignoreUnknownKeys = true
-        useAlternativeNames = false
+        classDiscriminator = "messageClass"
     }
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/BaseMessageProtocol.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/BaseMessageProtocol.kt
@@ -1,15 +1,33 @@
 package com.genesys.cloud.messenger.transport.shyrka.send
 
-import kotlinx.serialization.Required
+import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
-internal interface BaseMessageProtocol {
-    @Required
-    val type: Type
+@Serializable(with = BaseMessagingProtocolSerializer::class)
+internal sealed class BaseMessageProtocol {
+    abstract val type: Type
+
     @Serializable
     enum class Type {
         Text,
         Event,
         Structured
+    }
+}
+
+internal object BaseMessagingProtocolSerializer :
+    JsonContentPolymorphicSerializer<BaseMessageProtocol>(BaseMessageProtocol::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out BaseMessageProtocol> {
+        return when (element.jsonObject["type"]?.jsonPrimitive?.contentOrNull) {
+            BaseMessageProtocol.Type.Text.name -> TextMessage.serializer()
+            BaseMessageProtocol.Type.Structured.name -> StructuredMessage.serializer()
+            BaseMessageProtocol.Type.Event.name -> EventMessage.serializer()
+            else -> error("Unknown type for BaseMessagingProtocol")
+        }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EventMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/EventMessage.kt
@@ -8,6 +8,6 @@ import kotlinx.serialization.Serializable
 internal data class EventMessage(
     val events: List<StructuredMessageEvent>,
     val channel: Channel? = null,
-) : BaseMessageProtocol {
+) : BaseMessageProtocol() {
     @Required override val type = BaseMessageProtocol.Type.Event
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/OnMessageRequest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal class OnMessageRequest(
     override val token: String,
-    val message: TextMessage,
+    val message: BaseMessageProtocol,
     val time: String? = null,
 ) : WebMessagingRequest {
     @Required override val action: String = RequestAction.ON_MESSAGE.value

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/StructuredMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/StructuredMessage.kt
@@ -2,12 +2,15 @@ package com.genesys.cloud.messenger.transport.shyrka.send
 
 import com.genesys.cloud.messenger.transport.core.Message
 import kotlinx.serialization.Required
+import kotlinx.serialization.Serializable
 
-internal data class StructuredMessage (
+@Serializable
+internal data class StructuredMessage(
     val text: String,
     val metadata: Map<String, String>? = null,
     val content: List<Message.Content> = emptyList(),
-) : BaseMessageProtocol {
+    val channel: Channel? = null,
+) : BaseMessageProtocol() {
     @Required
     override val type = BaseMessageProtocol.Type.Structured
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/send/TextMessage.kt
@@ -10,7 +10,7 @@ internal data class TextMessage(
     val metadata: Map<String, String>? = null,
     val content: List<Message.Content> = emptyList(),
     val channel: Channel? = null,
-) : BaseMessageProtocol {
+) : BaseMessageProtocol() {
     @Required
     override val type = BaseMessageProtocol.Type.Text
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -136,7 +136,7 @@ private fun StructuredMessage.Type.toMessageType(hasQuickReplies: Boolean, hasCa
         StructuredMessage.Type.Structured -> {
             when {
                 hasQuickReplies -> Message.Type.QuickReply
-                hasCards -> Message.Type.Carousel
+                hasCards -> Message.Type.Cards
                 else -> Message.Type.Unknown
             }
         }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -101,7 +101,9 @@ class SerializationTest {
             WebMessagingJson.json.encodeToString(messageWithAttachmentAndCustomAttributesRequest)
 
         assertThat(encodedString, "encoded OnMessageRequest with attachment and custom attributes")
-            .isEqualTo("""{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"content":[{"contentType":"Attachment","attachment":{"id":"abcd-1234"}}],"channel":{"metadata":{"customAttributes":{"A":"B"}}},"type":"Text"},"action":"onMessage"}""")
+            .isEqualTo(
+                """{"token":"<token>","message":{"text":"Hello world","metadata":{"id":"aaa-bbb-ccc"},"content":[{"contentType":"Attachment","attachment":{"id":"abcd-1234"}}],"channel":{"metadata":{"customAttributes":{"A":"B"}}},"type":"Text"},"action":"onMessage"}"""
+            )
     }
 
     @Test

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -136,6 +136,11 @@ object QuickReplyTestValues {
     internal const val PAYLOAD_B = "payload_b"
     internal const val QUICK_REPLY = "QuickReply"
     internal const val BUTTON_RESPONSE = "ButtonResponse"
+    val postbackButtonResponse = ButtonResponse(
+        text = "Book Now",
+        type = "Postback",
+        payload = "I want it"
+    )
 
     internal val buttonResponse_a = ButtonResponse(
         text = TEXT_A,


### PR DESCRIPTION
refactor: use sealed BaseMessageProtocol with custom serializer and add preparePostbackMessage()

- Converted BaseMessageProtocol to a sealed class with JsonContentPolymorphicSerializer
  to support polymorphic deserialization without relying on @Polymorphic or module registration.
- Removed @Polymorphic usage in OnMessageRequest to fix serialization errors.
- Registered StructuredMessage and TextMessage in the custom serializer.
- Added preparePostbackMessage() helper to MessageStore for constructing postback OnMessageRequest.
- Updated and fixed related serialization and unit tests.