### PR TITLE
MTSDK-759 Encryption Error When Switching Between Default and Encrypted Vault

### DIFF
--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.android.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.android.kt
@@ -19,6 +19,7 @@ actual class EncryptedVault actual constructor(keys: Keys) :
         val currentContext = context ?: throw IllegalStateException("Must set EncryptedVault.context before instantiating.")
         sharedPreferences = currentContext.getSharedPreferences(keys.vaultKey, Context.MODE_PRIVATE)
         internalVault = InternalVault(keys.vaultKey, sharedPreferences)
+        migrateFromDefaultVault()
     }
 
     override fun store(key: String, value: String) {
@@ -31,6 +32,20 @@ actual class EncryptedVault actual constructor(keys: Keys) :
 
     override fun remove(key: String) {
         internalVault.remove(key)
+    }
+
+    private fun migrateFromDefaultVault() {
+        val currentContext = context ?: return
+        val defaultPrefs = currentContext.getSharedPreferences(VAULT_KEY, Context.MODE_PRIVATE)
+
+        if (defaultPrefs.all.isNotEmpty()) {
+            defaultPrefs.getString(keys.tokenKey, null)?.let { store(keys.tokenKey, it) }
+            defaultPrefs.getString(keys.authRefreshTokenKey, null)
+                ?.let { store(keys.authRefreshTokenKey, it) }
+            defaultPrefs.getString(keys.wasAuthenticated, null)
+                ?.let { store(keys.wasAuthenticated, it) }
+            defaultPrefs.edit().clear().apply()
+        }
     }
 
     companion object {

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.android.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.android.kt
@@ -39,11 +39,11 @@ actual class EncryptedVault actual constructor(keys: Keys) :
         val defaultPrefs = currentContext.getSharedPreferences(VAULT_KEY, Context.MODE_PRIVATE)
 
         if (defaultPrefs.all.isNotEmpty()) {
-            defaultPrefs.getString(keys.tokenKey, null)?.let { store(keys.tokenKey, it) }
-            defaultPrefs.getString(keys.authRefreshTokenKey, null)
-                ?.let { store(keys.authRefreshTokenKey, it) }
-            defaultPrefs.getString(keys.wasAuthenticated, null)
-                ?.let { store(keys.wasAuthenticated, it) }
+            defaultPrefs.all.forEach { (key, value) ->
+                if (value is String) {
+                    store(key, value)
+                }
+            }
             defaultPrefs.edit().clear().apply()
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/EncryptedVault.kt
@@ -1,11 +1,13 @@
 package com.genesys.cloud.messenger.transport.util
 
+internal const val ENCRYPTED_VAULT_KEY = "com.genesys.cloud.messenger.encrypted"
+
 /**
  * A encrypted implementation of the [Vault].
  */
 expect class EncryptedVault(
     keys: Keys = Keys(
-        vaultKey = VAULT_KEY,
+        vaultKey = ENCRYPTED_VAULT_KEY,
         tokenKey = TOKEN_KEY,
         authRefreshTokenKey = AUTH_REFRESH_TOKEN_KEY,
         wasAuthenticated = WAS_AUTHENTICATED,

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -27,6 +27,10 @@ object TestValues {
     internal const val AUTH_REFRESH_TOKEN_KEY = "auth_refresh_token_key"
     internal const val WAS_AUTHENTICATED = "was_authenticated"
     internal const val LOG_TAG = "TestLogTag"
+    internal const val CUSTOM_KEY = "custom_key"
+    internal const val INT_KEY = "int_key"
+    internal const val BOOLEAN_KEY = "boolean_key"
+    internal const val TRUE_STRING = "true"
     internal val defaultMap = mapOf("A" to "BBBBBB")
     internal val defaultSecureMap = mapOf("A" to "**BBBB")
     internal val advancedMap = mapOf("metadata" to """{"key":"value"}""")
@@ -42,6 +46,14 @@ object TestValues {
         tokenKey = com.genesys.cloud.messenger.transport.util.TOKEN_KEY,
         authRefreshTokenKey = com.genesys.cloud.messenger.transport.util.AUTH_REFRESH_TOKEN_KEY,
         wasAuthenticated = com.genesys.cloud.messenger.transport.util.WAS_AUTHENTICATED,
+    )
+    internal val migrationTestData = mapOf(
+        TOKEN_KEY to TOKEN,
+        AUTH_REFRESH_TOKEN_KEY to SECONDARY_TOKEN,
+        WAS_AUTHENTICATED to TRUE_STRING,
+        CUSTOM_KEY to DEFAULT_STRING,
+        INT_KEY to 123,
+        BOOLEAN_KEY to false
     )
 }
 


### PR DESCRIPTION
That issue was appears when we try to decrypt regular string (the decrypt function expexct base64 but got regular string), and also the other direction not raised errors but return, weird responses.

the propose solution use different shred pref files for storing encrypted and regular key- value pairs for avoiding any potentially collisions, the two files will only papers in devices that switch between the two cases, for the most part vault will create one file 

<img width="638" height="120" alt="image" src="https://github.com/user-attachments/assets/243bafac-3ac9-4951-b95b-8410e94b0090" />
