### PR TITLE
Feature/mtsdk 841 handle deployment id mismatch error code

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/ErrorCodeTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/ErrorCodeTest.kt
@@ -48,6 +48,7 @@ internal class ErrorCodeTest {
         assertThat(ErrorCode.mapFrom(6024)).isEqualTo(ErrorCode.DeviceRegistrationFailure)
         assertThat(ErrorCode.mapFrom(6025)).isEqualTo(ErrorCode.DeviceUpdateFailure)
         assertThat(ErrorCode.mapFrom(6026)).isEqualTo(ErrorCode.DeviceDeleteFailure)
+        assertThat(ErrorCode.mapFrom(6027)).isEqualTo(ErrorCode.DeploymentIdMismatch)
 
         val randomIn300Range = Random.nextInt(300, 400)
         ErrorCode.mapFrom(randomIn300Range).run {
@@ -127,6 +128,9 @@ internal class ErrorCodeTest {
         )
         assertThat(pushErrorResponseWith("identity.resolution.disabled").toErrorCode()).isEqualTo(
             ErrorCode.DeviceRegistrationFailure
+        )
+        assertThat(pushErrorResponseWith("deployment.id.mismatch").toErrorCode()).isEqualTo(
+            ErrorCode.DeploymentIdMismatch
         )
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/ErrorCodeTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/ErrorCodeTest.kt
@@ -3,6 +3,7 @@ package transport.core
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.genesys.cloud.messenger.transport.core.CorrectiveAction
+import com.genesys.cloud.messenger.transport.core.DEPLOYMENT_ID_MISMATCH_ERROR_MESSAGE
 import com.genesys.cloud.messenger.transport.core.ErrorCode
 import com.genesys.cloud.messenger.transport.core.toCorrectiveAction
 import com.genesys.cloud.messenger.transport.core.toErrorCode
@@ -129,7 +130,15 @@ internal class ErrorCodeTest {
         assertThat(pushErrorResponseWith("identity.resolution.disabled").toErrorCode()).isEqualTo(
             ErrorCode.DeviceRegistrationFailure
         )
-        assertThat(pushErrorResponseWith("deployment.id.mismatch").toErrorCode()).isEqualTo(
+        assertThat(pushErrorResponseWith("invalid.path.parameter").toErrorCode()).isEqualTo(
+            ErrorCode.DeviceTokenOperationFailure
+        )
+        assertThat(
+            pushErrorResponseWith(
+                code = "invalid.path.parameter",
+                message = DEPLOYMENT_ID_MISMATCH_ERROR_MESSAGE
+            ).toErrorCode()
+        ).isEqualTo(
             ErrorCode.DeploymentIdMismatch
         )
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -3,6 +3,9 @@ package com.genesys.cloud.messenger.transport.core
 import com.genesys.cloud.messenger.transport.shyrka.receive.PushErrorResponse
 import io.ktor.http.HttpStatusCode
 
+internal const val DEPLOYMENT_ID_MISMATCH_ERROR_MESSAGE =
+    "Deployment Id in the request does not match the expected deployment Id for the given TokenId"
+
 /**
  * List of all error codes used to report transport errors.
  */
@@ -163,7 +166,12 @@ internal fun PushErrorResponse.toErrorCode(): ErrorCode = when (code) {
     "feature.toggle.disabled" -> ErrorCode.FeatureUnavailable
     "too.many.requests.retry.after" -> ErrorCode.RequestRateTooHigh
     "identity.resolution.disabled" -> ErrorCode.DeviceRegistrationFailure
-    "deployment.id.mismatch" -> ErrorCode.DeploymentIdMismatch
     "required.fields.missing", "update.fields.missing" -> ErrorCode.MissingParameter
+    "invalid.path.parameter" -> if (message == DEPLOYMENT_ID_MISMATCH_ERROR_MESSAGE) {
+        ErrorCode.DeploymentIdMismatch
+    } else {
+        ErrorCode.DeviceTokenOperationFailure
+    }
+
     else -> ErrorCode.DeviceTokenOperationFailure
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -42,6 +42,7 @@ sealed class ErrorCode(val code: Int) {
     data object DeviceRegistrationFailure : ErrorCode(6024)
     data object DeviceUpdateFailure : ErrorCode(6025)
     data object DeviceDeleteFailure : ErrorCode(6026)
+    data object DeploymentIdMismatch : ErrorCode(6027)
 
     data class RedirectResponseError(val value: Int) : ErrorCode(value)
     data class ClientResponseError(val value: Int) : ErrorCode(value)
@@ -81,6 +82,7 @@ sealed class ErrorCode(val code: Int) {
                 6024 -> DeviceRegistrationFailure
                 6025 -> DeviceUpdateFailure
                 6026 -> DeviceDeleteFailure
+                6027 -> DeploymentIdMismatch
                 in 300..399 -> RedirectResponseError(value)
                 in 400..499 -> ClientResponseError(value)
                 in 500..599 -> ServerResponseError(value)
@@ -161,6 +163,7 @@ internal fun PushErrorResponse.toErrorCode(): ErrorCode = when (code) {
     "feature.toggle.disabled" -> ErrorCode.FeatureUnavailable
     "too.many.requests.retry.after" -> ErrorCode.RequestRateTooHigh
     "identity.resolution.disabled" -> ErrorCode.DeviceRegistrationFailure
+    "deployment.id.mismatch" -> ErrorCode.DeploymentIdMismatch
     "required.fields.missing", "update.fields.missing" -> ErrorCode.MissingParameter
     else -> ErrorCode.DeviceTokenOperationFailure
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/ErrorCode.kt
@@ -45,7 +45,7 @@ sealed class ErrorCode(val code: Int) {
     data object DeviceRegistrationFailure : ErrorCode(6024)
     data object DeviceUpdateFailure : ErrorCode(6025)
     data object DeviceDeleteFailure : ErrorCode(6026)
-    data object DeploymentIdMismatch : ErrorCode(6027)
+    data object DeploymentIdMismatch : ErrorCode(6027) // ErrorCode needed to support proper QA automation. Not expected to happen in production.
 
     data class RedirectResponseError(val value: Int) : ErrorCode(value)
     data class ClientResponseError(val value: Int) : ErrorCode(value)

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -212,8 +212,8 @@ object PushTestValues {
         pushProvider = TestValues.PUSH_PROVIDER,
     )
 
-    internal fun pushErrorResponseWith(code: String) = PushErrorResponse(
-        message = ErrorTest.MESSAGE,
+    internal fun pushErrorResponseWith(code: String, message: String = ErrorTest.MESSAGE) = PushErrorResponse(
+        message = message,
         code = code,
         status = ErrorTest.CODE_404.toInt(),
         contextId = TestValues.DEFAULT_STRING,


### PR DESCRIPTION
MTSDK-841 Handle deploymentID mismatch error

- Map to ErrorCode.DeploymentIdMismatch if Thandora error contains code:invalid.path.parameter AND the message match the DEPLOYMENT_ID_MISMATCH_ERROR_MESSAGE
- Add/Update unit tests.