### PR TITLE
[MTSDK-928] Emit Event.Logout when WS is disconnected during logoutFromAuthenticatedSession

### DIFF
--- a/transport/GenesysCloudMessengerTransport-Dev.podspec
+++ b/transport/GenesysCloudMessengerTransport-Dev.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'GenesysCloudMessengerTransport'
-    spec.version                  = '2.12.0-rc3'
+    spec.version                  = '2.12.0'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http => '' }
     spec.authors                  = 'Genesys Cloud Services, Inc.'

--- a/transport/GenesysCloudMessengerTransport-Dev.podspec
+++ b/transport/GenesysCloudMessengerTransport-Dev.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'GenesysCloudMessengerTransport'
-    spec.version                  = '2.11.0'
+    spec.version                  = '2.12.0-rc3'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http => '' }
     spec.authors                  = 'Genesys Cloud Services, Inc.'

--- a/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
@@ -277,14 +277,14 @@ class AuthHandlerTest {
                 ErrorCode.ClientResponseError(401),
                 ErrorTest.MESSAGE
             )
-        val onLogoutFailureMock = mockk<() -> Unit>(relaxed = true)
-        subject.logout(onLogoutFailure = onLogoutFailureMock)
+        val onUnauthorizedMock = mockk<() -> Unit>(relaxed = true)
+        subject.logout(onUnauthorized = onUnauthorizedMock)
 
         coVerify {
             mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
         }
         verify {
-            onLogoutFailureMock.invoke()
+            onUnauthorizedMock.invoke()
             fakeVault.remove(fakeVault.keys.tokenKey)
             subject.clear()
         }
@@ -303,14 +303,14 @@ class AuthHandlerTest {
                 ErrorTest.MESSAGE
             )
 
-        val onLogoutFailureMock = mockk<() -> Unit>(relaxed = true)
-        subject.logout(onLogoutFailure = onLogoutFailureMock)
+        val onUnauthorizedMock = mockk<() -> Unit>(relaxed = true)
+        subject.logout(onUnauthorized = onUnauthorizedMock)
 
         coVerify {
             mockWebMessagingApi.logoutFromAuthenticatedSession(NO_JWT)
         }
         verify {
-            onLogoutFailureMock.invoke()
+            onUnauthorizedMock.invoke()
             fakeVault.remove(fakeVault.keys.tokenKey)
             subject.clear()
         }
@@ -328,8 +328,8 @@ class AuthHandlerTest {
         val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
-        val onLogoutFailureMock = mockk<() -> Unit>(relaxed = true)
-        subject.logout(onLogoutFailure = onLogoutFailureMock)
+        val onUnauthorizedMock = mockk<() -> Unit>(relaxed = true)
+        subject.logout(onUnauthorized = onUnauthorizedMock)
 
         coVerify(exactly = 1) {
             mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
@@ -339,7 +339,7 @@ class AuthHandlerTest {
             mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
         }
         verify(exactly = 1) {
-            onLogoutFailureMock.invoke()
+            onUnauthorizedMock.invoke()
         }
         verify(exactly = 0) {
             mockEventHandler.onEvent(
@@ -367,15 +367,15 @@ class AuthHandlerTest {
             )
         val expectedAuthJwt = AuthJwt(NO_JWT, NO_REFRESH_TOKEN)
 
-        val onLogoutFailureMock = mockk<() -> Unit>(relaxed = true)
-        subject.logout(onLogoutFailure = onLogoutFailureMock)
+        val onUnauthorizedMock = mockk<() -> Unit>(relaxed = true)
+        subject.logout(onUnauthorized = onUnauthorizedMock)
 
         coVerify(exactly = 1) {
             mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
             mockWebMessagingApi.refreshAuthJwt(AuthTest.REFRESH_TOKEN)
         }
         verify {
-            onLogoutFailureMock.invoke()
+            onUnauthorizedMock.invoke()
 
             fakeVault.remove(fakeVault.keys.tokenKey)
             subject.clear()
@@ -403,8 +403,8 @@ class AuthHandlerTest {
         val expectedErrorMessage = ErrorTest.MESSAGE
         val expectedCorrectiveAction = CorrectiveAction.ReAuthenticate
 
-        val onLogoutFailureMock = mockk<() -> Unit>(relaxed = true)
-        subject.logout(onLogoutFailure = onLogoutFailureMock)
+        val onUnauthorizedMock = mockk<() -> Unit>(relaxed = true)
+        subject.logout(onUnauthorized = onUnauthorizedMock)
 
         coVerify(exactly = 1) {
             mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
@@ -412,7 +412,7 @@ class AuthHandlerTest {
         }
         // Event is fired twice: once in performTokenRefresh and once in handleRequestError (logout)
         verify(exactly = 1) {
-            onLogoutFailureMock.invoke()
+            onUnauthorizedMock.invoke()
             mockEventHandler.onEvent(
                 Event.Error(
                     expectedErrorCode,

--- a/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/auth/AuthHandlerTest.kt
@@ -232,11 +232,15 @@ class AuthHandlerTest {
     @Test
     fun `when authorized and logout() success`() {
         authorize()
+        val onLogoutSuccessMock = mockk<() -> Unit>(relaxed = true)
 
-        subject.logout()
+        subject.logout(onLogoutSuccess = onLogoutSuccessMock)
 
         coVerify {
             mockWebMessagingApi.logoutFromAuthenticatedSession(AuthTest.JWT_TOKEN)
+        }
+        verify {
+            onLogoutSuccessMock.invoke()
         }
     }
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientAuthTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientAuthTest.kt
@@ -158,7 +158,7 @@ class MessagingClientAuthTest : BaseMessagingClientTest() {
         subject.logoutFromAuthenticatedSession()
 
         verify {
-            mockAuthHandler.logout(any())
+            mockAuthHandler.logout(any(), any())
         }
     }
 
@@ -167,7 +167,7 @@ class MessagingClientAuthTest : BaseMessagingClientTest() {
         // Test from Idle state
         assertThat(subject.currentState).isIdle()
         subject.logoutFromAuthenticatedSession()
-        verify { mockAuthHandler.logout(any()) }
+        verify { mockAuthHandler.logout(any(), any()) }
 
         // Test from Error state
         every { mockPlatformSocket.sendMessage(match { Request.isConfigureRequest(it) }) } answers {
@@ -176,7 +176,7 @@ class MessagingClientAuthTest : BaseMessagingClientTest() {
         subject.connect()
         assertThat(subject.currentState).isError(ErrorCode.SessionNotFound, "session not found error message")
         subject.logoutFromAuthenticatedSession()
-        verify(exactly = 2) { mockAuthHandler.logout(any()) }
+        verify(exactly = 2) { mockAuthHandler.logout(any(), any()) }
 
         // Test from ReadOnly state
         every { mockPlatformSocket.sendMessage(match { Request.isConfigureRequest(it) }) } answers {
@@ -185,7 +185,7 @@ class MessagingClientAuthTest : BaseMessagingClientTest() {
         subject.connect()
         assertThat(subject.currentState).isReadOnly()
         subject.logoutFromAuthenticatedSession()
-        verify(exactly = 3) { mockAuthHandler.logout(any()) }
+        verify(exactly = 3) { mockAuthHandler.logout(any(), any()) }
     }
 
     @Test
@@ -196,7 +196,42 @@ class MessagingClientAuthTest : BaseMessagingClientTest() {
 
         verifySequence {
             connectSequence(shouldConfigureAuth = true)
-            mockAuthHandler.logout(any())
+            mockAuthHandler.logout(any(), any())
+        }
+    }
+
+    @Test
+    fun `when logoutFromAuthenticatedSession after disconnect should emit Event Logout`() {
+        subject.connectAuthenticatedSession()
+        subject.disconnect()
+        assertThat(subject.currentState).isClosed(1000, "The user has closed the connection.")
+
+        every { mockAuthHandler.logout(captureLambda(), any()) } answers {
+            lambda<() -> Unit>().invoke()
+        }
+
+        subject.logoutFromAuthenticatedSession()
+
+        verify {
+            mockVault.wasAuthenticated = false
+            mockAuthHandler.clear()
+            mockEventHandler.onEvent(eq(Event.Logout))
+        }
+    }
+
+    @Test
+    fun `when logoutFromAuthenticatedSession after disconnect should not call disconnect again`() {
+        subject.connectAuthenticatedSession()
+        subject.disconnect()
+
+        every { mockAuthHandler.logout(captureLambda(), any()) } answers {
+            lambda<() -> Unit>().invoke()
+        }
+
+        subject.logoutFromAuthenticatedSession()
+
+        verify(exactly = 1) {
+            mockPlatformSocket.closeSocket(any(), any())
         }
     }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandler.kt
@@ -20,7 +20,7 @@ internal interface AuthHandler {
         nonce: String
     )
 
-    fun logout(onLogoutFailure: () -> Unit = {})
+    fun logout(onLogoutSuccess: () -> Unit = {}, onLogoutFailure: () -> Unit = {})
 
     fun refreshToken(callback: (Result<Empty>) -> Unit)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandler.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandler.kt
@@ -20,7 +20,7 @@ internal interface AuthHandler {
         nonce: String
     )
 
-    fun logout(onLogoutSuccess: () -> Unit = {}, onLogoutFailure: () -> Unit = {})
+    fun logout(onLogoutSuccess: () -> Unit = {}, onUnauthorized: () -> Unit = {})
 
     fun refreshToken(callback: (Result<Empty>) -> Unit)
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerImpl.kt
@@ -74,7 +74,7 @@ internal class AuthHandlerImpl(
         }
     }
 
-    override fun logout(onLogoutSuccess: () -> Unit, onLogoutFailure: () -> Unit) {
+    override fun logout(onLogoutSuccess: () -> Unit, onUnauthorized: () -> Unit) {
         dispatcher.launch {
             when (val result = api.logoutFromAuthenticatedSession(authJwt.jwt)) {
                 is Result.Success -> {
@@ -86,10 +86,10 @@ internal class AuthHandlerImpl(
                         logoutAttempts++
                         refreshToken {
                             when (it) {
-                                is Result.Success -> logout(onLogoutSuccess, onLogoutFailure)
+                                is Result.Success -> logout(onLogoutSuccess, onUnauthorized)
                                 is Result.Failure -> {
                                     if (result.errorCode.isUnauthorized()) {
-                                        handleUnauthorizedError(onLogoutFailure)
+                                        handleUnauthorizedError(onUnauthorized)
                                     } else {
                                         handleRequestError(it, "logout()")
                                     }
@@ -97,7 +97,7 @@ internal class AuthHandlerImpl(
                             }
                         }
                     } else if (result.errorCode.isUnauthorized()) {
-                        handleUnauthorizedError(onLogoutFailure)
+                        handleUnauthorizedError(onUnauthorized)
                     } else {
                         logoutAttempts = 0
                         handleRequestError(result, "logout()")
@@ -107,9 +107,9 @@ internal class AuthHandlerImpl(
         }
     }
 
-    private fun handleUnauthorizedError(onLogoutFailure: () -> Unit) {
+    private fun handleUnauthorizedError(onUnauthorized: () -> Unit) {
         logoutAttempts = 0
-        onLogoutFailure()
+        onUnauthorized()
     }
 
     override fun refreshToken(callback: (Result<Empty>) -> Unit) {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/auth/AuthHandlerImpl.kt
@@ -74,16 +74,19 @@ internal class AuthHandlerImpl(
         }
     }
 
-    override fun logout(onLogoutFailure: () -> Unit) {
+    override fun logout(onLogoutSuccess: () -> Unit, onLogoutFailure: () -> Unit) {
         dispatcher.launch {
             when (val result = api.logoutFromAuthenticatedSession(authJwt.jwt)) {
-                is Result.Success -> logoutAttempts = 0
+                is Result.Success -> {
+                    logoutAttempts = 0
+                    onLogoutSuccess()
+                }
                 is Result.Failure -> {
                     if (eligibleToRefresh(result.errorCode) && logoutAttempts < MAX_LOGOUT_ATTEMPTS) {
                         logoutAttempts++
                         refreshToken {
                             when (it) {
-                                is Result.Success -> logout(onLogoutFailure)
+                                is Result.Success -> logout(onLogoutSuccess, onLogoutFailure)
                                 is Result.Failure -> {
                                     if (result.errorCode.isUnauthorized()) {
                                         handleUnauthorizedError(onLogoutFailure)

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -362,7 +362,7 @@ internal class MessagingClientImpl(
                     performLogout()
                 }
             },
-            onLogoutFailure = {
+            onUnauthorized = {
                 performLogout()
             }
         )

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -356,9 +356,16 @@ internal class MessagingClientImpl(
     }
 
     override fun logoutFromAuthenticatedSession() {
-        authHandler.logout {
-            performLogout()
-        }
+        authHandler.logout(
+            onLogoutSuccess = {
+                if (stateMachine.isInactive()) {
+                    performLogout()
+                }
+            },
+            onLogoutFailure = {
+                performLogout()
+            }
+        )
     }
 
     override fun shouldAuthorize(callback: (Boolean) -> Unit) {
@@ -786,7 +793,9 @@ internal class MessagingClientImpl(
         vault.wasAuthenticated = false
         authHandler.clear()
         eventHandler.onEvent(Event.Logout)
-        disconnect()
+        if (!stateMachine.isInactive()) {
+            disconnect()
+        }
     }
 
     private inner class SocketListener(


### PR DESCRIPTION
Add onLogoutSuccess callback to AuthHandler.logout() so that when the REST logout succeeds and the WebSocket is already closed, Event.Logout is emitted directly instead of waiting for a Shyrka LogoutEvent that will never arrive.