### PR TITLE
bug/MTSDK-877_Sending-button-response-type-postback-result-in-error

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
@@ -1059,10 +1059,75 @@ internal class MessageExtensionTest {
         val message = givenStructuredMessage.toMessage()
         val card = message.cards.single()
         val linkAction = card.actions.first { it.type == CardTestValues.LINK_TYPE }
-        val postbackAction = card.actions.first { it.type == QuickReplyTestValues.QUICK_REPLY }
+        val postbackAction = card.actions.first { it.type == QuickReplyTestValues.BUTTON }
 
         assertThat(linkAction.payload).isEqualTo(expectedUrl)
 
         assertThat(postbackAction.payload).isEqualTo(expectedPayload)
+    }
+
+    @Test
+    fun `when StructuredMessage has QuickReplyContent then messageType is QuickReply and quickReplies mapped`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(QuickReplyTestValues.createQuickReplyContentForTesting())
+        )
+        val expectedMessageType = Message.Type.QuickReply
+        val expectedQuickReply = ButtonResponse(
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.QUICK_REPLY
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result.messageType).isEqualTo(expectedMessageType)
+        assertThat(result.quickReplies).containsExactly(expectedQuickReply)
+        assertThat(result.cards).isEmpty()
+    }
+
+    @Test
+    fun `when StructuredMessage has ButtonResponseContent with type QuickReply then messageType is QuickReply and quickReplies mapped`() {
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(QuickReplyTestValues.createButtonResponseContentForTesting())
+        )
+        val expectedMessageType = Message.Type.QuickReply
+        val expectedQuickReply = ButtonResponse(
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.QUICK_REPLY
+        )
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result.messageType).isEqualTo(expectedMessageType)
+        assertThat(result.quickReplies).containsExactly(expectedQuickReply)
+        assertThat(result.cards).isEmpty()
+    }
+
+    @Test
+    fun `when StructuredMessage has ButtonResponseContent with type Button then messageType is Unknown and quickReplies empty`() {
+        val givenButton = StructuredMessage.Content.ButtonResponseContent.ButtonResponse(
+            text = QuickReplyTestValues.TEXT_A,
+            payload = QuickReplyTestValues.PAYLOAD_A,
+            type = QuickReplyTestValues.BUTTON
+        )
+        val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
+            type = StructuredMessage.Type.Structured,
+            content = listOf(
+                StructuredMessage.Content.ButtonResponseContent(
+                    contentType = StructuredMessage.Content.Type.ButtonResponse.name,
+                    buttonResponse = givenButton
+                )
+            )
+        )
+        val expectedMessageType = Message.Type.Unknown
+
+        val result = givenStructuredMessage.toMessage()
+
+        assertThat(result.messageType).isEqualTo(expectedMessageType)
+        assertThat(result.quickReplies).isEmpty()
+        assertThat(result.cards).isEmpty()
     }
 }

--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
@@ -175,7 +175,7 @@ internal class MessageExtensionTest {
             assertThat(id).isEqualTo(expectedMessage.id)
             assertThat(direction).isEqualTo(expectedMessage.direction)
             assertThat(state).isEqualTo(expectedMessage.state)
-            assertThat(type).isEqualTo(expectedMessage.type)
+            assertThat(messageType).isEqualTo(expectedMessage.messageType)
             assertThat(timeStamp).isEqualTo(expectedMessage.timeStamp)
             assertThat(events).containsExactly(*expectedMessage.events.toTypedArray())
             from.run {
@@ -1107,22 +1107,22 @@ internal class MessageExtensionTest {
     }
 
     @Test
-    fun `when StructuredMessage has ButtonResponseContent with type Button then messageType is Unknown and quickReplies empty`() {
+    fun `when StructuredMessage has ButtonResponseContent with type Button then messageType is Cards and quickReplies empty`() {
         val givenButton = StructuredMessage.Content.ButtonResponseContent.ButtonResponse(
             text = QuickReplyTestValues.TEXT_A,
             payload = QuickReplyTestValues.PAYLOAD_A,
             type = QuickReplyTestValues.BUTTON
         )
         val givenStructuredMessage = StructuredMessageValues.createStructuredMessageForTesting(
-            type = StructuredMessage.Type.Structured,
+            type = com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Type.Structured,
             content = listOf(
                 StructuredMessage.Content.ButtonResponseContent(
-                    contentType = StructuredMessage.Content.Type.ButtonResponse.name,
+                    contentType = com.genesys.cloud.messenger.transport.shyrka.receive.StructuredMessage.Content.Type.ButtonResponse.name,
                     buttonResponse = givenButton
                 )
             )
         )
-        val expectedMessageType = Message.Type.Unknown
+        val expectedMessageType = Message.Type.Cards
 
         val result = givenStructuredMessage.toMessage()
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MCCardsAndCarouselTests.kt
@@ -98,7 +98,7 @@ class MCCardsAndCarouselTests : BaseMessagingClientTest() {
             imageUrl = "http://image.com/image.png",
             actions = listOf(
                 ButtonResponse(
-                    type = "QuickReply",
+                    type = "Button",
                     text = "Select this option",
                     payload = "postback_payload"
                 )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -31,7 +31,7 @@ internal fun StructuredMessage.toMessage(): Message {
         id = metadata["customMessageId"] ?: id,
         direction = if (isInbound()) Direction.Inbound else Direction.Outbound,
         state = Message.State.Sent,
-        messageType = type.toMessageType(quickReplies.isNotEmpty(), hasCardSelection, cards.isNotEmpty()),
+        messageType = type.toMessageType(quickReplies.isNotEmpty(), cards.isNotEmpty(), hasCardSelection),
         text = text,
         timeStamp = channel?.time.fromIsoToEpochMilliseconds(),
         attachments = content.filterIsInstance<AttachmentContent>().toAttachments(),

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -102,8 +102,8 @@ private fun List<StructuredMessage.Content>.toQuickReplies(): List<ButtonRespons
 
     if (filteredButtonResponse.isNotEmpty()) {
         return filteredButtonResponse
-            .mapNotNull { br ->
-                br.buttonResponse.takeIf { it.type.normalizeButtonType() == "QuickReply" }
+            .mapNotNull { buttonResponseContent ->
+                buttonResponseContent.buttonResponse.takeIf { it.type.normalizeButtonType() == "QuickReply" }
             }
             .map { br -> ButtonResponse(br.text, br.payload, "QuickReply") }
     }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -170,11 +170,6 @@ private fun String.normalizeButtonType(): String =
         else -> "Button"
     }
 
-// private fun List<StructuredMessage.Content>.hasCardSelection(): Boolean =
-//    this.filterIsInstance<ButtonResponseContent>()
-//        .map { it.buttonResponse }
-//        .any { it.type.normalizeButtonType() == "Button" }
-
 private fun List<StructuredMessage.Content>.hasCardSelection(): Boolean =
     this.filterIsInstance<ButtonResponseContent>()
         .any { it.buttonResponse.type.normalizeButtonType() == "Button" }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -25,12 +25,13 @@ internal fun List<StructuredMessage>.toMessageList(): List<Message> =
 internal fun StructuredMessage.toMessage(): Message {
     val quickReplies = content.toQuickReplies()
     val cards = content.toCards()
+    val hasCardSelection = content.hasCardSelection()
 
     return Message(
         id = metadata["customMessageId"] ?: id,
         direction = if (isInbound()) Direction.Inbound else Direction.Outbound,
         state = Message.State.Sent,
-        messageType = type.toMessageType(quickReplies.isNotEmpty(), cards.isNotEmpty()),
+        messageType = type.toMessageType(quickReplies.isNotEmpty(), hasCardSelection, cards.isNotEmpty()),
         text = text,
         timeStamp = channel?.time.fromIsoToEpochMilliseconds(),
         attachments = content.filterIsInstance<AttachmentContent>().toAttachments(),
@@ -101,9 +102,9 @@ private fun List<StructuredMessage.Content>.toQuickReplies(): List<ButtonRespons
 
     if (filteredButtonResponse.isNotEmpty()) {
         return filteredButtonResponse
-            .mapNotNull { it.buttonResponse }
-            .map { br -> br.copy(type = br.type.normalizeButtonType()) }
-            .filter { it.type == "QuickReply" }
+            .mapNotNull { br ->
+                br.buttonResponse.takeIf { it.type.normalizeButtonType() == "QuickReply" }
+            }
             .map { br -> ButtonResponse(br.text, br.payload, "QuickReply") }
     }
 
@@ -150,14 +151,14 @@ private fun List<StructuredMessage.Content>.toCards(): List<Message.Card> =
         }
     }
 
-private fun StructuredMessage.Type.toMessageType(hasQuickReplies: Boolean, hasCards: Boolean): Message.Type =
+private fun StructuredMessage.Type.toMessageType(hasQuickReplies: Boolean, hasCards: Boolean, hasCardSelection: Boolean): Message.Type =
     when (this) {
         StructuredMessage.Type.Text -> Message.Type.Text
         StructuredMessage.Type.Event -> Message.Type.Event
         StructuredMessage.Type.Structured -> {
             when {
                 hasQuickReplies -> Message.Type.QuickReply
-                hasCards -> Message.Type.Cards
+                hasCards || hasCardSelection -> Message.Type.Cards
                 else -> Message.Type.Unknown
             }
         }
@@ -166,8 +167,17 @@ private fun StructuredMessage.Type.toMessageType(hasQuickReplies: Boolean, hasCa
 private fun String.normalizeButtonType(): String =
     when {
         this.equals("QuickReply", ignoreCase = true) -> "QuickReply"
-        else -> "Button" // anything else (including "Postback") is treated as Button
+        else -> "Button"
     }
+
+// private fun List<StructuredMessage.Content>.hasCardSelection(): Boolean =
+//    this.filterIsInstance<ButtonResponseContent>()
+//        .map { it.buttonResponse }
+//        .any { it.type.normalizeButtonType() == "Button" }
+
+private fun List<StructuredMessage.Content>.hasCardSelection(): Boolean =
+    this.filterIsInstance<ButtonResponseContent>()
+        .any { it.buttonResponse.type.normalizeButtonType() == "Button" }
 
 internal fun String.isHealthCheckResponseId(): Boolean = this == HealthCheckID
 

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/utility/TestValues.kt
@@ -149,6 +149,7 @@ object QuickReplyTestValues {
     internal const val PAYLOAD_A = "payload_a"
     internal const val PAYLOAD_B = "payload_b"
     internal const val QUICK_REPLY = "QuickReply"
+    internal const val BUTTON = "Button"
     internal const val BUTTON_RESPONSE = "ButtonResponse"
 
     internal val buttonResponse_a = ButtonResponse(
@@ -234,7 +235,7 @@ object CardTestValues {
     )
     val postbackButtonResponse = ButtonResponse(
         text = POSTBACK_TEXT,
-        type = QuickReplyTestValues.QUICK_REPLY,
+        type = QuickReplyTestValues.BUTTON,
         payload = POSTBACK_PAYLOAD
     )
 


### PR DESCRIPTION
Fix ButtonResponse type handling and update tests

- Normalize Postback → Button so messages don’t fail with 400
- Update toMessage mapping to correctly handle QuickReply vs Button
- Add tests for QuickReplyContent and ButtonResponseContent mapping