### PR TITLE
MTSDK-1511 Fix crash on attempt to disconnect in case of wrong state

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 }
 
 // CocoaPods requires the podspec to have a `version`
-val buildVersion = "2.14.0"
+val buildVersion = "2.14.1-rc1"
 val snapshot = System.getenv("SNAPSHOT_BUILD") ?: ""
 version = "${buildVersion}${snapshot}"
 group = "cloud.genesys"

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../transport"
 
 SPEC CHECKSUMS:
-  transport: c2e808d4aa6cf5d32a5a587c27e2756a88b8067a
+  transport: 8a96b35cda3f0d6361e4010e882fbe06ccd0ec41
 
 PODFILE CHECKSUM: 10743e43aeaf72bb49673a0e57360c028906ace5
 

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - transport (2.14.0)
+  - transport (2.14.1-rc1)
 
 DEPENDENCIES:
   - transport (from `../transport`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../transport"
 
 SPEC CHECKSUMS:
-  transport: fdb5fa403414cf2a6bc797fc496719a9beecc166
+  transport: c2e808d4aa6cf5d32a5a587c27e2756a88b8067a
 
 PODFILE CHECKSUM: 10743e43aeaf72bb49673a0e57360c028906ace5
 

--- a/transport/GenesysCloudMessengerTransport-Dev.podspec
+++ b/transport/GenesysCloudMessengerTransport-Dev.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'GenesysCloudMessengerTransport'
-    spec.version                  = '2.14.0'
+    spec.version                  = '2.14.1-rc1'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http => '' }
     spec.authors                  = 'Genesys Cloud Services, Inc.'

--- a/transport/GenesysCloudMessengerTransport.podspec
+++ b/transport/GenesysCloudMessengerTransport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                   = 'GenesysCloudMessengerTransport'
-  s.version                = '2.14.0'
+  s.version                = '2.14.1-rc1'
   s.summary                = 'Genesys Cloud Messenger Transport SDK'
 
   s.description            = <<-DESC
@@ -33,7 +33,7 @@ SOFTWARE.
                                LICENSE
                              }
   s.author                 = 'Genesys Cloud Services, Inc.'
-  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.14.0/MessengerTransport.xcframework.zip' }
+  s.source                 = { :http => 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk/releases/download/v2.14.1-rc1/MessengerTransport.xcframework.zip' }
 
   s.ios.deployment_target  = '13.0'
 

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
@@ -16,6 +16,7 @@ import com.genesys.cloud.messenger.transport.core.isConfigured
 import com.genesys.cloud.messenger.transport.core.isConnected
 import com.genesys.cloud.messenger.transport.core.isConnecting
 import com.genesys.cloud.messenger.transport.core.isError
+import com.genesys.cloud.messenger.transport.core.isIdle
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import com.genesys.cloud.messenger.transport.utility.ErrorTest
@@ -32,7 +33,6 @@ import transport.util.fromConfiguredToReconnecting
 import transport.util.fromConnectedToError
 import transport.util.fromIdleToConnecting
 import transport.util.fromReconnectingToError
-import com.genesys.cloud.messenger.transport.core.isIdle
 import kotlin.test.assertFailsWith
 
 class MessagingClientConnectionTest : BaseMessagingClientTest() {

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
@@ -17,7 +17,6 @@ import com.genesys.cloud.messenger.transport.core.isConfigured
 import com.genesys.cloud.messenger.transport.core.isConnected
 import com.genesys.cloud.messenger.transport.core.isConnecting
 import com.genesys.cloud.messenger.transport.core.isError
-import com.genesys.cloud.messenger.transport.core.isIdle
 import com.genesys.cloud.messenger.transport.network.PlatformSocketListener
 import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import com.genesys.cloud.messenger.transport.utility.ErrorTest
@@ -76,9 +75,9 @@ class MessagingClientConnectionTest : BaseMessagingClientTest() {
 
     @Test
     fun `when not connected and disconnect`() {
-        subject.disconnect()
-
-        assertThat(subject.currentState).isIdle()
+        assertFailsWith<IllegalStateException> {
+            subject.disconnect()
+        }
     }
 
     @Test

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
@@ -32,6 +32,7 @@ import transport.util.fromConfiguredToReconnecting
 import transport.util.fromConnectedToError
 import transport.util.fromIdleToConnecting
 import transport.util.fromReconnectingToError
+import com.genesys.cloud.messenger.transport.core.isIdle
 import kotlin.test.assertFailsWith
 
 class MessagingClientConnectionTest : BaseMessagingClientTest() {
@@ -74,9 +75,9 @@ class MessagingClientConnectionTest : BaseMessagingClientTest() {
 
     @Test
     fun `when not connected and disconnect`() {
-        assertFailsWith<IllegalStateException> {
-            subject.disconnect()
-        }
+        subject.disconnect()
+
+        assertThat(subject.currentState).isIdle()
     }
 
     @Test

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientConnectionTest.kt
@@ -12,6 +12,7 @@ import com.genesys.cloud.messenger.transport.core.StateChange
 import com.genesys.cloud.messenger.transport.core.TransportSDKException
 import com.genesys.cloud.messenger.transport.core.events.Event
 import com.genesys.cloud.messenger.transport.core.isClosed
+import com.genesys.cloud.messenger.transport.core.isClosing
 import com.genesys.cloud.messenger.transport.core.isConfigured
 import com.genesys.cloud.messenger.transport.core.isConnected
 import com.genesys.cloud.messenger.transport.core.isConnecting
@@ -78,6 +79,29 @@ class MessagingClientConnectionTest : BaseMessagingClientTest() {
         subject.disconnect()
 
         assertThat(subject.currentState).isIdle()
+    }
+
+    @Test
+    fun `when SocketListener invoke onClosing while Configured`() {
+        val expectedCloseCode = 1001
+        val expectedCloseReason = "Going away."
+        subject.connect()
+
+        slot.captured.onClosing(expectedCloseCode, expectedCloseReason)
+
+        assertThat(subject.currentState).isClosing(expectedCloseCode, expectedCloseReason)
+    }
+
+    @Test
+    fun `when SocketListener invoke onClosing but state is already Closed`() {
+        val expectedState = MessagingClient.State.Closed(1000, "The user has closed the connection.")
+        subject.connect()
+        subject.disconnect()
+        assertThat(subject.currentState).isClosed(expectedState.code, expectedState.reason)
+
+        slot.captured.onClosing(expectedState.code, expectedState.reason)
+
+        assertThat(subject.currentState).isClosed(expectedState.code, expectedState.reason)
     }
 
     @Test

--- a/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientEventHandlingTest.kt
+++ b/transport/src/androidUnitTest/kotlin/transport/core/messagingclient/MessagingClientEventHandlingTest.kt
@@ -8,6 +8,7 @@ import com.genesys.cloud.messenger.transport.core.ErrorCode
 import com.genesys.cloud.messenger.transport.core.Message
 import com.genesys.cloud.messenger.transport.core.MessagingClient
 import com.genesys.cloud.messenger.transport.core.events.Event
+import com.genesys.cloud.messenger.transport.core.isClosed
 import com.genesys.cloud.messenger.transport.util.logs.LogMessages
 import io.mockk.verify
 import io.mockk.verifySequence
@@ -108,6 +109,19 @@ class MessagingClientEventHandlingTest : BaseMessagingClientTest() {
             mockEventHandler.onEvent(eq(expectedEvent))
             disconnectSequence()
         }
+    }
+
+    @Test
+    fun `when event ConnectionClosed is received but state is already Closed`() {
+        val expectedState = MessagingClient.State.Closed(1000, "The user has closed the connection.")
+        subject.connect()
+        slot.captured.onMessage(Response.connectionClosedEventNoReason)
+        assertThat(subject.currentState).isClosed(expectedState.code, expectedState.reason)
+
+        slot.captured.onMessage(Response.connectionClosedEventNoReason)
+
+        assertThat(subject.currentState).isClosed(expectedState.code, expectedState.reason)
+        verify(exactly = 1) { mockPlatformSocket.closeSocket(expectedState.code, expectedState.reason) }
     }
 
     @Test

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -274,8 +274,10 @@ interface MessagingClient {
 
     /**
      * Close the WebSocket connection to the Web Messaging service.
-     * If the client is already disconnected (Closed, Idle, or Error state), this is a no-op.
+     *
+     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
      */
+    @Throws(IllegalStateException::class)
     fun disconnect()
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClient.kt
@@ -274,10 +274,8 @@ interface MessagingClient {
 
     /**
      * Close the WebSocket connection to the Web Messaging service.
-     *
-     * @throws IllegalStateException If the current state of the MessagingClient is not compatible with the requested action.
+     * If the client is already disconnected (Closed, Idle, or Error state), this is a no-op.
      */
-    @Throws(IllegalStateException::class)
     fun disconnect()
 
     /**

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -218,7 +218,6 @@ internal class MessagingClientImpl(
         closeAllConnectionsForTheSession()
     }
 
-    @Throws(IllegalStateException::class)
     override fun disconnect() {
         log.i { LogMessages.DISCONNECT }
         if (!stateMachine.canDisconnect()) {

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -218,12 +218,9 @@ internal class MessagingClientImpl(
         closeAllConnectionsForTheSession()
     }
 
+    @Throws(IllegalStateException::class)
     override fun disconnect() {
         log.i { LogMessages.DISCONNECT }
-        if (!stateMachine.canDisconnect()) {
-            log.i { LogMessages.disconnectIgnored(stateMachine.currentState) }
-            return
-        }
         val code = SocketCloseCode.NORMAL_CLOSURE.value
         val reason = "The user has closed the connection."
         reconnectionHandler.clear()
@@ -909,7 +906,11 @@ internal class MessagingClientImpl(
                         }
                         sessionDurationHandler.clearAndRemoveNotice()
                         eventHandler.onEvent(Event.ConnectionClosed(reason))
-                        disconnect()
+                        if (stateMachine.currentState.canDisconnect()) {
+                            disconnect()
+                        } else {
+                            log.i { "ConnectionClosedEvent ignored, state is already ${stateMachine.currentState}" }
+                        }
                     }
 
                     is LogoutEvent -> {
@@ -937,11 +938,11 @@ internal class MessagingClientImpl(
             reason: String
         ) {
             log.i { LogMessages.onClosing(code, reason) }
-            if (!stateMachine.canDisconnect()) {
-                log.i { LogMessages.disconnectIgnored(stateMachine.currentState) }
-                return
+            if (stateMachine.currentState.canDisconnect()) {
+                stateMachine.onClosing(code, reason)
+            } else {
+                log.i { "onClosing ignored, state is already ${stateMachine.currentState}" }
             }
-            stateMachine.onClosing(code, reason)
         }
 
         override fun onClosed(

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -909,7 +909,7 @@ internal class MessagingClientImpl(
                         if (stateMachine.currentState.canDisconnect()) {
                             disconnect()
                         } else {
-                            log.i { "ConnectionClosedEvent ignored, state is already ${stateMachine.currentState}" }
+                            log.i { LogMessages.connectionClosedEventIgnored(stateMachine.currentState) }
                         }
                     }
 
@@ -941,7 +941,7 @@ internal class MessagingClientImpl(
             if (stateMachine.currentState.canDisconnect()) {
                 stateMachine.onClosing(code, reason)
             } else {
-                log.i { "onClosing ignored, state is already ${stateMachine.currentState}" }
+                log.i { LogMessages.onClosingIgnored(stateMachine.currentState) }
             }
         }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/MessagingClientImpl.kt
@@ -221,6 +221,10 @@ internal class MessagingClientImpl(
     @Throws(IllegalStateException::class)
     override fun disconnect() {
         log.i { LogMessages.DISCONNECT }
+        if (!stateMachine.canDisconnect()) {
+            log.i { LogMessages.disconnectIgnored(stateMachine.currentState) }
+            return
+        }
         val code = SocketCloseCode.NORMAL_CLOSURE.value
         val reason = "The user has closed the connection."
         reconnectionHandler.clear()
@@ -934,6 +938,10 @@ internal class MessagingClientImpl(
             reason: String
         ) {
             log.i { LogMessages.onClosing(code, reason) }
+            if (!stateMachine.canDisconnect()) {
+                log.i { LogMessages.disconnectIgnored(stateMachine.currentState) }
+                return
+            }
             stateMachine.onClosing(code, reason)
         }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -88,6 +88,8 @@ internal fun StateMachine.isInactive(): Boolean = currentState is State.Idle || 
 
 internal fun StateMachine.isClosing(): Boolean = currentState is State.Closing
 
+internal fun StateMachine.canDisconnect(): Boolean = currentState.canDisconnect()
+
 @Throws(IllegalStateException::class)
 internal fun StateMachine.checkIfCanStartANewChat() = check(isReadOnly()) { "MessagingClient is not in ReadOnly state." }
 

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/core/StateMachineImpl.kt
@@ -95,4 +95,4 @@ internal fun StateMachine.checkIfCanStartANewChat() = check(isReadOnly()) { "Mes
 
 private fun State.canConnect(): Boolean = this is State.Closed || this is State.Idle || this is State.Error || this is State.Reconnecting
 
-private fun State.canDisconnect(): Boolean = this !is State.Closed && this !is State.Idle && this !is State.Error
+internal fun State.canDisconnect(): Boolean = this !is State.Closed && this !is State.Idle && this !is State.Error

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -127,6 +127,9 @@ internal object LogMessages {
         reason: String
     ) = "onClosing(code = $code, reason = $reason)"
 
+    fun disconnectIgnored(state: MessagingClient.State) =
+        "disconnect() ignored, state is already $state"
+
     fun onClosed(
         code: Int,
         reason: String

--- a/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
+++ b/transport/src/commonMain/kotlin/com/genesys/cloud/messenger/transport/util/logs/LogMessages.kt
@@ -127,8 +127,11 @@ internal object LogMessages {
         reason: String
     ) = "onClosing(code = $code, reason = $reason)"
 
-    fun disconnectIgnored(state: MessagingClient.State) =
-        "disconnect() ignored, state is already $state"
+    fun connectionClosedEventIgnored(state: MessagingClient.State) =
+        "ConnectionClosedEvent ignored, state is already $state"
+
+    fun onClosingIgnored(state: MessagingClient.State) =
+        "onClosing ignored, state is already $state"
 
     fun onClosed(
         code: Int,

--- a/transport/transport.podspec
+++ b/transport/transport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'transport'
-    spec.version                  = '2.14.0'
+    spec.version                  = '2.14.1-rc1'
     spec.homepage                 = 'https://github.com/MyPureCloud/genesys-messenger-transport-mobile-sdk'
     spec.source                   = { :http=> ''}
     spec.authors                  = 'Genesys Cloud Services, Inc.'


### PR DESCRIPTION
Fixed iOS crash in MessagingClientImpl.SocketListener.onClosing.

And also made the disconnect crash-safe by just being a no-op in case of being in wrong states.

## Analysis on the affected states
connect() is the only way back from all three states:
```
Idle   ──connect()──→ Connecting → Connected → Configured
Closed ──connect()──→ Connecting → ...
Error  ──connect()──→ Connecting → ...
```

There is no "resume" path. disconnect() in these states has no session to close and no path back to one — so the no-op is the correct and complete behavior.

