### PR TITLE
feature/MTSDK-383-customers-can-interact-with-the-cards-by-clicking-a-button

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
@@ -1,3 +1,66 @@
 package transport.core.messagingclient
 
-class MCCardsAndCarouselTests : BaseMessagingClientTest()
+import com.genesys.cloud.messenger.transport.core.Message
+import com.genesys.cloud.messenger.transport.shyrka.WebMessagingJson
+import com.genesys.cloud.messenger.transport.shyrka.send.OnMessageRequest
+import com.genesys.cloud.messenger.transport.shyrka.send.StructuredMessage
+import com.genesys.cloud.messenger.transport.utility.CardTestValues
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.verifySequence
+import kotlinx.serialization.encodeToString
+import org.junit.Test
+import transport.util.Request
+import kotlin.test.assertFailsWith
+
+class MCCardsAndCarouselTests : BaseMessagingClientTest() {
+
+    @Test
+    fun `when connect() and then sendCardReply() but no custom attributes`() {
+        val expectedPostbackResponse = CardTestValues.postbackButtonResponse
+        val expectedCustomMessageId = CardTestValues.customMessageId
+        val expectedMessage = StructuredMessage(
+            text = expectedPostbackResponse.text,
+            metadata = mapOf("customMessageId" to expectedCustomMessageId),
+            content = listOf(
+                Message.Content(
+                    contentType = Message.Content.Type.ButtonResponse,
+                    buttonResponse = expectedPostbackResponse
+                )
+            ),
+            channel = null
+        )
+        val expectedRequest = OnMessageRequest(
+            token = Request.token,
+            message = expectedMessage
+        )
+
+        every { mockCustomAttributesStore.getCustomAttributesToSend() } returns emptyMap()
+        every {
+            mockMessageStore.preparePostbackMessage(Request.token, expectedPostbackResponse, null)
+        } returns expectedRequest
+
+        subject.connect()
+        subject.sendCardReply(expectedPostbackResponse)
+
+        verifySequence {
+            connectSequence()
+            mockLogger.i(capture(logSlot))
+            mockCustomAttributesStore.getCustomAttributesToSend()
+            mockMessageStore.preparePostbackMessage(Request.token, expectedPostbackResponse, null)
+            mockLogger.i(capture(logSlot))
+            mockPlatformSocket.sendMessage(WebMessagingJson.json.encodeToString(expectedRequest))
+        }
+
+        verify(exactly = 0) {
+            mockAttachmentHandler.onSending()
+        }
+    }
+
+    @Test
+    fun `when sendCardReply() but client is not configured`() {
+        assertFailsWith<IllegalStateException> {
+            subject.sendCardReply(CardTestValues.postbackButtonResponse)
+        }
+    }
+}

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -187,6 +187,15 @@ interface MessagingClient {
     fun sendQuickReply(buttonResponse: ButtonResponse)
 
     /**
+     * Send a card reply to the Agent/Bot.
+     *
+     * @param postbackResponse the card button the user clicked.
+     * @throws IllegalStateException If the client is not connected.
+     */
+    @Throws(IllegalStateException::class)
+    fun sendCardReply(postbackResponse: ButtonResponse)
+
+    /**
      * Perform a health check of the connection by sending an echo message.
      * This command sends a single echo request and should be called a maximum of once every 30 seconds.
      * If called more frequently, this command will be rate limited in order to optimize network traffic.

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -216,6 +216,15 @@ internal class MessagingClientImpl(
         send(encodedJson)
     }
 
+    override fun sendCardReply(postbackResponse: ButtonResponse) {
+        stateMachine.checkIfConfigured()
+        log.i { LogMessages.sendCardReply(postbackResponse) }
+        val channel = prepareCustomAttributesForSending()
+        val request = messageStore.preparePostbackMessage(token, postbackResponse, channel)
+        val encodedJson = WebMessagingJson.json.encodeToString(request)
+        send(encodedJson)
+    }
+
     @Throws(IllegalStateException::class)
     override fun sendHealthCheck() {
         healthCheckProvider.encodeRequest(token)?.let {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -118,4 +118,5 @@ internal object LogMessages {
     fun postbackPrepareToSend(message: Message) = "Message with postback prepared to send: ${message.toString().sanitizeSensitiveData()}"
     fun sendQuickReply(buttonResponse: ButtonResponse) = "sendQuickReply(buttonResponse: $buttonResponse)"
     fun ignoreInboundEvent(event: Event) = "Ignore inbound event: $event."
+    fun sendCardReply(postbackResponse: ButtonResponse) = "sendCardReply(postbackResponse: $postbackResponse)"
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -203,6 +203,7 @@ object CardTestValues {
     internal const val POSTBACK_TEXT = "Book Now"
     internal const val POSTBACK_TYPE = "Postback"
     internal const val POSTBACK_PAYLOAD = "I want it"
+    internal const val customMessageId = "customMessageId"
     val postbackButtonResponse = ButtonResponse(
         text = POSTBACK_TEXT,
         type = POSTBACK_TYPE,


### PR DESCRIPTION
feature/MTSDK-383-customers-can-interact-with-the-cards-by-clicking-a-button

implement sendCardReply() to handle postback interactions from cards

Includes:

- New sendCardReply() method in MessagingClient

- Delegation to preparePostbackMessage() in MessageStore

- Validation, logging, and unit tests for button replies