### PR TITLE
MTSDK-876 remove unnecessary Darwin Http parameters

### DIFF
--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformHttpEngine.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformHttpEngine.kt
@@ -5,12 +5,5 @@ import io.ktor.client.engine.darwin.Darwin
 
 internal actual fun createPlatformHttpClient(logging: Boolean): HttpClient =
     HttpClient(Darwin) {
-        engine {
-            configureRequest {
-                setAllowsCellularAccess(true)
-                setAllowsConstrainedNetworkAccess(true)
-                setAllowsExpensiveNetworkAccess(true)
-            }
-        }
         applyDefaultConfig(logging)
     }


### PR DESCRIPTION
Reason of the change: Darwin is the default Http client for a while already, these flags have been added accidentally, and those are not needed