### PR TITLE
hotfix/push-not-recevied-after-login/logout/login

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
@@ -58,7 +58,6 @@ internal class PushServiceImpl(
             Diff.NO_TOKEN -> register(userPushConfig)
             Diff.TOKEN -> {
                 coroutineScope {
-                    launch { delete(storedPushConfig) }
                     launch { register(userPushConfig) }
                 }
             }


### PR DESCRIPTION
- Do not delete deviceToken associated with an old session token.