### PR TITLE
MTSDK-908 Investigate lint rule: Standard annotation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 # Necessary rules
 ktlint_function_naming_ignore_when_annotated_with = Composable
 # Investigation candidate rules
-ktlint_standard_argument-list-wrapping = disabled
 ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_block-comment-initial-star-alignment = disabled
 ktlint_standard_chain-method-continuation = disabled

--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,6 @@ root = true
 # Necessary rules
 ktlint_function_naming_ignore_when_annotated_with = Composable
 # Investigation candidate rules
-ktlint_standard_annotation = disabled
 ktlint_standard_argument-list-wrapping = disabled
 ktlint_standard_blank-line-before-declaration = disabled
 ktlint_standard_block-comment-initial-star-alignment = disabled

--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/theme/Theme.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/ui/theme/Theme.kt
@@ -17,8 +17,7 @@ private val LightColorPalette = lightColors(
 
 @Composable
 fun WebMessagingTheme(
-//    darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable() () -> Unit
+    content: @Composable () -> Unit
 ) {
     MaterialTheme(
         colors = LightColorPalette,

--- a/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/AttachmentHandlerTest.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import kotlinx.serialization.encodeToString
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -746,12 +745,16 @@ internal class AttachmentHandlerTest {
 
     private fun presignedUrlResponse(id: String = AttachmentValues.ID): PresignedUrlResponse =
         PresignedUrlResponse(
-            id, mapOf("header" to "given header"), "http://someuploadurl.com",
+            id,
+            mapOf("header" to "given header"),
+            "http://someuploadurl.com",
         )
 
     private fun uploadSuccessEvent(id: String = AttachmentValues.ID): UploadSuccessEvent =
         UploadSuccessEvent(
-            id, "http://somedownloadurl.com", "2021-08-17T17:00:08.746Z",
+            id,
+            "http://somedownloadurl.com",
+            "2021-08-17T17:00:08.746Z",
         )
 
     /**

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/network/SerializationTest.kt
@@ -39,7 +39,6 @@ import com.genesys.cloud.messenger.transport.shyrka.send.OnMessageRequest
 import com.genesys.cloud.messenger.transport.shyrka.send.TextMessage
 import com.genesys.cloud.messenger.transport.utility.TestValues
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.encodeToString
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -86,7 +85,8 @@ class SerializationTest {
         val messageWithAttachmentAndCustomAttributesRequest = OnMessageRequest(
             token = "<token>",
             message = TextMessage(
-                text = "Hello world", metadata = mapOf("id" to "aaa-bbb-ccc"),
+                text = "Hello world",
+                metadata = mapOf("id" to "aaa-bbb-ccc"),
                 content = listOf(
                     Message.Content(
                         contentType = Message.Content.Type.Attachment,

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalVault.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalVault.kt
@@ -135,7 +135,10 @@ internal class InternalVault(private val serviceName: String) {
         fun query(vararg pairs: Pair<CFStringRef?, CFTypeRef?>): CFDictionaryRef? {
             val map = mapOf(*pairs).plus(refs.filter { it.value != null })
             return CFDictionaryCreateMutable(
-                null, map.size.convert(), null, null
+                null,
+                map.size.convert(),
+                null,
+                null
             ).apply {
                 map.entries.forEach { CFDictionaryAddValue(this, it.key, it.value) }
             }.apply {

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -113,7 +113,8 @@ internal actual class PlatformSocket actual constructor(
                 nsError != null -> {
                     log.e { LogMessages.receiveMessageError(nsError.code, nsError.localizedDescription) }
                     handleError(
-                        nsError, "Receive handler error"
+                        nsError,
+                        "Receive handler error"
                     )
                     return@receiveMessageWithCompletionHandler
                 }


### PR DESCRIPTION
The `ktlint_standard_annotation` lint rule is safe to be removed 