### PR TITLE
MTSDK-368 add cards support to the IOS TestBed

### DIFF
--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -119,6 +119,15 @@ final class MessengerInteractor {
         }
     }
 
+    func sendCardReply(buttonResponse: ButtonResponse) throws {
+        do {
+            try messagingClient.sendCardReply(postbackResponse: buttonResponse)
+        } catch {
+            print("sendCardReply(buttonResponse:) failed. \(error.localizedDescription)")
+            throw error
+        }
+    }
+
     func fetchNextPage(completion: ((Error?) -> Void)? = nil) {
         messagingClient.fetchNextPage() { error in
             completion?(error)


### PR DESCRIPTION
implementation: https://genesyslab-my.sharepoint.com/:v:/g/personal/yarin_sason_genesys_com/EQTf2KZZ4u5DmJglthOMddkBzCYVZDvyA2gKcsdc2ZL9Og?e=Fmwl7F&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D


notice that we see QuickReplay sending instead of card because theres probably a bug on the Backend for type="Postback", so until it will be fixed we set 
<img width="1229" height="560" alt="image" src="https://github.com/user-attachments/assets/19bf6f25-528d-4545-8f75-b05ea1baae49" />
