### PR TITLE
New rc version format

### DIFF
--- a/transport/build.gradle.kts
+++ b/transport/build.gradle.kts
@@ -19,6 +19,24 @@ plugins {
 version = project.rootProject.version
 group = project.rootProject.group
 
+val givenVersion = version.toString()
+var baseVersion = givenVersion // Base part of the version if no RC
+var buildNumber = 1     // RC number (and build number for iOS starting from 1)
+
+println("Root: version: $givenVersion")
+
+val versionRegex = """^(\d+\.\d+\.\d+)(?:-[Rr][Cc](\d+))?$""".toRegex()
+val matchResult = versionRegex.find(givenVersion)
+
+if (matchResult != null) {
+    baseVersion = matchResult.groups[1]?.value ?: givenVersion
+    val buildNumberStr = matchResult.groups[2]?.value
+    buildNumber = buildNumberStr?.toIntOrNull() ?: 1
+}
+println("baseVersion: version: $baseVersion")
+println("buildNumber: version: $buildNumber")
+
+
 val iosFrameworkName = "MessengerTransport"
 val iosMinimumOSVersion = "13.0"
 val iosCocoaPodName = "GenesysCloudMessengerTransport"
@@ -187,8 +205,8 @@ tasks {
                         "build/XCFrameworks/${buildVariant.lowercase()}/$iosFrameworkName.xcframework/$arch/$iosFrameworkName.framework"
                     val infoPlistPath = "$xcframeworkPath/Info.plist"
                     val propertiesMap = mapOf(
-                        "CFBundleShortVersionString" to version,
-                        "CFBundleVersion" to version,
+                        "CFBundleShortVersionString" to baseVersion,
+                        "CFBundleVersion" to buildNumber,
                         "MinimumOSVersion" to iosMinimumOSVersion
                     )
                     println("Updating framework metadata at: ${this.project.projectDir}/$infoPlistPath")


### PR DESCRIPTION
- Avoid setting rc-x number on ios releases. Instead increment CFBundleVersion for every rc.