### PR TITLE
bug/MTSDK-920_c-and-c-spaces-are-removed-from-card-title

### DIFF
--- a/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/MessageExtensionTest.kt
@@ -56,7 +56,6 @@ import com.genesys.cloud.messenger.transport.utility.MessageValues
 import com.genesys.cloud.messenger.transport.utility.QuickReplyTestValues
 import com.genesys.cloud.messenger.transport.utility.StructuredMessageValues
 import com.genesys.cloud.messenger.transport.utility.TestValues
-import kotlinx.serialization.encodeToString
 import net.bytebuddy.utility.RandomString
 import org.junit.Test
 
@@ -981,7 +980,7 @@ internal class MessageExtensionTest {
     @Test
     fun `when StructuredMessage has CarouselContent then messageType is Carousel and cards are mapped`() {
         val givenTitles = listOf("Card One", "Card Two")
-        val expectedTitles = listOf("CardOne", "CardTwo")
+        val expectedTitles = listOf("Card One", "Card Two")
         val expectedActionText = "Open"
 
         val givenStructuredMessage = CardTestValues.createStructuredMessageWithCarouselContent(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/extensions/MessageExtension.kt
@@ -135,7 +135,7 @@ private fun StructuredMessage.Content.Action.mapDefaultActionIfLink(): ButtonRes
 
 private fun StructuredMessage.Content.CardContent.Card.toMessageCard(): Message.Card =
     Message.Card(
-        title = title.filterNot { it.isWhitespace() },
+        title = title,
         description = description,
         imageUrl = image,
         actions = actions.mapNotNull { it.toMessageCardAction() },


### PR DESCRIPTION
Fix: remove Card.title whitespace filter + align tests