### PR TITLE
feature/MTSDK-423 Push Notifications

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
@@ -113,7 +113,7 @@ class PushServiceImplTest {
 
         coVerifySequence {
             syncSequence(expectedUserConfig, expectedStoredConfig)
-            mockApi.performDeviceTokenOperation(expectedUserConfig, DeviceTokenOperation.Delete)
+            mockApi.performDeviceTokenOperation(expectedStoredConfig, DeviceTokenOperation.Delete)
             mockLogger.i(capture(logSlot))
             mockApi.performDeviceTokenOperation(expectedUserConfig, expectedOperation)
             mockLogger.i(capture(logSlot))
@@ -121,7 +121,7 @@ class PushServiceImplTest {
         }
         assertBaseSynchronizeLogsFor(Diff.TOKEN)
         assertThat(logSlot[2].invoke()).isEqualTo(
-            LogMessages.deviceTokenWasDeleted(expectedUserConfig)
+            LogMessages.deviceTokenWasDeleted(expectedStoredConfig)
         )
         assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)
@@ -142,7 +142,7 @@ class PushServiceImplTest {
 
         coVerifySequence {
             syncSequence(expectedUserConfig, expectedStoredConfig)
-            mockApi.performDeviceTokenOperation(expectedUserConfig, DeviceTokenOperation.Delete)
+            mockApi.performDeviceTokenOperation(expectedStoredConfig, DeviceTokenOperation.Delete)
             mockLogger.i(capture(logSlot))
             mockApi.performDeviceTokenOperation(expectedUserConfig, expectedOperation)
             mockLogger.i(capture(logSlot))
@@ -150,7 +150,7 @@ class PushServiceImplTest {
         }
         assertBaseSynchronizeLogsFor(Diff.TOKEN)
         assertThat(logSlot[2].invoke()).isEqualTo(
-            LogMessages.deviceTokenWasDeleted(expectedUserConfig)
+            LogMessages.deviceTokenWasDeleted(expectedStoredConfig)
         )
         assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)


### PR DESCRIPTION
- There is no problem with invalidation of session token upon authorize. When `handleSessionResponse` is called - Transport will synchronize and re-register device with updated session token. Problem was with incorrect pushConfig object when delete device token is called due to Diff.Token.
- Use stored push config data (instead of userPushConfig) when delete deviceToken is called due to Diff.Token
- Update unit tests.