### PR TITLE
Feature/mtsdk 390 confirm card selections are included in conversation history

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 // CocoaPods requires the podspec to have a `version`
-val buildVersion = "2.8.5"
+val buildVersion = "2.8.7"
 val snapshot = System.getenv("SNAPSHOT_BUILD") ?: ""
 version = "${buildVersion}${snapshot}"
 group = "cloud.genesys"
@@ -35,8 +35,8 @@ nexusPublishing {
         sonatype {
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/"))
         }
     }
 }

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - transport (2.8.5)
+  - transport (2.8.7)
 
 DEPENDENCIES:
   - transport (from `../transport`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../transport"
 
 SPEC CHECKSUMS:
-  transport: ede9948b1a2ccd4e846c2cf2140ee31f169facef
+  transport: a5b142a96987a6cedba2d395f695efcc000d0d48
 
 PODFILE CHECKSUM: 10743e43aeaf72bb49673a0e57360c028906ace5
 

--- a/transport/GenesysCloudMessengerTransport.podspec
+++ b/transport/GenesysCloudMessengerTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                   = 'GenesysCloudMessengerTransport'
-  s.version                = '2.8.5'
+  s.version                = '2.8.7-rc2'
   s.summary                = 'Genesys Cloud Messenger Transport SDK'
 
   s.description            = <<-DESC
@@ -33,7 +33,7 @@ SOFTWARE.
                                LICENSE
                              }
   s.author                 = 'Genesys Cloud Services, Inc.'
-  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.8.5/MessengerTransport.xcframework.zip' }
+  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.8.7-rc2/MessengerTransport.xcframework.zip' }
 
   s.ios.deployment_target  = '13.0'
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageStoreTest.kt
@@ -642,6 +642,42 @@ internal class MessageStoreTest {
         assertThat((actualEvent as MessageEvent.CardMessageReceived).message).isEqualTo(givenMessage)
     }
 
+    @Test
+    fun `when updateMessageHistory is called with card selections then history is merged`() {
+        val givenMessage = Message(
+            id = "history-card-1",
+            direction = Direction.Inbound,
+            state = State.Sent,
+            messageType = Type.Cards,
+            text = CardTestValues.postbackButtonResponse.text,
+            quickReplies = listOf(CardTestValues.postbackButtonResponse),
+            timeStamp = 123L
+        )
+        val givenHistory = listOf(givenMessage)
+
+        clearMocks(mockLogger, mockMessageListener)
+
+        subject.updateMessageHistory(givenHistory, total = givenHistory.size)
+
+        val expectedStartOfConversation = true
+        val expectedNextPage = 1
+        assertThat(subject.startOfConversation).isEqualTo(expectedStartOfConversation)
+        assertThat(subject.nextPage).isEqualTo(expectedNextPage)
+
+        val expectedConversation = givenHistory
+        val actualConversation = subject.getConversation()
+        assertThat(actualConversation).containsExactly(*expectedConversation.toTypedArray())
+
+        verify {
+            mockLogger.i(capture(logSlot))
+            mockMessageListener.invoke(capture(messageSlot))
+        }
+        val actualEvent = messageSlot.captured as MessageEvent.HistoryFetched
+        assertThat(actualEvent.messages).isEqualTo(expectedConversation)
+        assertThat(actualEvent.startOfConversation).isEqualTo(expectedStartOfConversation)
+        assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.messageHistoryUpdated(expectedConversation))
+    }
+
     private fun outboundMessage(messageId: Int = 0): Message = Message(
         id = "$messageId",
         direction = Direction.Outbound,

--- a/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/DeploymentConfigTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/shyrka/receive/DeploymentConfigTest.kt
@@ -42,9 +42,11 @@ class DeploymentConfigTest {
         val expectedAuth = Auth(enabled = true, allowSessionUpgrade = true)
         val expectedJourneyEvents = JourneyEvents(enabled = false)
         val expectedConversationClear = Conversations.ConversationClear(enabled = true)
+        val expectedMarkdown = Conversations.Markdown(false)
         val expectedConversations = Conversations(
             messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
-            conversationClear = expectedConversationClear
+            conversationClear = expectedConversationClear,
+            markdown = expectedMarkdown
         )
         val expectedApps = Apps(conversations = expectedConversations)
         val expectedStyles = Styles(primaryColor = DeploymentConfigValues.PRIMARY_COLOR)
@@ -122,10 +124,11 @@ class DeploymentConfigTest {
                 enabled = true,
                 Conversations.ConversationDisconnect.Type.ReadOnly
             ),
-            conversationClear = Conversations.ConversationClear(enabled = true)
+            conversationClear = Conversations.ConversationClear(enabled = true),
+            markdown = Conversations.Markdown(enabled = true),
         )
         val expectedConversationsAsJson =
-            """{"messagingEndpoint":"messaging_endpoint","showAgentTypingIndicator":true,"showUserTypingIndicator":true,"autoStart":{"enabled":true},"conversationDisconnect":{"enabled":true,"type":"ReadOnly"},"conversationClear":{"enabled":true}}"""
+            """{"messagingEndpoint":"messaging_endpoint","showAgentTypingIndicator":true,"showUserTypingIndicator":true,"autoStart":{"enabled":true},"conversationDisconnect":{"enabled":true,"type":"ReadOnly"},"conversationClear":{"enabled":true},"markdown":{"enabled":true}}"""
 
         val result = WebMessagingJson.json.encodeToString(givenConversations)
 
@@ -135,20 +138,22 @@ class DeploymentConfigTest {
     @Test
     fun `when Conversations deserialized`() {
         val givenConversationsAsJson =
-            """{"messagingEndpoint":"messaging_endpoint","showAgentTypingIndicator":true,"showUserTypingIndicator":true,"autoStart":{"enabled":true},"conversationDisconnect":{"enabled":true,"type":"ReadOnly"},"conversationClear":{"enabled":false}}"""
+            """{"messagingEndpoint":"messaging_endpoint","showAgentTypingIndicator":true,"showUserTypingIndicator":true,"autoStart":{"enabled":true},"markdown":{"enabled":false},"conversationDisconnect":{"enabled":true,"type":"ReadOnly"},"conversationClear":{"enabled":false}}"""
         val expectedConversationClear = Conversations.ConversationClear(enabled = false)
         val expectedAutoStart = Conversations.AutoStart(true)
         val expectedConversationDisconnect = Conversations.ConversationDisconnect(
             true,
             Conversations.ConversationDisconnect.Type.ReadOnly
         )
+        val expectedMarkdown = Conversations.Markdown(false)
         val expectedConversations = Conversations(
             messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
             showAgentTypingIndicator = true,
             showUserTypingIndicator = true,
             autoStart = expectedAutoStart,
             conversationDisconnect = expectedConversationDisconnect,
-            conversationClear = expectedConversationClear
+            conversationClear = expectedConversationClear,
+            markdown = expectedMarkdown
         )
 
         val result = WebMessagingJson.json.decodeFromString<Conversations>(givenConversationsAsJson)
@@ -210,6 +215,28 @@ class DeploymentConfigTest {
         )
 
         assertThat(result).isEqualTo(expectedConversationClear)
+        assertThat(result.enabled).isTrue()
+    }
+    @Test
+    fun `when Markdown serialized`() {
+        val givenMarkdown = Conversations.Markdown(enabled = true)
+        val expectedMarkdownAsJson = """{"enabled":true}"""
+
+        val result = WebMessagingJson.json.encodeToString(givenMarkdown)
+
+        assertThat(result).isEqualTo(expectedMarkdownAsJson)
+    }
+
+    @Test
+    fun `when Markdown deserialized`() {
+        val givenMarkdownAsJson = """{"enabled":true}"""
+        val expectedMarkdown = Conversations.Markdown(enabled = true)
+
+        val result = WebMessagingJson.json.decodeFromString<Conversations.Markdown>(
+            givenMarkdownAsJson
+        )
+
+        assertThat(result).isEqualTo(expectedMarkdown)
         assertThat(result.enabled).isTrue()
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/DeploymentConfig.kt
@@ -44,6 +44,7 @@ data class Conversations(
     val autoStart: AutoStart = AutoStart(),
     val conversationDisconnect: ConversationDisconnect = ConversationDisconnect(),
     val conversationClear: ConversationClear = ConversationClear(),
+    val markdown: Markdown = Markdown(),
 ) {
     @Serializable
     data class AutoStart(val enabled: Boolean = false)
@@ -60,6 +61,9 @@ data class Conversations(
 
     @Serializable
     data class ConversationClear(val enabled: Boolean = false)
+
+    @Serializable
+    data class Markdown(val enabled: Boolean = false)
 }
 
 @Serializable

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/TestWebMessagingApiResponses.kt
@@ -61,6 +61,9 @@ object TestWebMessagingApiResponses {
                     ),
                     conversationClear = Conversations.ConversationClear(
                         enabled = true
+                    ),
+                    markdown = Conversations.Markdown(
+                        enabled = false
                     )
                 )
             ),
@@ -80,7 +83,7 @@ object TestWebMessagingApiResponses {
         auth = Auth(
             enabled = true,
             allowSessionUpgrade = true,
-        )
+        ),
     )
 
     private fun buildEntities(): List<StructuredMessage> =

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/FakeDeploymentConfig.kt
@@ -49,9 +49,11 @@ fun createConversationsVOForTesting(
     autoStart: Conversations.AutoStart = Conversations.AutoStart(),
     conversationDisconnect: Conversations.ConversationDisconnect = Conversations.ConversationDisconnect(),
     conversationClear: Conversations.ConversationClear = Conversations.ConversationClear(enabled = true),
+    markdown: Conversations.Markdown = Conversations.Markdown(enabled = false),
 ): Conversations = Conversations(
     messagingEndpoint = DeploymentConfigValues.MESSAGING_ENDPOINT,
     autoStart = autoStart,
     conversationDisconnect = conversationDisconnect,
     conversationClear = conversationClear,
+    markdown = markdown,
 )

--- a/transport/transport.podspec
+++ b/transport/transport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'transport'
-    spec.version                  = '2.8.5'
+    spec.version                  = '2.8.7'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http=> ''}
     spec.authors                  = 'Genesys Cloud Services, Inc.'


### PR DESCRIPTION
feature/MTSDK-390_Confirm-card-selections-are-included-in-conversation-history

Confirm existing card selection history logic and add test

- Verified that the code for persisting and merging card‐reply messages into conversation history was already in place.  
- Added MessageStoreTest case to ensure updateMessageHistory merges card selections into conversation history in the right order.