### PR TITLE
Task/mtsdk 865 implement retry mechanism on fetch auth jwt request

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/HttpClientProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/HttpClientProvider.kt
@@ -5,13 +5,25 @@ import com.genesys.cloud.messenger.transport.util.logs.Log
 import com.genesys.cloud.messenger.transport.util.logs.LogTag
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpCallValidator
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.retry
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 
 private const val TIMEOUT_IN_MS = 30000L
+private const val MAX_RETRIES_ON_INTERNAL_SERVER_ERRORS = 3
+private const val DELAY_BETWEEN_RETRIES_IN_MILLISECONDS = 5000L
+private val RETRYABLE_STATUS_CODES = setOf(
+    HttpStatusCode.InternalServerError,
+    HttpStatusCode.BadGateway,
+    HttpStatusCode.ServiceUnavailable,
+    HttpStatusCode.GatewayTimeout,
+)
 
 internal fun defaultHttpClient(logging: Boolean = false): HttpClient = HttpClient {
     if (logging) {
@@ -27,5 +39,14 @@ internal fun defaultHttpClient(logging: Boolean = false): HttpClient = HttpClien
     install(HttpTimeout) {
         socketTimeoutMillis = TIMEOUT_IN_MS
         connectTimeoutMillis = TIMEOUT_IN_MS
+    }
+    install(HttpRequestRetry)
+}
+
+internal fun HttpRequestBuilder.retryOnServerErrors() {
+    retry {
+        maxRetries = MAX_RETRIES_ON_INTERNAL_SERVER_ERRORS
+        constantDelay(DELAY_BETWEEN_RETRIES_IN_MILLISECONDS)
+        retryIf { _, response -> response.status in RETRYABLE_STATUS_CODES }
     }
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/HttpClientProvider.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/HttpClientProvider.kt
@@ -16,7 +16,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 
 private const val TIMEOUT_IN_MS = 30000L
-private const val MAX_RETRIES_ON_INTERNAL_SERVER_ERRORS = 3
+private const val MAX_RETRIES_ON_SERVER_ERRORS = 3
 private const val DELAY_BETWEEN_RETRIES_IN_MILLISECONDS = 5000L
 private val RETRYABLE_STATUS_CODES = setOf(
     HttpStatusCode.InternalServerError,
@@ -45,7 +45,7 @@ internal fun defaultHttpClient(logging: Boolean = false): HttpClient = HttpClien
 
 internal fun HttpRequestBuilder.retryOnServerErrors() {
     retry {
-        maxRetries = MAX_RETRIES_ON_INTERNAL_SERVER_ERRORS
+        maxRetries = MAX_RETRIES_ON_SERVER_ERRORS
         constantDelay(DELAY_BETWEEN_RETRIES_IN_MILLISECONDS)
         retryIf { _, response -> response.status in RETRYABLE_STATUS_CODES }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/WebMessagingApi.kt
@@ -106,6 +106,7 @@ internal class WebMessagingApi(
         val response = client.post(configuration.jwtAuthUrl.toString()) {
             header("content-type", ContentType.Application.Json)
             setBody(requestBody)
+            retryOnServerErrors()
         }
         if (response.status.isSuccess()) {
             Result.Success(response.body())


### PR DESCRIPTION
- Add retryable mechanism to retry fetchAuthJwt request upon common server errors.
- No unit tests added as they are not really relevant here. 