### PR TITLE
MTSDK-863 Push notification is not received in case of second login from the same device

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/push/PushServiceImplTest.kt
@@ -113,17 +113,12 @@ class PushServiceImplTest {
 
         coVerifySequence {
             syncSequence(expectedUserConfig, expectedStoredConfig)
-            mockApi.performDeviceTokenOperation(expectedStoredConfig, DeviceTokenOperation.Delete)
-            mockLogger.i(capture(logSlot))
             mockApi.performDeviceTokenOperation(expectedUserConfig, expectedOperation)
             mockLogger.i(capture(logSlot))
             mockVault.pushConfig = expectedUserConfig
         }
         assertBaseSynchronizeLogsFor(Diff.TOKEN)
         assertThat(logSlot[2].invoke()).isEqualTo(
-            LogMessages.deviceTokenWasDeleted(expectedStoredConfig)
-        )
-        assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)
         )
     }
@@ -142,17 +137,12 @@ class PushServiceImplTest {
 
         coVerifySequence {
             syncSequence(expectedUserConfig, expectedStoredConfig)
-            mockApi.performDeviceTokenOperation(expectedStoredConfig, DeviceTokenOperation.Delete)
-            mockLogger.i(capture(logSlot))
             mockApi.performDeviceTokenOperation(expectedUserConfig, expectedOperation)
             mockLogger.i(capture(logSlot))
             mockVault.pushConfig = expectedUserConfig
         }
         assertBaseSynchronizeLogsFor(Diff.TOKEN)
         assertThat(logSlot[2].invoke()).isEqualTo(
-            LogMessages.deviceTokenWasDeleted(expectedStoredConfig)
-        )
-        assertThat(logSlot[3].invoke()).isEqualTo(
             LogMessages.deviceTokenWasRegistered(expectedUserConfig)
         )
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
@@ -58,7 +58,6 @@ internal class PushServiceImpl(
             Diff.NO_TOKEN -> register(userPushConfig)
             Diff.TOKEN -> {
                 coroutineScope {
-                    launch { delete(storedPushConfig) }
                     launch { register(userPushConfig) }
                 }
             }


### PR DESCRIPTION
- Do not delete deviceToken associated with an old session token.
- Fix unit tests


Continued from https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/pull/388