### PR TITLE
Improve unit test coverage

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
@@ -287,6 +287,34 @@ class AuthHandlerTest {
     }
 
     @Test
+    fun `when logout() without authorize failed because of 401`() {
+        coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(NO_JWT) } returns Result.Failure(
+            ErrorCode.ClientResponseError(401),
+            ErrorTest.MESSAGE
+        )
+        val expectedErrorCode = ErrorCode.ClientResponseError(401)
+        val expectedErrorMessage = ErrorTest.MESSAGE
+        val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
+
+        subject.logout()
+
+        coVerify {
+            mockWebMessagingApi.logoutFromAuthenticatedSession(NO_JWT)
+        }
+        verify {
+            mockLogger.e(capture(logSlot))
+            mockEventHandler.onEvent(
+                Event.Error(
+                    expectedErrorCode,
+                    expectedErrorMessage,
+                    expectedCorrectiveAction
+                )
+            )
+        }
+        assertThat(logSlot.captured.invoke()).isEqualTo(LogMessages.requestError("logout()", expectedErrorCode, expectedErrorMessage))
+    }
+
+    @Test
     fun `when authorized and logout() failed because of 401 and autoRefreshTokenWhenExpired is enabled but refreshToken() success`() {
         authorize()
         coEvery { mockWebMessagingApi.logoutFromAuthenticatedSession(any()) } returns Result.Failure(

--- a/transport/src/androidUnitTest/kotlin/transport/core/StateMachineTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/StateMachineTest.kt
@@ -44,13 +44,13 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenSubjectWasInitialized() {
+    fun `when subject was initialized`() {
         assertThat(subject.currentState).isIdle()
         assertTrue { subject.isInactive() }
     }
 
     @Test
-    fun whenOnConnectionOpened() {
+    fun `when onConnectionOpened`() {
         val expectedStateChange = StateChange(State.Idle, State.Connected)
 
         subject.onConnectionOpened()
@@ -71,7 +71,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnConnectionOpenedAfterOnReconnect() {
+    fun `when onConnectionOpened after onReconnect`() {
         val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
 
         subject.onReconnect()
@@ -86,7 +86,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnConnect() {
+    fun `when onConnect`() {
         val expectedStateChange = StateChange(State.Idle, State.Connecting)
 
         subject.onConnect()
@@ -100,7 +100,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnConnectAfterOnReconnect() {
+    fun `when onConnect after onReconnect`() {
         val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
 
         subject.onReconnect()
@@ -115,28 +115,28 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnConnectAndCurrentStateIsConnected() {
+    fun `when onConnect and current state is Connected`() {
         subject.onConnectionOpened()
 
         assertFailsWith<IllegalStateException> { subject.onConnect() }
     }
 
     @Test
-    fun whenOnConnectAndCurrentStateIsConfigured() {
+    fun `when onConnect and current state is Configured`() {
         subject.onSessionConfigured(connected = true, newSession = true)
 
         assertFailsWith<IllegalStateException> { subject.onConnect() }
     }
 
     @Test
-    fun whenOnConnectAndCurrentStateIsReadOnly() {
+    fun `when onConnect and current state is ReadOnly`() {
         subject.onReadOnly()
 
         assertFailsWith<IllegalStateException> { subject.onConnect() }
     }
 
     @Test
-    fun whenOnReconnect() {
+    fun `when onReconnect`() {
         val expectedStateChange = StateChange(State.Idle, State.Reconnecting)
 
         subject.onReconnect()
@@ -150,7 +150,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnSessionConfigured() {
+    fun `when onSessionConfigured`() {
         val expectedStateChange =
             StateChange(State.Idle, State.Configured(connected = true, newSession = true))
 
@@ -168,7 +168,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnSessionConfiguredAfterOnReconnect() {
+    fun `when onSessionConfigured after onReconnect`() {
         val expectedStateChange =
             StateChange(State.Reconnecting, State.Configured(connected = true, newSession = true))
 
@@ -187,7 +187,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnClosingAfterConnectionWasOpened() {
+    fun `when onClosing after connection was opened`() {
         val expectedStateChange =
             StateChange(State.Connected, State.Closing(code = 1, reason = "A reason."))
 
@@ -203,26 +203,26 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnClosingAndCurrentStateIsIdle() {
+    fun `when onClosing and current state is Idle`() {
         assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
     }
 
     @Test
-    fun whenOnClosingAndCurrentStateIsClosed() {
+    fun `when onClosing and current state is Closed`() {
         subject.onClosed(code = 1, reason = "A reason.")
 
         assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
     }
 
     @Test
-    fun whenOnClosingWhenStateIsError() {
+    fun `when onClosing when state is Error`() {
         subject.onError(code = ErrorCode.WebsocketError, message = "A message.")
 
         assertFailsWith<IllegalStateException> { subject.onClosing(code = 1, reason = "A reason.") }
     }
 
     @Test
-    fun whenOnClosed() {
+    fun `when onClosed`() {
         val expectedStateChange =
             StateChange(State.Idle, State.Closed(code = 1, reason = "A reason."))
 
@@ -237,7 +237,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnError() {
+    fun `when onError`() {
         val expectedStateChange =
             StateChange(State.Idle, State.Error(ErrorCode.WebsocketError, "A message."))
 
@@ -260,7 +260,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnReadOnly() {
+    fun `when onReadOnly`() {
         val expectedStateChange = StateChange(State.Idle, State.ReadOnly)
 
         subject.onReadOnly()
@@ -273,7 +273,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun whenOnReadOnlyAfterOnReconnect() {
+    fun `when onReadOnly after onReconnect`() {
         val expectedStateChange = StateChange(State.Reconnecting, State.ReadOnly)
 
         subject.onReconnect()
@@ -287,7 +287,7 @@ class StateMachineTest {
     }
 
     @Test
-    fun verifyFullStateTransitionCycle() {
+    fun `verify full state transition cycle`() {
         subject.onConnect()
         assertThat(subject.currentState).isConnecting()
         subject.onConnectionOpened()

--- a/transport/src/androidUnitTest/kotlin/transport/core/events/UserTypingProviderTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/events/UserTypingProviderTest.kt
@@ -106,7 +106,7 @@ class UserTypingProviderTest {
     fun `when encode with default getCurrentTimestamp function`() {
         val subject = UserTypingProvider(
             log = mockLogger,
-            showUserTypingEnabled = { true } // don’t override timestamp
+            showUserTypingEnabled = { true }
         )
 
         val result = subject.encodeRequest(token = Request.token)

--- a/transport/src/androidUnitTest/kotlin/transport/core/events/UserTypingProviderTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/events/UserTypingProviderTest.kt
@@ -32,7 +32,7 @@ class UserTypingProviderTest {
     )
 
     @Test
-    fun whenEncode() {
+    fun `when encode`() {
         val expected = Request.userTypingRequest
         val result = subject.encodeRequest(token = Request.token)
 
@@ -44,7 +44,7 @@ class UserTypingProviderTest {
     }
 
     @Test
-    fun whenEncodeWithCoolDown() {
+    fun `when encode with coolDown`() {
         val typingIndicatorCoolDownInMilliseconds = TYPING_INDICATOR_COOL_DOWN_MILLISECONDS + 250
         val expected = Request.userTypingRequest
         val firstResult = subject.encodeRequest(token = Request.token)
@@ -56,7 +56,7 @@ class UserTypingProviderTest {
     }
 
     @Test
-    fun whenEncodeWithoutCoolDown() {
+    fun `when encode without coolDown`() {
         val expected = Request.userTypingRequest
         val firstResult = subject.encodeRequest(token = Request.token)
         val secondResult = subject.encodeRequest(token = Request.token)
@@ -77,7 +77,7 @@ class UserTypingProviderTest {
     }
 
     @Test
-    fun whenEncodeWithoutCoolDownButWithClear() {
+    fun `when encode without coolDown but with clear`() {
         val expected = Request.userTypingRequest
         val firstResult = subject.encodeRequest(token = Request.token)
         subject.clear()
@@ -88,7 +88,7 @@ class UserTypingProviderTest {
     }
 
     @Test
-    fun whenEncodeAndShowUserTypingIsDisabled() {
+    fun `when encode and showUserTyping is disabled`() {
         every { mockShowUserTypingIndicatorFunction.invoke() } returns false
 
         val result = subject.encodeRequest(token = Request.token)
@@ -100,5 +100,17 @@ class UserTypingProviderTest {
 
         assertThat(result).isNull()
         assertThat(logSlot[0].invoke()).isEqualTo(LogMessages.TYPING_INDICATOR_DISABLED)
+    }
+
+    @Test
+    fun `when encode with default getCurrentTimestamp function`() {
+        val subject = UserTypingProvider(
+            log = mockLogger,
+            showUserTypingEnabled = { true } // don’t override timestamp
+        )
+
+        val result = subject.encodeRequest(token = Request.token)
+
+        assertThat(result).isEqualTo(Request.userTypingRequest)
     }
 }


### PR DESCRIPTION
- Align naming conventions of UserTypingProviderTest and StateMachineTest with rest of the project
- Add coverage of UserTypingProvider default constructor.
- Add test that verifies that all branches of eligibleToRefresh() are tested.