### PR TITLE
feature/MTSDK-575_handle-error-response-from-shyrka

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
@@ -124,4 +124,23 @@ class MCCardsAndCarouselTests : BaseMessagingClientTest() {
             mockMessageStore.update(expectedMessage)
         }
     }
+
+    @Test
+    fun `when error response received after sendCardReply then onMessageError is called`() {
+        val givenButtonResponse = CardTestValues.postbackButtonResponse
+        val expectedRequestJson = Request.expectedPostbackRequestJson
+
+        every {
+            mockPlatformSocket.sendMessage(expectedRequestJson)
+        } answers {
+            slot.captured.onMessage(Response.tooManyRequests)
+        }
+
+        subject.connect()
+        subject.sendCardReply(givenButtonResponse)
+
+        verify {
+            mockMessageStore.onMessageError(any(), any())
+        }
+    }
 }


### PR DESCRIPTION
feature/MTSDK-575_handle-error-response-from-shyrka

Add unit test for postback error handling

- Added a test to confirm that when Shyrka returns an error after sendCardReply, we call onMessageError as expected. The core error-handling logic was already in place.