### PR TITLE
MTSDK-883 Handle ErrorCode.DeviceAlreadyRegistered from Thandora

### DIFF
--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/push/PushServiceImpl.kt
@@ -132,6 +132,11 @@ internal class PushServiceImpl(
                 }
             }
 
+            ErrorCode.DeviceAlreadyRegistered -> {
+                log.i { LogMessages.DEVICE_ALREADY_REGISTERED }
+                update(userPushConfig)
+            }
+
             else -> throwDeviceTokenException(result, userPushConfig)
         }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/PushErrorResponse.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/shyrka/receive/PushErrorResponse.kt
@@ -7,6 +7,6 @@ internal data class PushErrorResponse(
     val message: String,
     val code: String,
     val status: Int,
-    val contextId: String,
+    val contextId: String? = null,
     val details: List<String> = emptyList(),
 )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -131,5 +131,6 @@ internal object LogMessages {
     const val SYNCHRONIZE_PUSH_SERVICE_ON_SESSION_CONFIGURE = "Synchronizing push service from session configured."
     const val UNREGISTERING_DEVICE = "Unregistering device from push notifications."
     const val DEVICE_NOT_REGISTERED = "Device is not registered."
+    const val DEVICE_ALREADY_REGISTERED = "Device is already registered. Performing update."
     const val NO_DEVICE_TOKEN_OR_PUSH_PROVIDER = "Skipping push service synchronization: Missing device token or push provider."
 }


### PR DESCRIPTION
- Perform Update operation when ErrorCode.DeviceAlreadyRegistered is received.
 - Make contextId an optional
 - Add/Update unit tests.
 - Use runTest instead of runBlocking on push related tests.