### PR TITLE
[MTSDK-1261] Rename minimumWebSocketTlsVersion to minimumIosWebSocketTlsVersion

### DIFF
--- a/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/MainActivity.kt
+++ b/androidComposePrototype/src/main/java/com/genesys/cloud/messenger/androidcomposeprototype/MainActivity.kt
@@ -31,11 +31,14 @@ class MainActivity :
         setPrototypeLauncherView()
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                onBackInvoked()
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    onBackInvoked()
+                }
             }
-        })
+        )
 
         intent?.data?.doIfRedirectedFromOkta { uri ->
             handleOktaRedirect(uri)

--- a/iosApp/iosApp/MessengerInteractor.swift
+++ b/iosApp/iosApp/MessengerInteractor.swift
@@ -31,7 +31,7 @@ final class MessengerInteractor {
                                            reconnectionTimeoutInSeconds: reconnectTimeout,
                                            autoRefreshTokenWhenExpired: true,
                                            encryptedVault: true,
-                                           minimumWebSocketTlsVersion: minimumTlsVersion)
+                                           minimumIosWebSocketTlsVersion: minimumTlsVersion)
         self.tokenVault = DefaultVault(keys: Vault.Keys(vaultKey: "com.genesys.cloud.messenger", tokenKey: "token", authRefreshTokenKey: "auth_refresh_token", wasAuthenticated: "wasAuthenticated", pushConfigKey: "pushConfig"))
         self.messengerTransport = MessengerTransportSDK(configuration: self.configuration, vault: self.tokenVault)
         self.messagingClient = self.messengerTransport.createMessagingClient()

--- a/transport/GenesysCloudMessengerTransport-Dev.podspec
+++ b/transport/GenesysCloudMessengerTransport-Dev.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'GenesysCloudMessengerTransport'
-    spec.version                  = '2.11.0'
+    spec.version                  = '2.12.0-rc3'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http => '' }
     spec.authors                  = 'Genesys Cloud Services, Inc.'

--- a/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/androidMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -20,7 +20,7 @@ internal actual class PlatformSocket actual constructor(
     private val log: Log,
     private val url: Url,
     actual val pingInterval: Int,
-    minimumWebSocketTlsVersion: TlsVersion,
+    minimumIosWebSocketTlsVersion: TlsVersion,
 ) {
     private var webSocket: WebSocket? = null
     private var listener: PlatformSocketListener? = null

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/Configuration.kt
@@ -6,7 +6,7 @@ package com.genesys.cloud.messenger.transport.core
  * @param logging indicates if logging should be enabled.
  * @param reconnectionTimeoutInSeconds period of time during which Transport will try to reconnect to the web socket in case of connectivity lost.
  * @param autoRefreshTokenWhenExpired indicates if Transport should auto refresh auth token if it was expired.
- * @param minimumWebSocketTlsVersion the minimum TLS protocol version for WebSocket connections. Default is [TlsVersion.SYSTEM_DEFAULT] for backward compatibility.
+ * @param minimumIosWebSocketTlsVersion the minimum TLS protocol version for iOS WebSocket connections. Only affects iOS; Android handles TLS via the system networking layer. Default is [TlsVersion.SYSTEM_DEFAULT] for backward compatibility.
  */
 data class Configuration(
     val deploymentId: String,
@@ -15,7 +15,7 @@ data class Configuration(
     val reconnectionTimeoutInSeconds: Long = 60 * 5,
     val autoRefreshTokenWhenExpired: Boolean = true,
     val encryptedVault: Boolean = false,
-    val minimumWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT
+    val minimumIosWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT
 ) {
     /**
      * Secondary constructor to avoid breaking changes on iOS platform.
@@ -37,7 +37,7 @@ data class Configuration(
         reconnectionTimeoutInSeconds = reconnectionTimeoutInSeconds,
         autoRefreshTokenWhenExpired = true,
         encryptedVault = false,
-        minimumWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
+        minimumIosWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
     )
 
     /**
@@ -57,7 +57,7 @@ data class Configuration(
         reconnectionTimeoutInSeconds = reconnectionTimeoutInSeconds,
         autoRefreshTokenWhenExpired = autoRefreshTokenWhenExpired,
         encryptedVault = encryptedVault,
-        minimumWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
+        minimumIosWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
     )
 
     internal var application: String = "TransportSDK-${MessengerTransportSDK.sdkVersion}"

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalConfigurationFactory.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/InternalConfigurationFactory.kt
@@ -14,7 +14,7 @@ object InternalConfigurationFactory {
      * @param reconnectionTimeoutInSeconds period of time during which Transport will try to reconnect.
      * @param autoRefreshTokenWhenExpired indicates if Transport should auto refresh auth token if expired.
      * @param encryptedVault indicates if encrypted vault should be used.
-     * @param minimumWebSocketTlsVersion the minimum TLS protocol version for WebSocket connections.
+     * @param minimumIosWebSocketTlsVersion the minimum TLS protocol version for iOS WebSocket connections.
      * @return Configuration instance with proper application parameter formatting.
      */
     fun create(
@@ -26,7 +26,7 @@ object InternalConfigurationFactory {
         reconnectionTimeoutInSeconds: Long = 60 * 5,
         autoRefreshTokenWhenExpired: Boolean = true,
         encryptedVault: Boolean = false,
-        minimumWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT
+        minimumIosWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT
     ): Configuration {
         val config =
             Configuration(
@@ -36,7 +36,7 @@ object InternalConfigurationFactory {
                 reconnectionTimeoutInSeconds = reconnectionTimeoutInSeconds,
                 autoRefreshTokenWhenExpired = autoRefreshTokenWhenExpired,
                 encryptedVault = encryptedVault,
-                minimumWebSocketTlsVersion = minimumWebSocketTlsVersion
+                minimumIosWebSocketTlsVersion = minimumIosWebSocketTlsVersion
             )
 
         config.application =
@@ -69,6 +69,6 @@ object InternalConfigurationFactory {
             reconnectionTimeoutInSeconds = reconnectionTimeoutInSeconds,
             autoRefreshTokenWhenExpired = autoRefreshTokenWhenExpired,
             encryptedVault = encryptedVault,
-            minimumWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
+            minimumIosWebSocketTlsVersion = TlsVersion.SYSTEM_DEFAULT
         )
 }

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessengerTransportSDK.kt
@@ -83,7 +83,7 @@ class MessengerTransportSDK(
                 log.withTag(LogTag.WEBSOCKET),
                 urls.webSocketUrl,
                 DEFAULT_PING_INTERVAL_IN_SECONDS,
-                configuration.minimumWebSocketTlsVersion,
+                configuration.minimumIosWebSocketTlsVersion,
             )
         // Support old TokenStore. If TokenStore not present fallback to the Vault.
         val token = tokenStore?.token ?: vault.token

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -12,13 +12,13 @@ const val DEFAULT_PING_INTERVAL_IN_SECONDS = 15
  * @param log the logger
  * @param url the WS endpoint.
  * @param pingInterval the interval in seconds for sending ping frames until the connection fails or is closed. Pinging may help keep the connection from timing out. The default value of 0 disables pinging.
- * @param minimumWebSocketTlsVersion the minimum TLS protocol version for this WebSocket connection.
+ * @param minimumIosWebSocketTlsVersion the minimum TLS protocol version for this iOS WebSocket connection.
  */
 internal expect class PlatformSocket(
     log: Log,
     url: Url,
     pingInterval: Int = DEFAULT_PING_INTERVAL_IN_SECONDS,
-    minimumWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT,
+    minimumIosWebSocketTlsVersion: TlsVersion = TlsVersion.SYSTEM_DEFAULT,
 ) {
     val pingInterval: Int
 

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/ConfigurationTest.kt
@@ -21,7 +21,7 @@ class ConfigurationTest {
             assertThat(reconnectionTimeoutInSeconds).isEqualTo(expectedReconnectionTimeout)
             assertThat(autoRefreshTokenWhenExpired).isTrue()
             assertThat(encryptedVault).isFalse()
-            assertThat(minimumWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
+            assertThat(minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
         }
     }
 
@@ -39,7 +39,7 @@ class ConfigurationTest {
             assertThat(reconnectionTimeoutInSeconds).isEqualTo(expectedReconnectionTimeout)
             assertThat(autoRefreshTokenWhenExpired).isTrue()
             assertThat(encryptedVault).isFalse()
-            assertThat(minimumWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
+            assertThat(minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
         }
     }
 
@@ -53,22 +53,22 @@ class ConfigurationTest {
             assertThat(reconnectionTimeoutInSeconds).isEqualTo(300L)
             assertThat(autoRefreshTokenWhenExpired).isTrue()
             assertThat(encryptedVault).isTrue()
-            assertThat(minimumWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
+            assertThat(minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
         }
     }
 
     @Test
     fun `validate configuration with non-default TLS version`() {
-        val configuration = TestValues.configuration.copy(minimumWebSocketTlsVersion = TlsVersion.TLS_1_2)
+        val configuration = TestValues.configuration.copy(minimumIosWebSocketTlsVersion = TlsVersion.TLS_1_2)
 
         configuration.run {
             assertThat(deploymentId).isEqualTo(TestValues.DEPLOYMENT_ID)
-            assertThat(minimumWebSocketTlsVersion).isEqualTo(TlsVersion.TLS_1_2)
+            assertThat(minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.TLS_1_2)
         }
     }
 
     @Test
-    fun `when using 4-param secondary constructor then minimumWebSocketTlsVersion defaults to SYSTEM_DEFAULT`() {
+    fun `when using 4-param secondary constructor then minimumIosWebSocketTlsVersion defaults to SYSTEM_DEFAULT`() {
         val configuration =
             Configuration(
                 deploymentId = TestValues.DEPLOYMENT_ID,
@@ -77,11 +77,11 @@ class ConfigurationTest {
                 reconnectionTimeoutInSeconds = 60,
             )
 
-        assertThat(configuration.minimumWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
+        assertThat(configuration.minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
     }
 
     @Test
-    fun `when using 6-param secondary constructor then minimumWebSocketTlsVersion defaults to SYSTEM_DEFAULT`() {
+    fun `when using 6-param secondary constructor then minimumIosWebSocketTlsVersion defaults to SYSTEM_DEFAULT`() {
         val configuration =
             Configuration(
                 deploymentId = TestValues.DEPLOYMENT_ID,
@@ -92,6 +92,6 @@ class ConfigurationTest {
                 encryptedVault = true,
             )
 
-        assertThat(configuration.minimumWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
+        assertThat(configuration.minimumIosWebSocketTlsVersion).isEqualTo(TlsVersion.SYSTEM_DEFAULT)
     }
 }

--- a/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/InternalConfigurationFactoryTest.kt
+++ b/transport/src/commonTest/kotlin/com/genesys/cloud/messenger/transport/InternalConfigurationFactoryTest.kt
@@ -42,7 +42,7 @@ class InternalConfigurationFactoryTest {
     }
 
     @Test
-    fun `when creating configuration without minimumWebSocketTlsVersion it should default to SYSTEM_DEFAULT`() {
+    fun `when creating configuration without minimumIosWebSocketTlsVersion it should default to SYSTEM_DEFAULT`() {
         val config =
             InternalConfigurationFactory.create(
                 deploymentId = "test-deployment",
@@ -51,25 +51,25 @@ class InternalConfigurationFactoryTest {
                 applicationVersion = "0.0.0"
             )
 
-        assertEquals(TlsVersion.SYSTEM_DEFAULT, config.minimumWebSocketTlsVersion)
+        assertEquals(TlsVersion.SYSTEM_DEFAULT, config.minimumIosWebSocketTlsVersion)
     }
 
     @Test
-    fun `when creating configuration with minimumWebSocketTlsVersion it should be propagated to Configuration`() {
+    fun `when creating configuration with minimumIosWebSocketTlsVersion it should be propagated to Configuration`() {
         val config =
             InternalConfigurationFactory.create(
                 deploymentId = "test-deployment",
                 domain = "test.com",
                 applicationType = ApplicationType.TRANSPORT_SDK,
                 applicationVersion = "0.0.0",
-                minimumWebSocketTlsVersion = TlsVersion.TLS_1_3
+                minimumIosWebSocketTlsVersion = TlsVersion.TLS_1_3
             )
 
-        assertEquals(TlsVersion.TLS_1_3, config.minimumWebSocketTlsVersion)
+        assertEquals(TlsVersion.TLS_1_3, config.minimumIosWebSocketTlsVersion)
     }
 
     @Test
-    fun `when using backward compatible overload it should default minimumWebSocketTlsVersion to SYSTEM_DEFAULT`() {
+    fun `when using backward compatible overload it should default minimumIosWebSocketTlsVersion to SYSTEM_DEFAULT`() {
         val config =
             InternalConfigurationFactory.create(
                 deploymentId = "test-deployment",
@@ -82,6 +82,6 @@ class InternalConfigurationFactoryTest {
                 encryptedVault = false
             )
 
-        assertEquals(TlsVersion.SYSTEM_DEFAULT, config.minimumWebSocketTlsVersion)
+        assertEquals(TlsVersion.SYSTEM_DEFAULT, config.minimumIosWebSocketTlsVersion)
     }
 }

--- a/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
+++ b/transport/src/iosMain/kotlin/com/genesys/cloud/messenger/transport/network/PlatformSocket.kt
@@ -43,7 +43,7 @@ internal actual class PlatformSocket actual constructor(
      * client assumes connectivity is lost and will notify [PlatformSocketListener.onFailure].
      */
     actual val pingInterval: Int,
-    private val minimumWebSocketTlsVersion: TlsVersion,
+    private val minimumIosWebSocketTlsVersion: TlsVersion,
 ) {
     private val socketEndpoint = NSURL.URLWithString(url.toString())!!
     private var webSocket: NSURLSessionWebSocketTask? = null
@@ -60,7 +60,7 @@ internal actual class PlatformSocket actual constructor(
         urlRequest.setValue(Platform().platform, forHTTPHeaderField = "User-Agent")
         urlRequest.setTimeoutInterval(TIMEOUT_INTERVAL)
         val sessionConfig = NSURLSessionConfiguration.defaultSessionConfiguration()
-        applyTlsConfiguration(sessionConfig, minimumWebSocketTlsVersion)
+        applyTlsConfiguration(sessionConfig, minimumIosWebSocketTlsVersion)
         val urlSession =
             NSURLSession.sessionWithConfiguration(
                 configuration = sessionConfig,
@@ -233,9 +233,9 @@ internal actual class PlatformSocket actual constructor(
 
 private fun applyTlsConfiguration(
     sessionConfig: NSURLSessionConfiguration,
-    minimumWebSocketTlsVersion: TlsVersion
+    minimumIosWebSocketTlsVersion: TlsVersion
 ) {
-    when (minimumWebSocketTlsVersion) {
+    when (minimumIosWebSocketTlsVersion) {
         TlsVersion.SYSTEM_DEFAULT -> {}
         TlsVersion.TLS_1_2 -> {
             sessionConfig.TLSMinimumSupportedProtocolVersion = tls_protocol_version_TLSv12


### PR DESCRIPTION
Renamed minimumWebSocketTlsVersion to minimumIosWebSocketTlsVersion across the Transport SDK to make the iOS-only scope of this parameter self-evident, eliminating the need for extra documentation and preventing misuse from Android consumers.